### PR TITLE
Cursor/DataTypeCursor improvements

### DIFF
--- a/modules/core/src/main/scala/cursor.scala
+++ b/modules/core/src/main/scala/cursor.scala
@@ -11,6 +11,7 @@ import QueryInterpreter.mkErrorResult
 
 trait Cursor {
   def focus: Any
+  def tpe: Type
   def isLeaf: Boolean
   def asLeaf: Result[Json]
   def isList: Boolean

--- a/modules/core/src/main/scala/datatype.scala
+++ b/modules/core/src/main/scala/datatype.scala
@@ -53,7 +53,7 @@ case class DataTypeCursor(
       }
     case (BooleanType, b: Boolean) => Json.fromBoolean(b).rightIor
     case (_: EnumType, e: Enumeration#Value) => Json.fromString(e.toString).rightIor
-    case _ => mkErrorResult(s"Expected Scalar type, found ${tpe.shortString}")
+    case _ => mkErrorResult(s"Expected Scalar type, found ${tpe.shortString} for focus ${focus}")
   }
 
   def isList: Boolean = (tpe, focus) match {

--- a/modules/core/src/main/scala/query.scala
+++ b/modules/core/src/main/scala/query.scala
@@ -262,7 +262,7 @@ abstract class QueryInterpreter[F[_]](val schema: Schema)(implicit val F: Monad[
         runFields(query, tpe, cursor).map(ProtoJson.fromFields)
 
       case _ =>
-        mkErrorResult(s"Unknown type $tpe")
+        mkErrorResult(s"Stuck at type $tpe for ${query.render}")
     }
   }
 }

--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -28,6 +28,9 @@ sealed trait Type {
     case _ => NoType
   }
 
+  def hasField(fieldName: String): Boolean =
+    field(fieldName) != NoType
+
   def path(fns: List[String]): Type = (fns, this) match {
     case (Nil, _) => this
     case (_, ListType(tpe)) => tpe.path(fns)

--- a/modules/doobie/src/main/scala/doobiemapping.scala
+++ b/modules/doobie/src/main/scala/doobiemapping.scala
@@ -241,9 +241,9 @@ object DoobieMapping {
   }
 
   class StagingElaborator(mapping: DoobieMapping) extends Phase {
-    val stagingJoin = (c: Cursor, q: Query) => (c, q) match {
-      case (dc: DoobieCursor, Select(fieldName, _, _)) =>
-        val tpe = dc.tpe.underlyingObject
+    val stagingJoin = (c: Cursor, q: Query) => q match {
+      case Select(fieldName, _, _) =>
+        val tpe = c.tpe.underlyingObject
 
         val osj = for {
           om                 <- mapping.objectMappings.find(_.tpe =:= tpe)

--- a/modules/doobie/src/test/scala/composed/ComposedWorldSchema.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldSchema.scala
@@ -18,7 +18,8 @@ object ComposedWorldSchema extends Schema {
       fields = List(
         Field("cities", None, List(NamePatternArg), NullableType(ListType(TypeRef("City"))), false, None),
         Field("country", None, List(CodeArg), NullableType(TypeRef("Country")), false, None),
-        Field("countries", None, Nil, NullableType(ListType(TypeRef("Country"))), false, None)
+        Field("countries", None, Nil, NullableType(ListType(TypeRef("Country"))), false, None),
+        Field("currencies", None, Nil, ListType(TypeRef("Currency")), false, None) // Should be local to CurrencySchema
       ),
       interfaces = Nil
     )


### PR DESCRIPTION
* Added `tpe: Type` member to `Cursor`
* Thread GraphQL type though `DataTypeCursor`
* Parameterise `DataTypeCursor/Interpreter` with `PartialFunctions` instead of subclassing.