### PR TITLE
Schema composability improvements; integrated Robs nullability support

### DIFF
--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -87,7 +87,7 @@ object QueryCompiler {
             }
           }
 
-        case w@Wrap(fieldName, child) => apply(child, tpe.underlyingField(fieldName)).map(ec => w.copy(child = ec))
+        case w@Wrap(_, child)         => apply(child, tpe).map(ec => w.copy(child = ec))
         case g@Group(queries)         => queries.traverse(q => apply(q, tpe)).map(eqs => g.copy(queries = eqs))
         case u@Unique(_, child)       => apply(child, tpe.nonNull).map(ec => u.copy(child = ec))
         case f@Filter(_, child)       => apply(child, tpe.item).map(ec => f.copy(child = ec))
@@ -105,7 +105,7 @@ object QueryCompiler {
           mapping.get((tpe.underlyingObject, fieldName)) match {
             case Some((cid, join)) =>
               apply(child, childTpe).map { elaboratedChild =>
-                Wrap(fieldName, Component(cid, join, elaboratedChild))
+                Wrap(fieldName, Component(cid, join, Select(fieldName, args, elaboratedChild)))
               }
             case None =>
               apply(child, childTpe).map { elaboratedChild =>
@@ -113,19 +113,7 @@ object QueryCompiler {
               }
           }
 
-        case Wrap(fieldName, child) =>
-          val childTpe = tpe.underlyingField(fieldName)
-          mapping.get((tpe.underlyingObject, fieldName)) match {
-            case Some((cid, join)) =>
-              apply(child, childTpe).map { elaboratedChild =>
-                Wrap(fieldName, Component(cid, join, Wrap(fieldName, elaboratedChild)))
-              }
-            case None =>
-              apply(child, childTpe).map { elaboratedChild =>
-                Wrap(fieldName, elaboratedChild)
-              }
-          }
-
+        case w@Wrap(_, child)         => apply(child, tpe).map(ec => w.copy(child = ec))
         case g@Group(queries)         => queries.traverse(q => apply(q, tpe)).map(eqs => g.copy(queries = eqs))
         case u@Unique(_, child)       => apply(child, tpe.nonNull).map(ec => u.copy(child = ec))
         case f@Filter(_, child)       => apply(child, tpe.item).map(ec => f.copy(child = ec))

--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -97,7 +97,7 @@ object QueryCompiler {
       }
   }
 
-  class ComponentElaborator private (mapping: Map[(Type, String), (SchemaComponent, (Cursor, Query) => Result[Query])]) extends Phase {
+  class ComponentElaborator private (mapping: Map[(Type, String), (Schema, (Cursor, Query) => Result[Query])]) extends Phase {
     def apply(query: Query, tpe: Type): Result[Query] =
       query match {
         case Select(fieldName, args, child) =>
@@ -138,7 +138,7 @@ object QueryCompiler {
   object ComponentElaborator {
     val TrivialJoin = (_: Cursor, q: Query) => q.rightIor
 
-    case class Mapping(tpe: Type, fieldName: String, schema: SchemaComponent, join: (Cursor, Query) => Result[Query] = TrivialJoin)
+    case class Mapping(tpe: Type, fieldName: String, schema: Schema, join: (Cursor, Query) => Result[Query] = TrivialJoin)
 
     def apply(mappings: Mapping*): ComponentElaborator =
       new ComponentElaborator(mappings.map(m => ((m.tpe, m.fieldName), (m.schema, m.join))).toMap)

--- a/modules/core/src/main/scala/datatype.scala
+++ b/modules/core/src/main/scala/datatype.scala
@@ -12,11 +12,10 @@ import QueryInterpreter.{ mkErrorResult, ProtoJson }
 import ScalarType._
 
 class DataTypeQueryInterpreter[F[_]: Monad](
-  schema: Schema,
   root:   PartialFunction[String, (Type, Any)],
   fields: PartialFunction[(Any, String), Any],
   attrs:  PartialFunction[(Any, String), Any] = PartialFunction.empty
-) extends QueryInterpreter[F](schema) {
+) extends QueryInterpreter[F] {
 
   def runRootValue(query: Query, rootTpe: Type): F[Result[ProtoJson]] =
     query match {

--- a/modules/core/src/main/scala/datatype.scala
+++ b/modules/core/src/main/scala/datatype.scala
@@ -51,7 +51,7 @@ case class DataTypeCursor(
       }
     case (BooleanType, b: Boolean) => Json.fromBoolean(b).rightIor
     case (_: EnumType, e: Enumeration#Value) => Json.fromString(e.toString).rightIor
-    case _ => mkErrorResult(s"Expected Scalar type, found ${tpe.shortString} for focus ${focus}")
+    case _ => mkErrorResult(s"Expected Scalar type, found $tpe for focus ${focus}")
   }
 
   def isList: Boolean = (tpe, focus) match {
@@ -61,7 +61,7 @@ case class DataTypeCursor(
 
   def asList: Result[List[Cursor]] = (tpe, focus) match {
     case (ListType(tpe), it: List[_]) => it.map(f => copy(tpe = tpe, focus = f)).rightIor
-    case _ => mkErrorResult(s"Expected List type, found ${tpe.shortString}")
+    case _ => mkErrorResult(s"Expected List type, found $tpe")
   }
 
   def isNullable: Boolean = focus match {
@@ -71,7 +71,7 @@ case class DataTypeCursor(
 
   def asNullable: Result[Option[Cursor]] = (tpe, focus) match {
     case (NullableType(tpe), o: Option[_]) => o.map(f => copy(tpe = tpe, focus = f)).rightIor
-    case _ => mkErrorResult(s"Expected Nullable type, found ${tpe.shortString}")
+    case _ => mkErrorResult(s"Expected Nullable type, found $tpe")
   }
 
   def hasField(fieldName: String): Boolean =
@@ -81,7 +81,7 @@ case class DataTypeCursor(
     if (hasField(fieldName))
       copy(tpe = tpe.field(fieldName), focus = fields((focus, fieldName))).rightIor
     else
-      mkErrorResult(s"No field '$fieldName' for type ${tpe.shortString}")
+      mkErrorResult(s"No field '$fieldName' for type $tpe")
 
   def hasAttribute(attributeName: String): Boolean =
     attrs.isDefinedAt((focus, attributeName))
@@ -90,5 +90,5 @@ case class DataTypeCursor(
     if (hasAttribute(attributeName))
       attrs((focus, attributeName)).rightIor
     else
-      mkErrorResult(s"No attribute '$attributeName' for type ${tpe.shortString}")
+      mkErrorResult(s"No attribute '$attributeName' for type $tpe")
 }

--- a/modules/core/src/main/scala/datatype.scala
+++ b/modules/core/src/main/scala/datatype.scala
@@ -7,7 +7,7 @@ import cats.Monad
 import cats.implicits._
 import io.circe.Json
 
-import Query.Wrap
+import Query.{ Select, Wrap }
 import QueryInterpreter.{ mkErrorResult, ProtoJson }
 import ScalarType._
 
@@ -19,11 +19,11 @@ class DataTypeQueryInterpreter[F[_]: Monad](
 
   def runRootValue(query: Query, rootTpe: Type): F[Result[ProtoJson]] =
     query match {
-      case Wrap(fieldName, _) =>
+      case Select(fieldName, _, child) =>
         if (root.isDefinedAt(fieldName)) {
           val (tpe, focus) = root(fieldName)
           val cursor = DataTypeCursor(tpe, focus, fields, attrs)
-          runValue(query, rootTpe.field(fieldName), cursor).pure[F]
+          runValue(Wrap(fieldName, child), rootTpe.field(fieldName), cursor).pure[F]
         } else
           mkErrorResult(s"No root field '$fieldName'").pure[F]
       case _ =>

--- a/modules/core/src/main/scala/datatype.scala
+++ b/modules/core/src/main/scala/datatype.scala
@@ -18,14 +18,13 @@ class DataTypeQueryInterpreter[F[_]: Monad](
   attrs:  PartialFunction[(Any, String), Any] = PartialFunction.empty
 ) extends QueryInterpreter[F](schema) {
 
-  def runRootValue(query: Query): F[Result[ProtoJson]] =
+  def runRootValue(query: Query, rootTpe: Type): F[Result[ProtoJson]] =
     query match {
       case Wrap(fieldName, _) =>
         if (root.isDefinedAt(fieldName)) {
           val (tpe, focus) = root(fieldName)
-          val rootType = schema.queryType.field(fieldName)
           val cursor = DataTypeCursor(tpe, focus, fields, attrs)
-          runValue(query, rootType, cursor).pure[F]
+          runValue(query, rootTpe.field(fieldName), cursor).pure[F]
         } else
           mkErrorResult(s"No root field '$fieldName'").pure[F]
       case _ =>

--- a/modules/core/src/main/scala/query.scala
+++ b/modules/core/src/main/scala/query.scala
@@ -206,7 +206,7 @@ abstract class QueryInterpreter[F[_]](implicit val F: Monad[F]) {
         siblings.flatTraverse(query => runFields(query, tpe, cursor))
 
       case _ =>
-        mkErrorResult(s"failed: { ${query.render} } ${tpe.shortString}")
+        mkErrorResult(s"failed: { ${query.render} } $tpe")
     }
   }
 

--- a/modules/core/src/main/scala/query.scala
+++ b/modules/core/src/main/scala/query.scala
@@ -46,8 +46,8 @@ object Query {
   case class Filter(pred: Predicate, child: Query) extends Query {
     def render = s"<filter: $pred ${child.render}>"
   }
-  case class Component(schema: Schema, join: (Cursor, Query) => Result[Query], child: Query) extends Query {
-    def render = s"<component: ${schema.getClass.getSimpleName} ${child.render}>"
+  case class Component(componentId: String, join: (Cursor, Query) => Result[Query], child: Query) extends Query {
+    def render = s"<component: $componentId ${child.render}>"
   }
   case class Defer(join: (Cursor, Query) => Result[Query], child: Query) extends Query {
     def render = s"<defer: ${child.render}>"
@@ -158,7 +158,7 @@ abstract class QueryInterpreter[F[_]](val schema: Schema)(implicit val F: Monad[
     runRoot(query).map(QueryInterpreter.mkResponse)
 
   def complete(pj: ProtoJson): F[Result[Json]] =
-    QueryInterpreter.complete(pj, Map(schema -> this))
+    QueryInterpreter.complete[F](pj, Map.empty)
 
   def runRoot(query: Query): F[Result[Json]] = {
     (for {
@@ -217,15 +217,15 @@ abstract class QueryInterpreter[F[_]](val schema: Schema)(implicit val F: Monad[
           pvalue <- runValue(child, tpe, cursor)
         } yield ProtoJson.fromFields(List((fieldName, pvalue)))
 
-      case (Component(schema, join, child), _) =>
+      case (Component(cid, join, child), _) =>
         for {
           cont <- join(cursor, child)
-        } yield ProtoJson.deferred(schema, cont, tpe)
+        } yield ProtoJson.component(cid, cont, tpe)
 
       case (Defer(join, child), _) =>
         for {
           cont <- join(cursor, child)
-        } yield ProtoJson.deferred(schema, cont, tpe)
+        } yield ProtoJson.staged(this, cont, tpe)
 
       case (Unique(pred, child), _) if cursor.isList =>
         cursor.asList.map(_.filter(pred)).flatMap(lc =>
@@ -271,12 +271,17 @@ object QueryInterpreter {
   type ProtoJson <: AnyRef
 
   object ProtoJson {
-    private[QueryInterpreter] case class DeferredJson(schema: Schema, query: Query, rootTpe: Type)
+    private[QueryInterpreter] sealed trait DeferredJson
+    private[QueryInterpreter] case class ComponentJson(componentId: String, query: Query, rootTpe: Type) extends DeferredJson
+    private[QueryInterpreter] case class StagedJson[F[_]](interpreter: QueryInterpreter[F], query: Query, rootTpe: Type) extends DeferredJson
     private[QueryInterpreter] case class ProtoObject(fields: List[(String, ProtoJson)])
     private[QueryInterpreter] case class ProtoArray(elems: List[ProtoJson])
 
-    def deferred(schema: Schema, query: Query, rootTpe: Type): ProtoJson =
-      wrap(DeferredJson(schema, query, rootTpe))
+    def component(componentId: String, query: Query, rootTpe: Type): ProtoJson =
+      wrap(ComponentJson(componentId, query, rootTpe))
+
+    def staged[F[_]](interpreter: QueryInterpreter[F], query: Query, rootTpe: Type): ProtoJson =
+      wrap(StagedJson(interpreter, query, rootTpe))
 
     def fromJson(value: Json): ProtoJson = wrap(value)
 
@@ -300,7 +305,7 @@ object QueryInterpreter {
 
   import ProtoJson._
 
-  def complete[F[_]: Monad](pj: ProtoJson, mapping: Map[Schema, QueryInterpreter[F]]): F[Result[Json]] =
+  def complete[F[_]: Monad](pj: ProtoJson, mapping: Map[String, QueryInterpreter[F]]): F[Result[Json]] =
     completeAll(List(pj), mapping).map {
       case (errors, List(value)) =>
         NonEmptyChain.fromChain(errors) match {
@@ -309,7 +314,7 @@ object QueryInterpreter {
         }
     }
 
-  def completeAll[F[_]: Monad](pjs: List[ProtoJson], mapping: Map[Schema, QueryInterpreter[F]]): F[(Chain[Json], List[Json])] = {
+  def completeAll[F[_]: Monad](pjs: List[ProtoJson], mapping: Map[String, QueryInterpreter[F]]): F[(Chain[Json], List[Json])] = {
     def gatherDeferred(pj: ProtoJson): List[DeferredJson] = {
       @tailrec
       def loop(pending: Chain[ProtoJson], acc: List[DeferredJson]): List[DeferredJson] =
@@ -355,13 +360,15 @@ object QueryInterpreter {
 
     val (good, bad, errors0) =
       collected.foldLeft((List.empty[(DeferredJson, QueryInterpreter[F], (Query, Type))], List.empty[DeferredJson], Chain.empty[Json])) {
-        case ((good, bad, errors), d@DeferredJson(schema, query, rootTpe)) =>
-          mapping.get(schema) match {
+        case ((good, bad, errors), d@ComponentJson(cid, query, rootTpe)) =>
+          mapping.get(cid) match {
             case Some(interpreter) =>
               ((d, interpreter, (query, rootTpe)) :: good, bad, errors)
             case None =>
-              (good, d :: bad, mkError(s"No interpreter for query '${query.render}' which maps to schema '${schema.getClass.getName}'") +: errors)
+              (good, d :: bad, mkError(s"No interpreter for query '${query.render}' which maps to component '$cid'") +: errors)
           }
+        case ((good, bad, errors), d@StagedJson(interpreter, query, rootTpe)) =>
+          ((d, interpreter.asInstanceOf[QueryInterpreter[F]], (query, rootTpe)) :: good, bad, errors)
       }
 
     val grouped = good.groupMap(_._2)(e => (e._1, e._3)).toList
@@ -417,17 +424,17 @@ object QueryInterpreter {
     Ior.leftNec(mkError(message, locations, path))
 }
 
-class ComposedQueryInterpreter[F[_]: Monad](schema: Schema, mapping: Map[Schema, QueryInterpreter[F]])
+class ComposedQueryInterpreter[F[_]: Monad](schema: Schema, mapping: Map[String, QueryInterpreter[F]])
   extends QueryInterpreter[F](schema) {
 
   override def complete(pj: ProtoJson): F[Result[Json]] =
     QueryInterpreter.complete(pj, mapping)
 
   def runRootValue(query: Query, rootTpe: Type): F[Result[ProtoJson]] = query match {
-    case Wrap(_, Component(schema, _, child)) =>
-      mapping.get(schema) match {
+    case Wrap(_, Component(cid, _, child)) =>
+      mapping.get(cid) match {
         case Some(interpreter) => interpreter.runRootValue(child, rootTpe)
-        case None => mkErrorResult(s"No interpreter for query '${query.render}' which maps to schema '${schema.getClass.getSimpleName}'").pure[F]
+        case None => mkErrorResult(s"No interpreter for query '${query.render}' which maps to component '$cid'").pure[F]
       }
     case _ => mkErrorResult(s"Bad root query '${query.render}' in ComposedQueryInterpreter").pure[F]
   }

--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -3,18 +3,16 @@
 
 package edu.gemini.grackle
 
-trait SchemaComponent {
+trait Schema {
   val types: List[NamedType]
 
-  def TypeRef(ref: String): TypeRef =
-    new TypeRef(this, ref)
-}
-
-trait Schema extends SchemaComponent {
-  val queryType:        TypeRef
+  val queryType:        Type
   val mutationType:     Option[TypeRef]
   val subscriptionType: Option[TypeRef]
   val directives:       List[Directive]
+
+  def TypeRef(ref: String): TypeRef =
+    new TypeRef(this, ref)
 }
 
 sealed trait Type {
@@ -25,7 +23,9 @@ sealed trait Type {
     case TypeRef(_, _) => dealias.field(fieldName)
     case ObjectType(_, _, fields, _) => fields.find(_.name == fieldName).map(_.tpe).getOrElse(NoType)
     case InterfaceType(_, _, fields) => fields.find(_.name == fieldName).map(_.tpe).getOrElse(NoType)
-    case _ => NoType
+    case _ =>
+      println(s"Type ${this.shortString} has no field $fieldName")
+      NoType
   }
 
   def hasField(fieldName: String): Boolean =
@@ -127,7 +127,7 @@ sealed trait NamedType extends Type {
 }
 
 case object NoType extends Type
-case class TypeRef(schema: SchemaComponent, ref: String) extends Type {
+case class TypeRef(schema: Schema, ref: String) extends Type {
   override def toString: String = s"@$ref"
 }
 

--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -63,6 +63,8 @@ sealed trait Type {
     case _ => NoType
   }
 
+  def prunePath(fns: List[String]): (Type, String) = (path(fns.init), fns.last)
+
   def pathIsList(fns: List[String]): Boolean = (fns, this) match {
     case (Nil, _) => false
     case (_, _: ListType) => true

--- a/modules/core/src/test/scala/compiler/CompilerSpec.scala
+++ b/modules/core/src/test/scala/compiler/CompilerSpec.scala
@@ -101,15 +101,15 @@ final class CompilerSuite extends CatsSuite {
 
     val expected =
       Wrap("componenta",
-        Component(SchemaA, TrivialJoin,
+        Component("SchemaA", TrivialJoin,
           Select("fielda1", Nil) ~
           Select("fielda2", Nil,
             Wrap("componentb",
-              Component(SchemaB, TrivialJoin,
+              Component("SchemaB", TrivialJoin,
                 Select("fieldb1", Nil) ~
                 Select("fieldb2", Nil,
                   Wrap("componentc",
-                    Component(SchemaC, TrivialJoin, Empty)
+                    Component("SchemaC", TrivialJoin, Empty)
                   )
                 )
               )
@@ -321,9 +321,9 @@ object ComposedCompiler extends QueryCompiler(ComposedSchema) {
   import ComposedSchema._
 
   val componentElaborator = ComponentElaborator(
-    Mapping(QueryType, "componenta", SchemaA),
-    Mapping(FieldA2Type, "componentb", SchemaB),
-    Mapping(FieldB2Type, "componentc", SchemaC)
+    Mapping(QueryType, "componenta", "SchemaA"),
+    Mapping(FieldA2Type, "componentb", "SchemaB"),
+    Mapping(FieldB2Type, "componentc", "SchemaC")
   )
 
   val phases = List(componentElaborator)

--- a/modules/core/src/test/scala/compiler/CompilerSpec.scala
+++ b/modules/core/src/test/scala/compiler/CompilerSpec.scala
@@ -101,15 +101,21 @@ final class CompilerSuite extends CatsSuite {
 
     val expected =
       Wrap("componenta",
-        Component("SchemaA", TrivialJoin,
-          Select("fielda1", Nil) ~
-          Select("fielda2", Nil,
-            Wrap("componentb",
-              Component("SchemaB", TrivialJoin,
-                Select("fieldb1", Nil) ~
-                Select("fieldb2", Nil,
-                  Wrap("componentc",
-                    Component("SchemaC", TrivialJoin, Empty)
+        Component("ComponentA", TrivialJoin,
+          Select("componenta", Nil,
+            Select("fielda1", Nil) ~
+            Select("fielda2", Nil,
+              Wrap("componentb",
+                Component("ComponentB", TrivialJoin,
+                  Select("componentb", Nil,
+                    Select("fieldb1", Nil) ~
+                    Select("fieldb2", Nil,
+                      Wrap("componentc",
+                        Component("ComponentC", TrivialJoin,
+                          Select("componentc", Nil, Empty)
+                        )
+                      )
+                    )
                   )
                 )
               )
@@ -283,9 +289,9 @@ object ComposedSchema extends Schema {
 
 object ComposedCompiler extends QueryCompiler(ComposedSchema) {
   val componentElaborator = ComponentElaborator(
-    Mapping(ComposedSchema.tpe("Query"), "componenta", "SchemaA"),
-    Mapping(ComposedSchema.tpe("FieldA2"), "componentb", "SchemaB"),
-    Mapping(ComposedSchema.tpe("FieldB2"), "componentc", "SchemaC")
+    Mapping(ComposedSchema.tpe("Query"), "componenta", "ComponentA"),
+    Mapping(ComposedSchema.tpe("FieldA2"), "componentb", "ComponentB"),
+    Mapping(ComposedSchema.tpe("FieldB2"), "componentc", "ComponentC")
   )
 
   val phases = List(componentElaborator)

--- a/modules/core/src/test/scala/compiler/CompilerSpec.scala
+++ b/modules/core/src/test/scala/compiler/CompilerSpec.scala
@@ -129,7 +129,7 @@ object SimpleSchema extends Schema {
 
   val IdArg = InputValue("id", None, StringType, None)
 
-  val QueryType: ObjectType =
+  val types = List(
     ObjectType(
       name = "Query",
       description = None,
@@ -137,9 +137,7 @@ object SimpleSchema extends Schema {
         Field("character", None, List(IdArg), NullableType(TypeRef("Character")), false, None),
       ),
       interfaces = Nil
-    )
-
-  val CharacterType: InterfaceType =
+    ),
     InterfaceType(
       name = "Character",
       description = None,
@@ -149,19 +147,14 @@ object SimpleSchema extends Schema {
         Field("friends", None, Nil, NullableType(ListType(TypeRef("Character"))), false, None),
       )
     )
+  )
 
-  val types = List(QueryType, CharacterType)
-  val queryType = TypeRef("Query")
-  val mutationType = None
-  val subscriptionType = None
   val directives = Nil
 }
 
 object SimpleCompiler extends QueryCompiler(SimpleSchema) {
-  import SimpleSchema._
-
   val selectElaborator = new SelectElaborator(Map(
-    QueryType -> {
+    SimpleSchema.tpe("Query").dealias -> {
       case Select("character", List(StringBinding("id", id)), child) =>
         Unique(FieldEquals("id", id), child).rightIor
     }
@@ -173,15 +166,13 @@ object SimpleCompiler extends QueryCompiler(SimpleSchema) {
 object SchemaA extends Schema {
   import ScalarType._
 
-  val FieldA2Type: ObjectType =
+  val types = List(
     ObjectType(
       name = "FieldA2",
       description = None,
       fields = Nil,
       interfaces = Nil
-    )
-
-  val ComponentAType: ObjectType =
+    ),
     ObjectType(
       name = "ComponentA",
       description = None,
@@ -191,27 +182,21 @@ object SchemaA extends Schema {
       ),
       interfaces = Nil
     )
+  )
 
-  val queryType = NoType
-  val mutationType = None
-  val subscriptionType = None
   val directives = Nil
-
-  val types = List(ComponentAType, FieldA2Type)
 }
 
 object SchemaB extends Schema {
   import ScalarType._
 
-  val FieldB2Type: ObjectType =
+  val types = List(
     ObjectType(
       name = "FieldB2",
       description = None,
       fields = Nil,
       interfaces = Nil
-    )
-
-  val ComponentBType: ObjectType =
+    ),
     ObjectType(
       name = "ComponentB",
       description = None,
@@ -221,36 +206,28 @@ object SchemaB extends Schema {
       ),
       interfaces = Nil
     )
+  )
 
-  val queryType = NoType
-  val mutationType = None
-  val subscriptionType = None
   val directives = Nil
-
-  val types = List(ComponentBType, FieldB2Type)
 }
 
 object SchemaC extends Schema {
-  val ComponentCType: ObjectType =
+  val types = List(
     ObjectType(
       name = "ComponentC",
       description = None,
       fields = Nil,
       interfaces = Nil
     )
+  )
 
-  val queryType = NoType
-  val mutationType = None
-  val subscriptionType = None
   val directives = Nil
-
-  val types = List(ComponentCType)
 }
 
 object ComposedSchema extends Schema {
   import ScalarType._
 
-  val QueryType =
+  val types = List(
     ObjectType(
       name = "Query",
       description = None,
@@ -258,9 +235,7 @@ object ComposedSchema extends Schema {
         Field("componenta", None, Nil, TypeRef("ComponentA"), false, None)
       ),
       interfaces = Nil
-    )
-
-  val ComponentAType: ObjectType =
+    ),
     ObjectType(
       name = "ComponentA",
       description = None,
@@ -269,9 +244,7 @@ object ComposedSchema extends Schema {
         Field("fielda2", None, Nil, TypeRef("FieldA2"), false, None)
       ),
       interfaces = Nil
-    )
-
-  val FieldA2Type: ObjectType =
+    ),
     ObjectType(
       name = "FieldA2",
       description = None,
@@ -279,9 +252,7 @@ object ComposedSchema extends Schema {
         Field("componentb", None, Nil, TypeRef("ComponentB"), false, None)
       ),
       interfaces = Nil
-    )
-
-  val ComponentBType: ObjectType =
+    ),
     ObjectType(
       name = "ComponentB",
       description = None,
@@ -290,9 +261,7 @@ object ComposedSchema extends Schema {
         Field("fieldb2", None, Nil, TypeRef("FieldB2"), false, None)
       ),
       interfaces = Nil
-    )
-
-  val FieldB2Type: ObjectType =
+    ),
     ObjectType(
       name = "FieldB2",
       description = None,
@@ -300,30 +269,23 @@ object ComposedSchema extends Schema {
         Field("componentc", None, Nil, TypeRef("ComponentC"), false, None)
       ),
       interfaces = Nil
-    )
-
-  val ComponentCType: ObjectType =
+    ),
     ObjectType(
       name = "ComponentC",
       description = None,
       fields = Nil,
       interfaces = Nil
     )
+  )
 
-  val types = List(QueryType, ComponentAType, FieldA2Type, ComponentBType, FieldB2Type, ComponentCType)
-  val queryType = TypeRef("Query")
-  val mutationType = None
-  val subscriptionType = None
   val directives = Nil
 }
 
 object ComposedCompiler extends QueryCompiler(ComposedSchema) {
-  import ComposedSchema._
-
   val componentElaborator = ComponentElaborator(
-    Mapping(QueryType, "componenta", "SchemaA"),
-    Mapping(FieldA2Type, "componentb", "SchemaB"),
-    Mapping(FieldB2Type, "componentc", "SchemaC")
+    Mapping(ComposedSchema.tpe("Query"), "componenta", "SchemaA"),
+    Mapping(ComposedSchema.tpe("FieldA2"), "componentb", "SchemaB"),
+    Mapping(ComposedSchema.tpe("FieldB2"), "componentc", "SchemaC")
   )
 
   val phases = List(componentElaborator)

--- a/modules/core/src/test/scala/compiler/CompilerSpec.scala
+++ b/modules/core/src/test/scala/compiler/CompilerSpec.scala
@@ -170,7 +170,7 @@ object SimpleCompiler extends QueryCompiler(SimpleSchema) {
   val phases = List(selectElaborator)
 }
 
-object SchemaA extends SchemaComponent {
+object SchemaA extends Schema {
   import ScalarType._
 
   val FieldA2Type: ObjectType =
@@ -192,10 +192,15 @@ object SchemaA extends SchemaComponent {
       interfaces = Nil
     )
 
+  val queryType = NoType
+  val mutationType = None
+  val subscriptionType = None
+  val directives = Nil
+
   val types = List(ComponentAType, FieldA2Type)
 }
 
-object SchemaB extends SchemaComponent {
+object SchemaB extends Schema {
   import ScalarType._
 
   val FieldB2Type: ObjectType =
@@ -217,10 +222,15 @@ object SchemaB extends SchemaComponent {
       interfaces = Nil
     )
 
+  val queryType = NoType
+  val mutationType = None
+  val subscriptionType = None
+  val directives = Nil
+
   val types = List(ComponentBType, FieldB2Type)
 }
 
-object SchemaC extends SchemaComponent {
+object SchemaC extends Schema {
   val ComponentCType: ObjectType =
     ObjectType(
       name = "ComponentC",
@@ -228,6 +238,11 @@ object SchemaC extends SchemaComponent {
       fields = Nil,
       interfaces = Nil
     )
+
+  val queryType = NoType
+  val mutationType = None
+  val subscriptionType = None
+  val directives = Nil
 
   val types = List(ComponentCType)
 }

--- a/modules/core/src/test/scala/composed/ComposedData.scala
+++ b/modules/core/src/test/scala/composed/ComposedData.scala
@@ -35,7 +35,7 @@ object CountryQueryCompiler extends QueryCompiler(ComposedSchema) {
   val phases = List(selectElaborator)
 }
 
-object CountryCurrencyQueryCompiler extends QueryCompiler(ComposedSchema) {
+object ComposedQueryCompiler extends QueryCompiler(ComposedSchema) {
   import CountryData._
 
   val selectElaborator =  new SelectElaborator(Map(
@@ -58,18 +58,18 @@ object CountryCurrencyQueryCompiler extends QueryCompiler(ComposedSchema) {
     }
 
   val componentElaborator = ComponentElaborator(
-    Mapping(ComposedSchema.tpe("Query"), "country", "CountrySchema"),
-    Mapping(ComposedSchema.tpe("Query"), "countries", "CountrySchema"),
-    Mapping(ComposedSchema.tpe("Country"), "currency", "CurrencySchema", countryCurrencyJoin)
+    Mapping(ComposedSchema.tpe("Query"), "country", "CountryComponent"),
+    Mapping(ComposedSchema.tpe("Query"), "countries", "CountryComponent"),
+    Mapping(ComposedSchema.tpe("Country"), "currency", "CurrencyComponent", countryCurrencyJoin)
   )
 
   val phases = List(selectElaborator, componentElaborator)
 }
 
-object CountryCurrencyQueryInterpreter extends
+object ComposedQueryInterpreter extends
   ComposedQueryInterpreter[Id](Map(
-    "CountrySchema"  -> CountryQueryInterpreter,
-    "CurrencySchema" -> CurrencyQueryInterpreter
+    "CountryComponent"  -> CountryQueryInterpreter,
+    "CurrencyComponent" -> CurrencyQueryInterpreter
   ))
 
 object CurrencyData {

--- a/modules/core/src/test/scala/composed/ComposedData.scala
+++ b/modules/core/src/test/scala/composed/ComposedData.scala
@@ -117,9 +117,9 @@ object ComposedQueryCompiler extends QueryCompiler(ComposedSchema) {
   ))
 
   val countryCurrencyJoin = (c: Cursor, q: Query) =>
-    c.focus match {
-      case c: Country =>
-        Wrap("currency", Unique(FieldEquals("code", c.currencyCode), q)).rightIor
+    (c.focus, q) match {
+      case (c: Country, Select("currency", _, child)) =>
+        Wrap("currency", Unique(FieldEquals("code", c.currencyCode), child)).rightIor
       case _ =>
         mkErrorResult(s"Unexpected cursor focus type in countryCurrencyJoin")
     }
@@ -130,7 +130,7 @@ object ComposedQueryCompiler extends QueryCompiler(ComposedSchema) {
     Mapping(CountryType, "currency", "CurrencyComponent", countryCurrencyJoin)
   )
 
-  val phases = List(selectElaborator, componentElaborator)
+  val phases = List(componentElaborator, selectElaborator)
 }
 
 object ComposedQueryInterpreter extends

--- a/modules/core/src/test/scala/composed/ComposedData.scala
+++ b/modules/core/src/test/scala/composed/ComposedData.scala
@@ -37,8 +37,8 @@ object CurrencyQueryInterpreter extends DataTypeQueryInterpreter[Id](
   }
 )
 
-object CurrencyQueryCompiler extends QueryCompiler(ComposedSchema) {
-  val QueryType = ComposedSchema.tpe("Query").dealias
+object CurrencyQueryCompiler extends QueryCompiler(CurrencySchema) {
+  val QueryType = CurrencySchema.tpe("Query").dealias
 
   val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
@@ -78,8 +78,8 @@ object CountryQueryInterpreter extends DataTypeQueryInterpreter[Id](
   }
 )
 
-object CountryQueryCompiler extends QueryCompiler(ComposedSchema) {
-  val QueryType = ComposedSchema.tpe("Query").dealias
+object CountryQueryCompiler extends QueryCompiler(CountrySchema) {
+  val QueryType = CountrySchema.tpe("Query").dealias
 
   val selectElaborator = new SelectElaborator(Map(
     QueryType -> {

--- a/modules/core/src/test/scala/composed/ComposedData.scala
+++ b/modules/core/src/test/scala/composed/ComposedData.scala
@@ -11,7 +11,7 @@ import Query._, Binding._, Predicate._
 import QueryCompiler._, ComponentElaborator.Mapping
 import QueryInterpreter.mkErrorResult
 
-import ComposedSchema._
+import ComposedSchema.{ CountryType, QueryType }
 
 object CurrencyQueryCompiler extends QueryCompiler(ComposedSchema) {
   val selectElaborator = new SelectElaborator(Map(
@@ -69,12 +69,10 @@ object CountryCurrencyQueryCompiler extends QueryCompiler(ComposedSchema) {
 }
 
 object CountryCurrencyQueryInterpreter extends
-  ComposedQueryInterpreter[Id](ComposedSchema,
-    Map(
-      "CountrySchema"  -> CountryQueryInterpreter,
-      "CurrencySchema" -> CurrencyQueryInterpreter
-    )
-  )
+  ComposedQueryInterpreter[Id](Map(
+    "CountrySchema"  -> CountryQueryInterpreter,
+    "CurrencySchema" -> CurrencyQueryInterpreter
+  ))
 
 object CurrencyData {
   case class Currency(
@@ -88,12 +86,11 @@ object CurrencyData {
   val currencies = List(EUR, GBP)
 }
 
-import CurrencyData._
+import CurrencyData.{ Currency, currencies }
 
 object CurrencyQueryInterpreter extends DataTypeQueryInterpreter[Id](
-  ComposedSchema,
   {
-    case "currency" => (ListType(CurrencyType), currencies)
+    case "currency" => (ListType(CurrencySchema.CurrencyType), currencies)
   },
   {
     case (c: Currency, "code")         => c.code
@@ -115,12 +112,11 @@ object CountryData {
   val countries = List(DEU, FRA, GBR)
 }
 
-import CountryData._
+import CountryData.{ Country, countries }
 
 object CountryQueryInterpreter extends DataTypeQueryInterpreter[Id](
-  ComposedSchema,
   {
-      case "country" | "countries"  => (ListType(CountryType), countries)
+    case "country" | "countries"  => (ListType(CountrySchema.CountryType), countries)
   },
   {
     case (c: Country, "code") => c.code

--- a/modules/core/src/test/scala/composed/ComposedData.scala
+++ b/modules/core/src/test/scala/composed/ComposedData.scala
@@ -60,9 +60,9 @@ object CountryCurrencyQueryCompiler extends QueryCompiler(ComposedSchema) {
     }
 
   val componentElaborator = ComponentElaborator(
-    Mapping(QueryType, "country", CountrySchema),
-    Mapping(QueryType, "countries", CountrySchema),
-    Mapping(CountryType, "currency", CurrencySchema, countryCurrencyJoin)
+    Mapping(QueryType, "country", "CountrySchema"),
+    Mapping(QueryType, "countries", "CountrySchema"),
+    Mapping(CountryType, "currency", "CurrencySchema", countryCurrencyJoin)
   )
 
   val phases = List(selectElaborator, componentElaborator)
@@ -71,8 +71,8 @@ object CountryCurrencyQueryCompiler extends QueryCompiler(ComposedSchema) {
 object CountryCurrencyQueryInterpreter extends
   ComposedQueryInterpreter[Id](ComposedSchema,
     Map(
-      CountrySchema  -> CountryQueryInterpreter,
-      CurrencySchema -> CurrencyQueryInterpreter
+      "CountrySchema"  -> CountryQueryInterpreter,
+      "CurrencySchema" -> CurrencyQueryInterpreter
     )
   )
 

--- a/modules/core/src/test/scala/composed/ComposedData.scala
+++ b/modules/core/src/test/scala/composed/ComposedData.scala
@@ -45,7 +45,7 @@ object CurrencyQueryCompiler extends QueryCompiler(CurrencySchema) {
   val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("currency", List(StringBinding("code", code)), child) =>
-        Wrap("currency", Unique(FieldEquals("code", code), child)).rightIor
+        Select("currency", Nil, Unique(FieldEquals("code", code), child)).rightIor
     }
   ))
 
@@ -88,9 +88,9 @@ object CountryQueryCompiler extends QueryCompiler(CountrySchema) {
   val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("country", List(StringBinding("code", code)), child) =>
-        Wrap("country", Unique(FieldEquals("code", code), child)).rightIor
+        Select("country", Nil, Unique(FieldEquals("code", code), child)).rightIor
       case Select("countries", _, child) =>
-        Wrap("countries", child).rightIor
+        Select("countries", Nil, child).rightIor
     }
   ))
 
@@ -108,18 +108,18 @@ object ComposedQueryCompiler extends QueryCompiler(ComposedSchema) {
   val selectElaborator =  new SelectElaborator(Map(
     QueryType -> {
       case Select("currency", List(StringBinding("code", code)), child) =>
-        Wrap("currency", Unique(FieldEquals("code", code), child)).rightIor
+        Select("currency", Nil, Unique(FieldEquals("code", code), child)).rightIor
       case Select("country", List(StringBinding("code", code)), child) =>
-        Wrap("country", Unique(FieldEquals("code", code), child)).rightIor
+        Select("country", Nil, Unique(FieldEquals("code", code), child)).rightIor
       case Select("countries", _, child) =>
-        Wrap("countries", child).rightIor
+        Select("countries", Nil, child).rightIor
     }
   ))
 
   val countryCurrencyJoin = (c: Cursor, q: Query) =>
     (c.focus, q) match {
       case (c: Country, Select("currency", _, child)) =>
-        Wrap("currency", Unique(FieldEquals("code", c.currencyCode), child)).rightIor
+        Select("currency", Nil, Unique(FieldEquals("code", c.currencyCode), child)).rightIor
       case _ =>
         mkErrorResult(s"Unexpected cursor focus type in countryCurrencyJoin")
     }

--- a/modules/core/src/test/scala/composed/ComposedSchema.scala
+++ b/modules/core/src/test/scala/composed/ComposedSchema.scala
@@ -10,7 +10,7 @@ object ComposedSchema extends Schema {
 
   val CodeArg = InputValue("code", None, NullableType(StringType), None)
 
-  val QueryType: ObjectType =
+  val types = List(
     ObjectType(
       name = "Query",
       description = None,
@@ -20,9 +20,7 @@ object ComposedSchema extends Schema {
         Field("countries", None, Nil, ListType(TypeRef("Country")), false, None)
       ),
       interfaces = Nil
-    )
-
-  val CurrencyType: ObjectType =
+    ),
     ObjectType(
       name = "Currency",
       description = None,
@@ -31,9 +29,7 @@ object ComposedSchema extends Schema {
         Field("exchangeRate", None, Nil, FloatType, false, None),
       ),
       interfaces = Nil
-    )
-
-  val CountryType: ObjectType =
+    ),
     ObjectType(
       name = "Country",
       description = None,
@@ -44,11 +40,8 @@ object ComposedSchema extends Schema {
       ),
       interfaces = Nil
     )
+  )
 
-  val types = List(QueryType, CurrencyType, CountryType)
-  val queryType = TypeRef("Query")
-  val mutationType = None
-  val subscriptionType = None
   val directives = Nil
 }
 
@@ -57,7 +50,7 @@ object CountrySchema extends Schema {
 
   val CodeArg = InputValue("code", None, NullableType(StringType), None)
 
-  val QueryType: ObjectType =
+  val types = List(
     ObjectType(
       name = "Query",
       description = None,
@@ -66,9 +59,7 @@ object CountrySchema extends Schema {
         Field("countries", None, Nil, ListType(TypeRef("Country")), false, None)
       ),
       interfaces = Nil
-    )
-
-  val CountryType: ObjectType =
+    ),
     ObjectType(
       name = "Country",
       description = None,
@@ -78,11 +69,8 @@ object CountrySchema extends Schema {
       ),
       interfaces = Nil
     )
+  )
 
-  val types = List(QueryType, CountryType)
-  val queryType = TypeRef("Query")
-  val mutationType = None
-  val subscriptionType = None
   val directives = Nil
 }
 
@@ -91,7 +79,7 @@ object CurrencySchema extends Schema {
 
   val CodeArg = InputValue("code", None, NullableType(StringType), None)
 
-  val QueryType: ObjectType =
+  val types = List(
     ObjectType(
       name = "Query",
       description = None,
@@ -99,9 +87,7 @@ object CurrencySchema extends Schema {
         Field("currency", None, List(CodeArg), NullableType(TypeRef("Currency")), false, None)
       ),
       interfaces = Nil
-    )
-
-  val CurrencyType: ObjectType =
+    ),
     ObjectType(
       name = "Currency",
       description = None,
@@ -111,10 +97,7 @@ object CurrencySchema extends Schema {
       ),
       interfaces = Nil
     )
+  )
 
-  val types = List(QueryType, CurrencyType)
-  val queryType = TypeRef("Query")
-  val mutationType = None
-  val subscriptionType = None
   val directives = Nil
 }

--- a/modules/core/src/test/scala/composed/ComposedSpec.scala
+++ b/modules/core/src/test/scala/composed/ComposedSpec.scala
@@ -88,8 +88,8 @@ final class ComposedSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = CountryCurrencyQueryCompiler.compile(query).right.get
-    val res = CountryCurrencyQueryInterpreter.run(compiledQuery, ComposedSchema.queryType)
+    val compiledQuery = ComposedQueryCompiler.compile(query).right.get
+    val res = ComposedQueryInterpreter.run(compiledQuery, ComposedSchema.queryType)
     //println(res)
 
     assert(res == expected)
@@ -138,8 +138,8 @@ final class ComposedSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = CountryCurrencyQueryCompiler.compile(query).right.get
-    val res = CountryCurrencyQueryInterpreter.run(compiledQuery, ComposedSchema.queryType)
+    val compiledQuery = ComposedQueryCompiler.compile(query).right.get
+    val res = ComposedQueryInterpreter.run(compiledQuery, ComposedSchema.queryType)
     //println(res)
 
     assert(res == expected)

--- a/modules/core/src/test/scala/composed/ComposedSpec.scala
+++ b/modules/core/src/test/scala/composed/ComposedSpec.scala
@@ -29,7 +29,7 @@ final class ComposedSpec extends CatsSuite {
     """
 
     val compiledQuery = CurrencyQueryCompiler.compile(query).right.get
-    val res = CurrencyQueryInterpreter.run(compiledQuery)
+    val res = CurrencyQueryInterpreter.run(compiledQuery, CurrencySchema.queryType)
     //println(res)
 
     assert(res == expected)
@@ -55,7 +55,7 @@ final class ComposedSpec extends CatsSuite {
     """
 
     val compiledQuery = CountryQueryCompiler.compile(query).right.get
-    val res = CountryQueryInterpreter.run(compiledQuery)
+    val res = CountryQueryInterpreter.run(compiledQuery, CountrySchema.queryType)
     //println(res)
 
     assert(res == expected)
@@ -89,7 +89,7 @@ final class ComposedSpec extends CatsSuite {
     """
 
     val compiledQuery = CountryCurrencyQueryCompiler.compile(query).right.get
-    val res = CountryCurrencyQueryInterpreter.run(compiledQuery)
+    val res = CountryCurrencyQueryInterpreter.run(compiledQuery, ComposedSchema.queryType)
     //println(res)
 
     assert(res == expected)
@@ -139,7 +139,7 @@ final class ComposedSpec extends CatsSuite {
     """
 
     val compiledQuery = CountryCurrencyQueryCompiler.compile(query).right.get
-    val res = CountryCurrencyQueryInterpreter.run(compiledQuery)
+    val res = CountryCurrencyQueryInterpreter.run(compiledQuery, ComposedSchema.queryType)
     //println(res)
 
     assert(res == expected)

--- a/modules/core/src/test/scala/starwars/StarWarsData.scala
+++ b/modules/core/src/test/scala/starwars/StarWarsData.scala
@@ -113,7 +113,6 @@ object StarWarsQueryCompiler extends QueryCompiler(StarWarsSchema) {
 }
 
 object StarWarsQueryInterpreter extends DataTypeQueryInterpreter[Id](
-  StarWarsSchema,
   {
     case "hero"                        => (ListType(CharacterType), characters)
     case "character" | "human"         => (ListType(CharacterType), characters)

--- a/modules/core/src/test/scala/starwars/StarWarsData.scala
+++ b/modules/core/src/test/scala/starwars/StarWarsData.scala
@@ -102,9 +102,9 @@ object StarWarsQueryCompiler extends QueryCompiler(StarWarsSchema) {
   val selectElaborator = new SelectElaborator(Map(
     StarWarsSchema.tpe("Query").dealias -> {
       case Select("hero", _, child) =>
-        Wrap("hero", Unique(FieldEquals("id", R2D2.id), child)).rightIor
+        Select("hero", Nil, Unique(FieldEquals("id", R2D2.id), child)).rightIor
       case Select(f@("character" | "human"), List(StringBinding("id", id)), child) =>
-        Wrap(f, Unique(FieldEquals("id", id), child)).rightIor
+        Select(f, Nil, Unique(FieldEquals("id", id), child)).rightIor
     }
   ))
 

--- a/modules/core/src/test/scala/starwars/StarWarsData.scala
+++ b/modules/core/src/test/scala/starwars/StarWarsData.scala
@@ -12,7 +12,6 @@ import Query._, Binding._, Predicate._
 import QueryCompiler._
 
 import StarWarsData._
-import StarWarsSchema._
 
 object StarWarsData {
   object Episode extends Enumeration {
@@ -101,7 +100,7 @@ object StarWarsData {
 
 object StarWarsQueryCompiler extends QueryCompiler(StarWarsSchema) {
   val selectElaborator = new SelectElaborator(Map(
-    QueryType -> {
+    StarWarsSchema.tpe("Query").dealias -> {
       case Select("hero", _, child) =>
         Wrap("hero", Unique(FieldEquals("id", R2D2.id), child)).rightIor
       case Select(f@("character" | "human"), List(StringBinding("id", id)), child) =>
@@ -114,8 +113,8 @@ object StarWarsQueryCompiler extends QueryCompiler(StarWarsSchema) {
 
 object StarWarsQueryInterpreter extends DataTypeQueryInterpreter[Id](
   {
-    case "hero"                        => (ListType(CharacterType), characters)
-    case "character" | "human"         => (ListType(CharacterType), characters)
+    case "hero"                        => (ListType(StarWarsSchema.tpe("Character")), characters)
+    case "character" | "human"         => (ListType(StarWarsSchema.tpe("Character")), characters)
   },
   {
     case (c: Character, "id")          => c.id

--- a/modules/core/src/test/scala/starwars/StarWarsSchema.scala
+++ b/modules/core/src/test/scala/starwars/StarWarsSchema.scala
@@ -11,7 +11,7 @@ object StarWarsSchema extends Schema {
   val EpisodeArg = InputValue("episode", None, NullableType(TypeRef("Episode")), None)
   val IdArg = InputValue("id", None, StringType, None)
 
-  val QueryType: ObjectType =
+  val types = List(
     ObjectType(
       name = "Query",
       description = None,
@@ -21,9 +21,7 @@ object StarWarsSchema extends Schema {
         Field("human", None, List(IdArg), NullableType(TypeRef("Character")), false, None)
       ),
       interfaces = Nil
-    )
-
-  val EpisodeType: EnumType =
+    ),
     EnumType(
       name = "Episode",
       description = None,
@@ -32,9 +30,7 @@ object StarWarsSchema extends Schema {
         EnumValue("EMPIRE", None),
         EnumValue("JEDI", None)
       )
-    )
-
-  val CharacterType: InterfaceType =
+    ),
     InterfaceType(
       name = "Character",
       description = None,
@@ -44,9 +40,7 @@ object StarWarsSchema extends Schema {
         Field("friends", None, Nil, NullableType(ListType(TypeRef("Character"))), false, None),
         Field("appearsIn", None, Nil, NullableType(ListType(TypeRef("Episode"))), false, None)
       )
-    )
-
-  val HumanType: ObjectType =
+    ),
     ObjectType(
       name = "Human",
       description = None,
@@ -58,9 +52,7 @@ object StarWarsSchema extends Schema {
         Field("homePlanet", None, Nil, NullableType(StringType), false, None)
       ),
       interfaces = List(TypeRef("Character"))
-    )
-
-  val DroidType: ObjectType =
+    ),
     ObjectType(
       name = "Droid",
       description = None,
@@ -73,10 +65,7 @@ object StarWarsSchema extends Schema {
       ),
       interfaces = List(TypeRef("Character"))
     )
+  )
 
-  val types = List(QueryType, EpisodeType, CharacterType, HumanType, DroidType)
-  val queryType = TypeRef("Query")
-  val mutationType = None
-  val subscriptionType = None
   val directives = Nil
 }

--- a/modules/core/src/test/scala/starwars/StarWarsSpec.scala
+++ b/modules/core/src/test/scala/starwars/StarWarsSpec.scala
@@ -28,7 +28,7 @@ final class StarWarsSpec extends CatsSuite {
     """
 
     val compiledQuery = StarWarsQueryCompiler.compile(query).right.get
-    val res = StarWarsQueryInterpreter.run(compiledQuery)
+    val res = StarWarsQueryInterpreter.run(compiledQuery, StarWarsSchema.queryType)
     //println(res)
 
     assert(res == expected)
@@ -71,7 +71,7 @@ final class StarWarsSpec extends CatsSuite {
     """
 
     val compiledQuery = StarWarsQueryCompiler.compile(query).right.get
-    val res = StarWarsQueryInterpreter.run(compiledQuery)
+    val res = StarWarsQueryInterpreter.run(compiledQuery, StarWarsSchema.queryType)
     //println(res)
 
     assert(res == expected)

--- a/modules/doobie/src/main/scala/doobieinterpreter.scala
+++ b/modules/doobie/src/main/scala/doobieinterpreter.scala
@@ -20,11 +20,10 @@ import Query._
 import QueryInterpreter.{ mkErrorResult, ProtoJson }
 
 class DoobieQueryInterpreter[F[_]](
-  schema: Schema,
   mapping: DoobieMapping,
   xa: Transactor[F],
   logger: Logger[F]
-) (override implicit val F: Bracket[F, Throwable]) extends QueryInterpreter[F](schema) {
+) (override implicit val F: Bracket[F, Throwable]) extends QueryInterpreter[F] {
 
   def runRootValue(query: Query, rootTpe: Type): F[Result[ProtoJson]] =
     query match {

--- a/modules/doobie/src/main/scala/doobieinterpreter.scala
+++ b/modules/doobie/src/main/scala/doobieinterpreter.scala
@@ -50,7 +50,7 @@ object DoobiePredicate {
     (if (caseInsensitive) s"(?i:$csr)" else csr).r
   }
 
-  case class FieldLike(fieldName: String, pattern: String, caseInsensitive: Boolean) extends Predicate {
+  case class FieldLike(fieldName: String, pattern: String, caseInsensitive: Boolean) extends FieldPredicate {
     lazy val r = likeToRegex(pattern, caseInsensitive)
 
     def path = List(fieldName)
@@ -61,7 +61,7 @@ object DoobiePredicate {
       }
   }
 
-  case class AttrLike(keyName: String, pattern: String, caseInsensitive: Boolean) extends Predicate {
+  case class AttrLike(keyName: String, pattern: String, caseInsensitive: Boolean) extends AttributePredicate {
     lazy val r = likeToRegex(pattern, caseInsensitive)
 
     def path = List(keyName)
@@ -138,8 +138,8 @@ case class DoobieCursor(val tpe: Type, val focus: Any, mapped: MappedQuery) exte
   }
 
   def hasAttribute(attributeName: String): Boolean =
-    mapped.hasKey(tpe, attributeName)
+    mapped.hasAttribute(tpe, attributeName)
 
   def attribute(attributeName: String): Result[Any] =
-    asTable.map(table => mapped.selectKey(table.head, tpe, attributeName))
+    asTable.map(table => mapped.selectAttribute(table.head, tpe, attributeName))
 }

--- a/modules/doobie/src/main/scala/doobiemapping.scala
+++ b/modules/doobie/src/main/scala/doobiemapping.scala
@@ -266,7 +266,7 @@ object DoobieMapping {
         osj match {
           case Some(stagingJoin) => stagingJoin(c, q)
           case None =>
-            mkErrorResult(s"No staging join for field '$fieldName' of type ${obj.shortString}")
+            mkErrorResult(s"No staging join for field '$fieldName' of type $obj")
         }
       case _ => mkErrorResult(s"No staging join for non-Select $q")
     }

--- a/modules/doobie/src/main/scala/doobiemapping.scala
+++ b/modules/doobie/src/main/scala/doobiemapping.scala
@@ -283,15 +283,7 @@ object DoobieMapping {
               loop(child, childTpe, filtered + tpe.underlyingObject).map(ec => s.copy(child = ec))
             }
 
-          case w@Wrap(fieldName, child)      =>
-            val childTpe = tpe.underlyingField(fieldName)
-            if(filtered(childTpe.underlyingObject)) {
-              val elaboratedSelect = loop(child, childTpe, Set.empty).map(ec => w.copy(child = ec))
-              elaboratedSelect.map(ec => Wrap(fieldName, Defer(stagingJoin, ec)))
-            } else {
-              loop(child, childTpe, filtered + tpe.underlyingObject).map(ec => w.copy(child = ec))
-            }
-
+          case w@Wrap(_, child)              => loop(child, tpe, filtered).map(ec => w.copy(child = ec))
           case g@Group(queries)              => queries.traverse(q => loop(q, tpe, filtered)).map(eqs => g.copy(queries = eqs))
           case u@Unique(_, child)            => loop(child, tpe.nonNull, filtered + tpe.underlyingObject).map(ec => u.copy(child = ec))
           case f@Filter(_, child)            => loop(child, tpe.item, filtered + tpe.underlyingObject).map(ec => f.copy(child = ec))

--- a/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
@@ -154,9 +154,9 @@ object ComposedQueryCompiler extends QueryCompiler(ComposedSchema) {
   ))
 
   val countryCurrencyJoin = (c: Cursor, q: Query) =>
-    c.attribute("code") match {
-      case Ior.Right(countryCode: String) =>
-        Wrap("currencies", Filter(FieldEquals("countryCode", countryCode), q)).rightIor
+    (c.attribute("code"), q) match {
+      case (Ior.Right(countryCode: String), Select("currencies", _, child)) =>
+        Wrap("currencies", Filter(FieldEquals("countryCode", countryCode), child)).rightIor
       case _ => mkErrorResult(s"Expected 'code' attribute at ${c.tpe.shortString}")
     }
 
@@ -167,7 +167,7 @@ object ComposedQueryCompiler extends QueryCompiler(ComposedSchema) {
     Mapping(CountryType, "currencies", "CurrencyComponent", countryCurrencyJoin)
   )
 
-  val phases = List(selectElaborator, componentElaborator)
+  val phases = List(componentElaborator, selectElaborator)
 }
 
 object ComposedQueryInterpreter {

--- a/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
@@ -145,18 +145,18 @@ object ComposedQueryCompiler extends QueryCompiler(ComposedSchema) {
   val selectElaborator =  new SelectElaborator(Map(
     QueryType -> {
       case Select("country", List(StringBinding("code", code)), child) =>
-        Wrap("country", Unique(AttrEquals("code", code), child)).rightIor
+        Select("country", Nil, Unique(AttrEquals("code", code), child)).rightIor
       case Select("countries", _, child) =>
-        Wrap("countries", child).rightIor
+        Select("countries", Nil, child).rightIor
       case Select("cities", List(StringBinding("namePattern", namePattern)), child) =>
-        Wrap("cities", Filter(FieldLike("name", namePattern, true), child)).rightIor
+        Select("cities", Nil, Filter(FieldLike("name", namePattern, true), child)).rightIor
     }
   ))
 
   val countryCurrencyJoin = (c: Cursor, q: Query) =>
     (c.attribute("code"), q) match {
       case (Ior.Right(countryCode: String), Select("currencies", _, child)) =>
-        Wrap("currencies", Filter(FieldEquals("countryCode", countryCode), child)).rightIor
+        Select("currencies", Nil, Filter(FieldEquals("countryCode", countryCode), child)).rightIor
       case _ => mkErrorResult(s"Expected 'code' attribute at ${c.tpe.shortString}")
     }
 

--- a/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
@@ -16,9 +16,10 @@ import QueryCompiler._, ComponentElaborator.Mapping
 import QueryInterpreter.mkErrorResult
 import DoobiePredicate._
 
-import ComposedWorldSchema._
-
 object CountryCurrencyQueryCompiler extends QueryCompiler(ComposedWorldSchema) {
+  val QueryType = ComposedWorldSchema.tpe("Query")
+  val CountryType = ComposedWorldSchema.tpe("Country")
+
   val selectElaborator =  new SelectElaborator(Map(
     QueryType -> {
       case Select("country", List(StringBinding("code", code)), child) =>
@@ -75,6 +76,8 @@ object CurrencyData {
 object CurrencyQueryInterpreter {
   import CurrencyData._
 
+  val CurrencyType = ComposedWorldSchema.tpe("Currency")
+
   def apply[F[_]: Monad] = new DataTypeQueryInterpreter[F](
     {
       case "currencies" => (ListType(CurrencyType), currencies)
@@ -90,6 +93,11 @@ object CurrencyQueryInterpreter {
 object ComposedWorldData extends DoobieMapping {
   import DoobieMapping._, FieldMapping._
   import ScalarType._
+
+  val QueryType = ComposedWorldSchema.tpe("Query")
+  val CountryType = ComposedWorldSchema.tpe("Country")
+  val CityType = ComposedWorldSchema.tpe("City")
+  val LanguageType = ComposedWorldSchema.tpe("Language")
 
   val queryMapping =
     ObjectMapping(

--- a/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
@@ -157,7 +157,7 @@ object ComposedQueryCompiler extends QueryCompiler(ComposedSchema) {
     (c.attribute("code"), q) match {
       case (Ior.Right(countryCode: String), Select("currencies", _, child)) =>
         Select("currencies", Nil, Filter(FieldEquals("countryCode", countryCode), child)).rightIor
-      case _ => mkErrorResult(s"Expected 'code' attribute at ${c.tpe.shortString}")
+      case _ => mkErrorResult(s"Expected 'code' attribute at ${c.tpe}")
     }
 
   val componentElaborator = ComponentElaborator(

--- a/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
@@ -38,10 +38,10 @@ object CountryCurrencyQueryCompiler extends QueryCompiler(ComposedWorldSchema) {
     }
 
   val componentElaborator = ComponentElaborator(
-    Mapping(QueryType, "country", WorldSchema),
-    Mapping(QueryType, "countries", WorldSchema),
-    Mapping(QueryType, "cities", WorldSchema),
-    Mapping(CountryType, "currencies", CurrencySchema, countryCurrencyJoin)
+    Mapping(QueryType, "country", "WorldSchema"),
+    Mapping(QueryType, "countries", "WorldSchema"),
+    Mapping(QueryType, "cities", "WorldSchema"),
+    Mapping(CountryType, "currencies", "CurrencySchema", countryCurrencyJoin)
   )
 
   val phases = List(selectElaborator, componentElaborator)
@@ -50,9 +50,9 @@ object CountryCurrencyQueryCompiler extends QueryCompiler(ComposedWorldSchema) {
 object CountryCurrencyQueryInterpreter {
   def fromTransactor[F[_]](xa: Transactor[F])
     (implicit brkt: Bracket[F, Throwable], logger0: Logger[F]): ComposedQueryInterpreter[F] = {
-      val mapping: Map[Schema, QueryInterpreter[F]] = Map(
-        WorldSchema    -> WorldQueryInterpreter.fromTransactor(xa),
-        CurrencySchema -> CurrencyQueryInterpreter[F]
+      val mapping: Map[String, QueryInterpreter[F]] = Map(
+        "WorldSchema"    -> WorldQueryInterpreter.fromTransactor(xa),
+        "CurrencySchema" -> CurrencyQueryInterpreter[F]
       )
       new ComposedQueryInterpreter(ComposedWorldSchema, mapping)
   }

--- a/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
@@ -50,7 +50,7 @@ object CountryCurrencyQueryCompiler extends QueryCompiler(ComposedWorldSchema) {
 object CountryCurrencyQueryInterpreter {
   def fromTransactor[F[_]](xa: Transactor[F])
     (implicit brkt: Bracket[F, Throwable], logger0: Logger[F]): ComposedQueryInterpreter[F] = {
-      val mapping: Map[SchemaComponent, QueryInterpreter[F]] = Map(
+      val mapping: Map[Schema, QueryInterpreter[F]] = Map(
         WorldSchema    -> WorldQueryInterpreter.fromTransactor(xa),
         CurrencySchema -> CurrencyQueryInterpreter[F]
       )

--- a/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
@@ -100,7 +100,7 @@ object WorldData extends DoobieMapping {
       attributeMappings =
         List(
           "id" -> Attr[Int](ColumnRef("city", "id")),
-          "countrycode" -> Attr[String](ColumnRef("city", "countycode")),
+          "countrycode" -> Attr[String](ColumnRef("city", "countrycode")),
         )
     )
 

--- a/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
@@ -53,81 +53,76 @@ object CurrencyQueryInterpreter {
 
 object WorldData extends DoobieMapping {
   import DoobieMapping._, FieldMapping._
-  import ScalarType._
-
-  val QueryType = WorldSchema.tpe("Query")
-  val CountryType = WorldSchema.tpe("Country")
-  val CityType = WorldSchema.tpe("City")
-  val LanguageType = WorldSchema.tpe("Language")
-
-  val queryMapping =
-    ObjectMapping(
-      tpe = QueryType,
-      key = Nil,
-      fieldMappings =
-        List(
-          "cities" -> Subobject(ListType(CityType), Nil),
-          "country" -> Subobject(CountryType, Nil),
-          "countries" -> Subobject(ListType(CountryType), Nil)
-        )
-    )
 
   val countryMapping =
     ObjectMapping(
-      tpe = CountryType,
-      key = List(ColumnRef("country", "code", StringType)),
+      tpe = "Country",
+      key = List(ColumnRef("country", "code")),
       fieldMappings =
         List(
-          "name" -> ColumnRef("country", "name", StringType),
-          "continent" -> ColumnRef("country", "continent", StringType),
-          "region" -> ColumnRef("country", "region", StringType),
-          "surfacearea" -> ColumnRef("country", "surfacearea", FloatType),
-          "indepyear" -> ColumnRef("country", "indepyear", IntType),
-          "population" -> ColumnRef("country", "population", IntType),
-          "lifeexpectancy" -> ColumnRef("country", "lifeexpectancy", FloatType),
-          "gnp" -> ColumnRef("country", "gnp", StringType),
-          "gnpold" -> ColumnRef("country", "gnpold", StringType),
-          "localname" -> ColumnRef("country", "localname", StringType),
-          "governmentform" -> ColumnRef("country", "governmentform", StringType),
-          "headofstate" -> ColumnRef("country", "headofstate", StringType),
-          "capitalId" -> ColumnRef("country", "capitalId", IntType),
-          "code2" -> ColumnRef("country", "code2", StringType),
-          "cities" -> Subobject(ListType(CityType),
-            List(Join(ColumnRef("country", "code", StringType), ColumnRef("city", "countrycode", StringType)))),
-          "languages" -> Subobject(ListType(LanguageType),
-            List(Join(ColumnRef("country", "code", StringType), ColumnRef("countryLanguage", "countrycode", StringType))))
+          "name" -> ColumnRef("country", "name"),
+          "continent" -> ColumnRef("country", "continent"),
+          "region" -> ColumnRef("country", "region"),
+          "surfacearea" -> ColumnRef("country", "surfacearea"),
+          "indepyear" -> ColumnRef("country", "indepyear"),
+          "population" -> ColumnRef("country", "population"),
+          "lifeexpectancy" -> ColumnRef("country", "lifeexpectancy"),
+          "gnp" -> ColumnRef("country", "gnp"),
+          "gnpold" -> ColumnRef("country", "gnpold"),
+          "localname" -> ColumnRef("country", "localname"),
+          "governmentform" -> ColumnRef("country", "governmentform"),
+          "headofstate" -> ColumnRef("country", "headofstate"),
+          "capitalId" -> ColumnRef("country", "capitalId"),
+          "code2" -> ColumnRef("country", "code2"),
+          "cities" -> Subobject(
+            List(Join(ColumnRef("country", "code"), ColumnRef("city", "countrycode")))),
+          "languages" -> Subobject(
+            List(Join(ColumnRef("country", "code"), ColumnRef("countryLanguage", "countrycode"))))
+        ),
+      attributeMappings =
+        List(
+          "code" -> Attr[String](ColumnRef("country", "code"))
         )
     )
 
   val cityMapping =
     ObjectMapping(
-      tpe = CityType,
-      key = List(ColumnRef("city", "id", IntType)),
+      tpe = "City",
+      key = List(ColumnRef("city", "id")),
       fieldMappings =
         List(
-          "name" -> ColumnRef("city", "name", StringType),
-          "country" -> Subobject(CountryType,
-            List(Join(ColumnRef("city", "countrycode", StringType), ColumnRef("country", "code", StringType)))),
-          "district" -> ColumnRef("city", "district", StringType),
-          "population" -> ColumnRef("city", "population", IntType)
+          "name" -> ColumnRef("city", "name"),
+          "country" -> Subobject(
+            List(Join(ColumnRef("city", "countrycode"), ColumnRef("country", "code")))),
+          "district" -> ColumnRef("city", "district"),
+          "population" -> ColumnRef("city", "population")
+        ),
+      attributeMappings =
+        List(
+          "id" -> Attr[Int](ColumnRef("city", "id")),
+          "countrycode" -> Attr[String](ColumnRef("city", "countycode")),
         )
     )
 
   val languageMapping =
     ObjectMapping(
-      tpe = LanguageType,
-      key = List(ColumnRef("countryLanguage", "language", StringType)),
+      tpe = "Language",
+      key = List(ColumnRef("countryLanguage", "language")),
       fieldMappings =
         List(
-          "language" -> ColumnRef("countryLanguage", "language", StringType),
-          "isOfficial" -> ColumnRef("countryLanguage", "isOfficial", BooleanType),
-          "percentage" -> ColumnRef("countryLanguage", "percentage", FloatType),
-          "countries" -> Subobject(ListType(CountryType),
-            List(Join(ColumnRef("countryLanguage", "countrycode", StringType), ColumnRef("country", "code", StringType))))
+          "language" -> ColumnRef("countryLanguage", "language"),
+          "isOfficial" -> ColumnRef("countryLanguage", "isOfficial"),
+          "percentage" -> ColumnRef("countryLanguage", "percentage"),
+          "countries" -> Subobject(
+            List(Join(ColumnRef("countryLanguage", "countrycode"), ColumnRef("country", "code"))))
+        ),
+      attributeMappings =
+        List(
+          "countrycode" -> Attr[String](ColumnRef("countryLanguage", "countrycode"))
         )
     )
 
-  val objectMappings = List(queryMapping, countryMapping, cityMapping, languageMapping)
+  val objectMappings = List(countryMapping, cityMapping, languageMapping)
 }
 
 object WorldQueryInterpreter {

--- a/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
@@ -35,7 +35,7 @@ object CurrencyData {
 object CurrencyQueryInterpreter {
   import CurrencyData._
 
-  val CurrencyType = ComposedSchema.tpe("Currency")
+  val CurrencyType = CurrencySchema.tpe("Currency")
 
   def apply[F[_]: Monad] = new DataTypeQueryInterpreter[F](
     {
@@ -55,10 +55,10 @@ object WorldData extends DoobieMapping {
   import DoobieMapping._, FieldMapping._
   import ScalarType._
 
-  val QueryType = ComposedSchema.tpe("Query")
-  val CountryType = ComposedSchema.tpe("Country")
-  val CityType = ComposedSchema.tpe("City")
-  val LanguageType = ComposedSchema.tpe("Language")
+  val QueryType = WorldSchema.tpe("Query")
+  val CountryType = WorldSchema.tpe("Country")
+  val CityType = WorldSchema.tpe("City")
+  val LanguageType = WorldSchema.tpe("Language")
 
   val queryMapping =
     ObjectMapping(

--- a/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
@@ -54,7 +54,7 @@ object CountryCurrencyQueryInterpreter {
         "WorldSchema"    -> WorldQueryInterpreter.fromTransactor(xa),
         "CurrencySchema" -> CurrencyQueryInterpreter[F]
       )
-      new ComposedQueryInterpreter(ComposedWorldSchema, mapping)
+      new ComposedQueryInterpreter(mapping)
   }
 }
 
@@ -76,7 +76,6 @@ object CurrencyQueryInterpreter {
   import CurrencyData._
 
   def apply[F[_]: Monad] = new DataTypeQueryInterpreter[F](
-    ComposedWorldSchema,
     {
       case "currencies" => (ListType(CurrencyType), currencies)
     },
@@ -165,5 +164,5 @@ object ComposedWorldData extends DoobieMapping {
 object WorldQueryInterpreter {
   def fromTransactor[F[_]](xa: Transactor[F])
     (implicit brkt: Bracket[F, Throwable], logger: Logger[F]): DoobieQueryInterpreter[F] =
-      new DoobieQueryInterpreter[F](ComposedWorldSchema, ComposedWorldData, xa, logger)
+      new DoobieQueryInterpreter[F](ComposedWorldData, xa, logger)
 }

--- a/modules/doobie/src/test/scala/composed/ComposedWorldSchema.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldSchema.scala
@@ -11,7 +11,7 @@ object ComposedWorldSchema extends Schema {
   val NamePatternArg = InputValue("namePattern", None, NullableType(StringType), Some("%"))
   val CodeArg = InputValue("code", None, NullableType(StringType), None)
 
-  val QueryType: ObjectType =
+  val types = List(
     ObjectType(
       name = "Query",
       description = None,
@@ -22,9 +22,7 @@ object ComposedWorldSchema extends Schema {
         Field("currencies", None, Nil, ListType(TypeRef("Currency")), false, None) // Should be local to CurrencySchema
       ),
       interfaces = Nil
-    )
-
-  val CityType: ObjectType =
+    ),
     ObjectType(
       name = "City",
       description = None,
@@ -35,9 +33,7 @@ object ComposedWorldSchema extends Schema {
         Field("population", None, Nil, IntType, false, None)
       ),
       interfaces = Nil
-    )
-
-  val LanguageType: ObjectType =
+    ),
     ObjectType(
       name = "Language",
       description = None,
@@ -48,9 +44,7 @@ object ComposedWorldSchema extends Schema {
         Field("countries", None, Nil, ListType(TypeRef("Country")), false, None)
       ),
       interfaces = Nil
-    )
-
-  val CurrencyType: ObjectType =
+    ),
     ObjectType(
       name = "Currency",
       description = None,
@@ -60,9 +54,7 @@ object ComposedWorldSchema extends Schema {
         Field("countryCode", None, Nil, StringType, false, None)
       ),
       interfaces = Nil
-    )
-
-  val CountryType: ObjectType =
+    ),
     ObjectType(
       name = "Country",
       description = None,
@@ -87,11 +79,8 @@ object ComposedWorldSchema extends Schema {
       ),
       interfaces = Nil
     )
+  )
 
-  val types = List(QueryType, CityType, LanguageType, CurrencyType, CountryType)
-  val queryType = TypeRef("Query")
-  val mutationType = None
-  val subscriptionType = None
   val directives = Nil
 }
 
@@ -101,7 +90,7 @@ object WorldSchema extends Schema {
   val NamePatternArg = InputValue("namePattern", None, NullableType(StringType), Some("%"))
   val CodeArg = InputValue("code", None, NullableType(StringType), None)
 
-  val QueryType: ObjectType =
+  val types = List(
     ObjectType(
       name = "Query",
       description = None,
@@ -111,9 +100,7 @@ object WorldSchema extends Schema {
         Field("countries", None, Nil, NullableType(ListType(TypeRef("Country"))), false, None)
       ),
       interfaces = Nil
-    )
-
-  val CityType: ObjectType =
+    ),
     ObjectType(
       name = "City",
       description = None,
@@ -124,9 +111,7 @@ object WorldSchema extends Schema {
         Field("population", None, Nil, IntType, false, None)
       ),
       interfaces = Nil
-    )
-
-  val LanguageType: ObjectType =
+    ),
     ObjectType(
       name = "Language",
       description = None,
@@ -137,9 +122,7 @@ object WorldSchema extends Schema {
         Field("countries", None, Nil, ListType(TypeRef("Country")), false, None)
       ),
       interfaces = Nil
-    )
-
-  val CountryType: ObjectType =
+    ),
     ObjectType(
       name = "Country",
       description = None,
@@ -163,18 +146,15 @@ object WorldSchema extends Schema {
       ),
       interfaces = Nil
     )
+  )
 
-  val types = List(QueryType, CityType, LanguageType, CountryType)
-  val queryType = TypeRef("Query")
-  val mutationType = None
-  val subscriptionType = None
   val directives = Nil
 }
 
 object CurrencySchema extends Schema {
   import ScalarType._
 
-  val CurrencyType: ObjectType =
+  val types = List(
     ObjectType(
       name = "Currency",
       description = None,
@@ -185,10 +165,7 @@ object CurrencySchema extends Schema {
       ),
       interfaces = Nil
     )
+  )
 
-  val types = List(CurrencyType)
-  val queryType = NoType
-  val mutationType = None
-  val subscriptionType = None
   val directives = Nil
 }

--- a/modules/doobie/src/test/scala/composed/ComposedWorldSchema.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldSchema.scala
@@ -171,7 +171,7 @@ object WorldSchema extends Schema {
   val directives = Nil
 }
 
-object CurrencySchema extends SchemaComponent {
+object CurrencySchema extends Schema {
   import ScalarType._
 
   val CurrencyType: ObjectType =
@@ -187,4 +187,8 @@ object CurrencySchema extends SchemaComponent {
     )
 
   val types = List(CurrencyType)
+  val queryType = NoType
+  val mutationType = None
+  val subscriptionType = None
+  val directives = Nil
 }

--- a/modules/doobie/src/test/scala/composed/ComposedWorldSchema.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldSchema.scala
@@ -5,7 +5,7 @@ package composed
 
 import edu.gemini.grackle._
 
-object ComposedWorldSchema extends Schema {
+object ComposedSchema extends Schema {
   import ScalarType._
 
   val NamePatternArg = InputValue("namePattern", None, NullableType(StringType), Some("%"))

--- a/modules/doobie/src/test/scala/composed/ComposedWorldSpec.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldSpec.scala
@@ -54,7 +54,7 @@ final class ComposedWorldSpec extends CatsSuite {
     """
 
     val compiledQuery = CountryCurrencyQueryCompiler.compile(query).right.get
-    val res = CountryCurrencyQueryInterpreter.fromTransactor(xa).run(compiledQuery).unsafeRunSync
+    val res = CountryCurrencyQueryInterpreter.fromTransactor(xa).run(compiledQuery, ComposedWorldSchema.queryType).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -110,7 +110,7 @@ final class ComposedWorldSpec extends CatsSuite {
     """
 
     val compiledQuery = CountryCurrencyQueryCompiler.compile(query).right.get
-    val res = CountryCurrencyQueryInterpreter.fromTransactor(xa).run(compiledQuery).unsafeRunSync
+    val res = CountryCurrencyQueryInterpreter.fromTransactor(xa).run(compiledQuery, ComposedWorldSchema.queryType).unsafeRunSync
     //println(res)
 
     assert(res == expected)

--- a/modules/doobie/src/test/scala/composed/ComposedWorldSpec.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldSpec.scala
@@ -53,8 +53,8 @@ final class ComposedWorldSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = CountryCurrencyQueryCompiler.compile(query).right.get
-    val res = CountryCurrencyQueryInterpreter.fromTransactor(xa).run(compiledQuery, ComposedWorldSchema.queryType).unsafeRunSync
+    val compiledQuery = ComposedQueryCompiler.compile(query).right.get
+    val res = ComposedQueryInterpreter.fromTransactor(xa).run(compiledQuery, ComposedSchema.queryType).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -109,8 +109,8 @@ final class ComposedWorldSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = CountryCurrencyQueryCompiler.compile(query).right.get
-    val res = CountryCurrencyQueryInterpreter.fromTransactor(xa).run(compiledQuery, ComposedWorldSchema.queryType).unsafeRunSync
+    val compiledQuery = ComposedQueryCompiler.compile(query).right.get
+    val res = ComposedQueryInterpreter.fromTransactor(xa).run(compiledQuery, ComposedSchema.queryType).unsafeRunSync
     //println(res)
 
     assert(res == expected)

--- a/modules/doobie/src/test/scala/world/WorldData.scala
+++ b/modules/doobie/src/test/scala/world/WorldData.scala
@@ -118,11 +118,8 @@ object WorldData extends DoobieMapping {
 
   def languageCountryJoin(c: Cursor, q: Query): Result[Query] = q match {
     case Select("countries", Nil, child) =>
-      for {
-        f <- c.field("language", Map.empty)
-      } yield f.focus match {
-        case language: String =>
-          Select("countries", Nil, Filter(FieldContains(List("languages", "language"), language), child))
+      c.field("language", Map.empty).map { case StringScalarFocus(language) =>
+        Select("countries", Nil, Filter(FieldContains(List("languages", "language"), language), child))
       }
     case _ => mkErrorResult("Bad staging join")
   }

--- a/modules/doobie/src/test/scala/world/WorldData.scala
+++ b/modules/doobie/src/test/scala/world/WorldData.scala
@@ -16,9 +16,12 @@ import DoobiePredicate._
 import DoobieMapping._, FieldMapping._
 import ScalarType._
 
-import WorldSchema._
-
 object WorldData extends DoobieMapping {
+  val QueryType = WorldSchema.tpe("Query")
+  val CountryType = WorldSchema.tpe("Country")
+  val CityType = WorldSchema.tpe("City")
+  val LanguageType = WorldSchema.tpe("Language")
+
   val queryMapping =
     ObjectMapping(
       tpe = QueryType,
@@ -138,6 +141,8 @@ object WorldData extends DoobieMapping {
 }
 
 object WorldQueryCompiler extends QueryCompiler(WorldSchema) {
+  val QueryType = WorldSchema.tpe("Query")
+
   val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("country", List(StringBinding("code", code)), child) =>

--- a/modules/doobie/src/test/scala/world/WorldData.scala
+++ b/modules/doobie/src/test/scala/world/WorldData.scala
@@ -70,7 +70,7 @@ object WorldData extends DoobieMapping {
   def countryCityJoin(c: Cursor, q: Query): Result[Query] = q match {
     case Select("cities", Nil, child) =>
       c.attribute("code").map { case (code: String) =>
-        Wrap("cities", Filter(AttrEquals("countrycode", code), child))
+        Select("cities", Nil, Filter(AttrEquals("countrycode", code), child))
       }
     case _ => mkErrorResult("Bad staging join")
   }
@@ -78,7 +78,7 @@ object WorldData extends DoobieMapping {
   def countryLanguageJoin(c: Cursor, q: Query): Result[Query] = q match {
     case Select("languages", Nil, child) =>
       c.attribute("code").map { case (code: String) =>
-        Wrap("languages", Filter(FieldEquals("countrycode", code), child))
+        Select("languages", Nil, Filter(FieldEquals("countrycode", code), child))
       }
     case _ => mkErrorResult("Bad staging join")
   }
@@ -105,7 +105,7 @@ object WorldData extends DoobieMapping {
   def cityCountryJoin(c: Cursor, q: Query): Result[Query] = q match {
     case Select("country", Nil, child) =>
       c.attribute("countrycode").map { case (countrycode: String) =>
-        Wrap("country", Unique(AttrEquals("code", countrycode), child))
+        Select("country", Nil, Unique(AttrEquals("code", countrycode), child))
       }
     case _ => mkErrorResult("Bad staging join")
   }
@@ -132,7 +132,7 @@ object WorldData extends DoobieMapping {
   def languageCountryJoin(c: Cursor, q: Query): Result[Query] = q match {
     case Select("countries", Nil, child) =>
       c.attribute("language").map { case (language: String) =>
-        Wrap("countries", Filter(FieldContains(List("languages", "language"), language), child))
+        Select("countries", Nil, Filter(FieldContains(List("languages", "language"), language), child))
       }
     case _ => mkErrorResult("Bad staging join")
   }
@@ -146,15 +146,15 @@ object WorldQueryCompiler extends QueryCompiler(WorldSchema) {
   val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("country", List(StringBinding("code", code)), child) =>
-        Wrap("country", Unique(AttrEquals("code", code), child)).rightIor
+        Select("country", Nil, Unique(AttrEquals("code", code), child)).rightIor
       case Select("countries", Nil, child) =>
-        Wrap("countries", child).rightIor
+        Select("countries", Nil, child).rightIor
       case Select("cities", List(StringBinding("namePattern", namePattern)), child) =>
-        Wrap("cities", Filter(FieldLike("name", namePattern, true), child)).rightIor
+        Select("cities", Nil, Filter(FieldLike("name", namePattern, true), child)).rightIor
       case Select("language", List(StringBinding("language", language)), child) =>
-        Wrap("language", Unique(FieldEquals("language", language), child)).rightIor
+        Select("language", Nil, Unique(FieldEquals("language", language), child)).rightIor
       case Select("languages", Nil, child) =>
-        Wrap("languages", child).rightIor
+        Select("languages", Nil, child).rightIor
     }
   ))
 

--- a/modules/doobie/src/test/scala/world/WorldData.scala
+++ b/modules/doobie/src/test/scala/world/WorldData.scala
@@ -161,5 +161,5 @@ object WorldQueryCompiler extends QueryCompiler(WorldSchema) {
 object WorldQueryInterpreter {
   def fromTransactor[F[_]](xa: Transactor[F])
     (implicit brkt: Bracket[F, Throwable], logger: Logger[F]): DoobieQueryInterpreter[F] =
-      new DoobieQueryInterpreter[F](WorldSchema, WorldData, xa, logger)
+      new DoobieQueryInterpreter[F](WorldData, xa, logger)
 }

--- a/modules/doobie/src/test/scala/world/WorldSchema.scala
+++ b/modules/doobie/src/test/scala/world/WorldSchema.scala
@@ -12,7 +12,7 @@ object WorldSchema extends Schema {
   val CodeArg = InputValue("code", None, NullableType(StringType), None)
   val LanguageArg = InputValue("language", None, NullableType(StringType), None)
 
-  val QueryType: ObjectType =
+  val types = List(
     ObjectType(
       name = "Query",
       description = None,
@@ -24,9 +24,7 @@ object WorldSchema extends Schema {
         Field("languages", None, Nil, NullableType(ListType(TypeRef("Language"))), false, None)
       ),
       interfaces = Nil
-    )
-
-  val CityType: ObjectType =
+    ),
     ObjectType(
       name = "City",
       description = None,
@@ -37,9 +35,7 @@ object WorldSchema extends Schema {
         Field("population", None, Nil, IntType, false, None)
       ),
       interfaces = Nil
-    )
-
-  val LanguageType: ObjectType =
+    ),
     ObjectType(
       name = "Language",
       description = None,
@@ -51,9 +47,7 @@ object WorldSchema extends Schema {
         Field("countries", None, Nil, ListType(TypeRef("Country")), false, None)
       ),
       interfaces = Nil
-    )
-
-  val CountryType: ObjectType =
+    ),
     ObjectType(
       name = "Country",
       description = None,
@@ -77,10 +71,7 @@ object WorldSchema extends Schema {
       ),
       interfaces = Nil
     )
+  )
 
-  val types = List(QueryType, CityType, LanguageType, CountryType)
-  val queryType = TypeRef("Query")
-  val mutationType = None
-  val subscriptionType = None
   val directives = Nil
 }

--- a/modules/doobie/src/test/scala/world/WorldSchema.scala
+++ b/modules/doobie/src/test/scala/world/WorldSchema.scala
@@ -43,7 +43,6 @@ object WorldSchema extends Schema {
         Field("language", None, Nil, StringType, false, None),
         Field("isOfficial", None, Nil, BooleanType, false, None),
         Field("percentage", None, Nil, FloatType, false, None),
-        Field("countrycode", None, Nil, StringType, false, None), // FIXME: should be a private non-key attribute
         Field("countries", None, Nil, ListType(TypeRef("Country")), false, None)
       ),
       interfaces = Nil

--- a/modules/doobie/src/test/scala/world/WorldSpec.scala
+++ b/modules/doobie/src/test/scala/world/WorldSpec.scala
@@ -37,7 +37,7 @@ final class WorldSpec extends CatsSuite {
     val expected = 239
 
     val compiledQuery = WorldQueryCompiler.compile(query).right.get
-    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery).unsafeRunSync
+    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery, WorldSchema.queryType).unsafeRunSync
     //println(res)
 
     val resSize = root.data.countries.arr.getOption(res).map(_.size)
@@ -65,7 +65,7 @@ final class WorldSpec extends CatsSuite {
     """
 
     val compiledQuery = WorldQueryCompiler.compile(query).right.get
-    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery).unsafeRunSync
+    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery, WorldSchema.queryType).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -139,7 +139,7 @@ final class WorldSpec extends CatsSuite {
     """
 
     val compiledQuery = WorldQueryCompiler.compile(query).right.get
-    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery).unsafeRunSync
+    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery, WorldSchema.queryType).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -201,7 +201,7 @@ final class WorldSpec extends CatsSuite {
     """
 
     val compiledQuery = WorldQueryCompiler.compile(query).right.get
-    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery).unsafeRunSync
+    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery, WorldSchema.queryType).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -351,7 +351,7 @@ final class WorldSpec extends CatsSuite {
     """
 
     val compiledQuery = WorldQueryCompiler.compile(query).right.get
-    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery).unsafeRunSync
+    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery, WorldSchema.queryType).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -405,7 +405,7 @@ final class WorldSpec extends CatsSuite {
     """
 
     val compiledQuery = WorldQueryCompiler.compile(query).right.get
-    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery).unsafeRunSync
+    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery, WorldSchema.queryType).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -469,7 +469,7 @@ final class WorldSpec extends CatsSuite {
     """
 
     val compiledQuery = WorldQueryCompiler.compile(query).right.get
-    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery).unsafeRunSync
+    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery, WorldSchema.queryType).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -543,7 +543,7 @@ final class WorldSpec extends CatsSuite {
     """
 
     val compiledQuery = WorldQueryCompiler.compile(query).right.get
-    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery).unsafeRunSync
+    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery, WorldSchema.queryType).unsafeRunSync
     //println(res)
 
     assert(res == expected)

--- a/modules/doobie/src/test/scala/world/WorldSpec.scala
+++ b/modules/doobie/src/test/scala/world/WorldSpec.scala
@@ -148,7 +148,7 @@ final class WorldSpec extends CatsSuite {
   test("recursive query (1)") {
     val query = """
       query {
-        cities(namePattern: "Tirana") {
+        cities(namePattern: "Monte-Carlo") {
           name
           country {
             name
@@ -170,34 +170,60 @@ final class WorldSpec extends CatsSuite {
     """
 
     val expected = json"""
-      {
-        "data": {
-          "cities": [
-            {
-              "name": "Tirana",
-              "country": {
-                "name": "Albania",
-                "cities": [
-                  {
-                    "name": "Tirana",
-                    "country": {
-                      "name": "Albania",
-                      "cities": [
-                        {
-                          "name": "Tirana",
-                          "country": {
-                            "name": "Albania"
-                          }
+    {
+      "data" : {
+        "cities" : [
+          {
+            "name" : "Monte-Carlo",
+            "country" : {
+              "name" : "Monaco",
+              "cities" : [
+                {
+                  "name" : "Monte-Carlo",
+                  "country" : {
+                    "name" : "Monaco",
+                    "cities" : [
+                      {
+                        "name" : "Monte-Carlo",
+                        "country" : {
+                          "name" : "Monaco"
                         }
-                      ]
-                    }
+                      },
+                      {
+                        "name" : "Monaco-Ville",
+                        "country" : {
+                          "name" : "Monaco"
+                        }
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "name" : "Monaco-Ville",
+                  "country" : {
+                    "name" : "Monaco",
+                    "cities" : [
+                      {
+                        "name" : "Monte-Carlo",
+                        "country" : {
+                          "name" : "Monaco"
+                        }
+                      },
+                      {
+                        "name" : "Monaco-Ville",
+                        "country" : {
+                          "name" : "Monaco"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
             }
-          ]
-        }
+          }
+        ]
       }
+    }
     """
 
     val compiledQuery = WorldQueryCompiler.compile(query).right.get
@@ -548,4 +574,140 @@ final class WorldSpec extends CatsSuite {
 
     assert(res == expected)
   }
+
+  test("country with no cities") {
+    val query = """
+      query {
+        country(code: "ATA") {
+          name
+          cities {
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data": {
+          "country": {
+            "name": "Antarctica",
+            "cities": []
+          }
+        }
+      }
+    """
+
+    val compiledQuery = WorldQueryCompiler.compile(query).right.get
+    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery, WorldSchema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  // Outer join in which some parents have children and others do not.
+  test("countries, some with no cities") {
+    val query = """
+      query {
+        countries {
+          name
+          cities {
+            name
+          }
+        }
+      }
+    """
+    val cquery    = WorldQueryCompiler.compile(query).right.get
+    val json      = WorldQueryInterpreter.fromTransactor(xa).run(cquery, WorldSchema.queryType).unsafeRunSync
+    val countries = root.data.countries.arr.getOption(json).get
+    val map       = countries.map(j => root.name.string.getOption(j).get -> root.cities.arr.getOption(j).get.length).toMap
+    assert(map("Kazakstan")  == 21)
+    assert(map("Antarctica") == 0)
+  }
+
+  test("no such country") {
+    val query = """
+      query {
+        country(code: "XXX") {
+          name
+          cities {
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "errors" : [
+          {
+            "message" : "No match"
+          }
+        ]
+      }
+    """
+
+    val compiledQuery = WorldQueryCompiler.compile(query).right.get
+    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery, WorldSchema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("nullable column (null)") {
+    val query = """
+    query {
+        country(code: "ANT") {
+          name
+          indepyear
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "country" : {
+            "name" : "Netherlands Antilles",
+            "indepyear" : null
+          }
+        }
+      }
+    """
+
+    val compiledQuery = WorldQueryCompiler.compile(query).right.get
+    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery, WorldSchema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("nullable column (non-null)") {
+    val query = """
+    query {
+        country(code: "USA") {
+          name
+          indepyear
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "country" : {
+            "name" : "United States",
+            "indepyear" : 1776
+          }
+        }
+      }
+    """
+
+    val compiledQuery = WorldQueryCompiler.compile(query).right.get
+    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery, WorldSchema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
+
 }


### PR DESCRIPTION
This is a fairly large reorganization to support the composition of schemas/models/interpreters more cleanly. Prior to this PR _component_ interpreters had to be parameterised with the _composed_ schema. Following this PR component interpreters are always parameterized with their local schemas whether they are part of a larger composition or being used standalone.

For example, suppose we have schema/model/interpreter A and schema/model/interpreter B. We could work with either individually, in which case the interpreter for A would be parameterized with the schema for A; and the interpreter for B would be parameterized with the schema for B. So far so good.

However if we wanted to compose the schemas/models we would not be able to simply glom the A and B interpreters together. Instead they would both need to be parametrized with the composed schema, despite their local behaviour and semantics being unchanged. This opened up many opportunities for error, mainly around confusions between types belonging to the local and the composed schemas, and types leaking between components inappropriately.

Following this PR, component interpreters always work with their corresponding component types. The elaboration process during compilation is now responsible for ensuring that when a part of a query is dispatched to a component interpreter it's given an expected type from drawn from the corresponding component schema.

This had a fairly significant impact on the DB mapping (a parameter of the DB-backed interpreter). Previously it had to be defined in terms of a specific schema, which was problematic where there was more than one schema in play (ie. component vs. composed, as above). It turned out that the field types mentioned in the mapping were redundant (ie. could be inferred from the mapping and the actual schema it was used in conjunction with) and could be removed, simplifying the definition of the mapping with no loss of safety.

This left a small number of hard references to top-level types from a fixed schema in the mapping which would need to be rebound somehow if moving between schemas. In the end I decided to bind these by name rather than by reference to a type (ie. a Scala reference to a value of type `Type`). I've managed to convince myself that while this might seem like a reduction in safety, it actually isn't. There's work still to be done here, checking that a mapping is consistent with the schema it's used with, but that's work that would have had to be done anyway.

Relatedly I cleaned up the distinction between _fields_ (things which appear in the GraphQL schema) and _attributes_ (things which appear only in the model, eg. ids for joins) and between both of these and keys. In the DB mapping, attributes are assigned an arbitrary Scala type (rather than a GraphQL type) so long as there is a Doobie `Get` instance available for it.

There were lots of conflicts with @tpolecat's [PR](https://github.com/gemini-hlsw/gsp-graphql/pull/1) adding nullability support, so I've also reworked that here in the final commit.