### PR TITLE
make Phase a monoid, rename to Elaborator

### DIFF
--- a/demo/src/main/scala/starwars/StarWarsData.scala
+++ b/demo/src/main/scala/starwars/StarWarsData.scala
@@ -136,7 +136,7 @@ object StarWarsData {
 
 object StarWarsQueryCompiler extends QueryCompiler(StarWarsSchema) {
   // #elaborator
-  val selectElaborator = new SelectElaborator(Map(
+  val elaborator = new SelectElaborator(Map(
     StarWarsSchema.tpe("Query").dealias -> {
       // The hero selector take an Episode argument and yields a single value. We use the
       // Unique operator to pick out the target using the FieldEquals predicate.
@@ -153,8 +153,6 @@ object StarWarsQueryCompiler extends QueryCompiler(StarWarsSchema) {
     }
   ))
   // #elaborator
-
-  val phases = List(selectElaborator)
 }
 
 object StarWarsQueryInterpreter extends DataTypeQueryInterpreter[Id](

--- a/modules/core/src/main/scala/introspection.scala
+++ b/modules/core/src/main/scala/introspection.scala
@@ -10,7 +10,7 @@ import Query._, Binding._, Predicate._
 import QueryCompiler._
 
 object IntrospectionQueryCompiler extends QueryCompiler(SchemaSchema) {
-  val selectElaborator = new SelectElaborator(Map(
+  val elaborator = new SelectElaborator(Map(
     SchemaSchema.tpe("Query").dealias -> {
       case Select("__type", List(StringBinding("name", name)), child) =>
         Select("__type", Nil, Unique(FieldEquals("name", name), child)).rightIor
@@ -24,8 +24,6 @@ object IntrospectionQueryCompiler extends QueryCompiler(SchemaSchema) {
         Select("enumValues", Nil, filteredChild).rightIor
     }
   ))
-
-  val phases = List(selectElaborator)
 }
 
 object IntrospectionQueryInterpreter {

--- a/modules/core/src/test/scala/compiler/CompilerSpec.scala
+++ b/modules/core/src/test/scala/compiler/CompilerSpec.scala
@@ -219,14 +219,12 @@ object SimpleSchema extends Schema {
 }
 
 object SimpleCompiler extends QueryCompiler(SimpleSchema) {
-  val selectElaborator = new SelectElaborator(Map(
+  val elaborator = new SelectElaborator(Map(
     SimpleSchema.tpe("Query").dealias -> {
       case Select("character", List(StringBinding("id", id)), child) =>
         Unique(FieldEquals("id", id), child).rightIor
     }
   ))
-
-  val phases = List(selectElaborator)
 }
 
 object SchemaA extends Schema {
@@ -348,11 +346,9 @@ object ComposedSchema extends Schema {
 }
 
 object ComposedCompiler extends QueryCompiler(ComposedSchema) {
-  val componentElaborator = ComponentElaborator(
+  val elaborator = ComponentElaborator(
     Mapping(ComposedSchema.tpe("Query"), "componenta", "ComponentA"),
     Mapping(ComposedSchema.tpe("FieldA2"), "componentb", "ComponentB"),
     Mapping(ComposedSchema.tpe("FieldB2"), "componentc", "ComponentC")
   )
-
-  val phases = List(componentElaborator)
 }

--- a/modules/core/src/test/scala/compiler/FragmentSpec.scala
+++ b/modules/core/src/test/scala/compiler/FragmentSpec.scala
@@ -374,7 +374,7 @@ object FragmentSchema extends Schema {
 }
 
 object FragmentCompiler extends QueryCompiler(FragmentSchema) {
-  val selectElaborator = new SelectElaborator(Map(
+  val elaborator = new SelectElaborator(Map(
     FragmentSchema.tpe("Query").dealias -> {
       case Select("user", List(IDBinding("id", id)), child) =>
         Select("user", Nil, Unique(FieldEquals("id", id), child)).rightIor
@@ -382,8 +382,6 @@ object FragmentCompiler extends QueryCompiler(FragmentSchema) {
         sel.rightIor
     }
   ))
-
-  val phases = List(selectElaborator)
 }
 
 object FragmentData {

--- a/modules/core/src/test/scala/composed/ComposedData.scala
+++ b/modules/core/src/test/scala/composed/ComposedData.scala
@@ -42,14 +42,13 @@ object CurrencyQueryInterpreter extends DataTypeQueryInterpreter[Id](
 object CurrencyQueryCompiler extends QueryCompiler(CurrencySchema) {
   val QueryType = CurrencySchema.tpe("Query").dealias
 
-  val selectElaborator = new SelectElaborator(Map(
+  val elaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("currency", List(StringBinding("code", code)), child) =>
         Select("currency", Nil, Unique(FieldEquals("code", code), child)).rightIor
     }
   ))
 
-  val phases = List(selectElaborator)
 }
 
 /* Country component */
@@ -85,7 +84,7 @@ object CountryQueryInterpreter extends DataTypeQueryInterpreter[Id](
 object CountryQueryCompiler extends QueryCompiler(CountrySchema) {
   val QueryType = CountrySchema.tpe("Query").dealias
 
-  val selectElaborator = new SelectElaborator(Map(
+  val elaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("country", List(StringBinding("code", code)), child) =>
         Select("country", Nil, Unique(FieldEquals("code", code), child)).rightIor
@@ -94,7 +93,6 @@ object CountryQueryCompiler extends QueryCompiler(CountrySchema) {
     }
   ))
 
-  val phases = List(selectElaborator)
 }
 
 /* Composition */
@@ -130,7 +128,7 @@ object ComposedQueryCompiler extends QueryCompiler(ComposedSchema) {
     Mapping(CountryType, "currency", "CurrencyComponent", countryCurrencyJoin)
   )
 
-  val phases = List(componentElaborator, selectElaborator)
+  val elaborator = componentElaborator andThen selectElaborator
 }
 
 object ComposedQueryInterpreter extends

--- a/modules/core/src/test/scala/starwars/StarWarsData.scala
+++ b/modules/core/src/test/scala/starwars/StarWarsData.scala
@@ -107,7 +107,7 @@ object StarWarsData {
 }
 
 object StarWarsQueryCompiler extends QueryCompiler(StarWarsSchema) {
-  val selectElaborator = new SelectElaborator(Map(
+  val elaborator = new SelectElaborator(Map(
     StarWarsSchema.tpe("Query").dealias -> {
       case Select("hero", List(EnumBinding("episode", e)), child) =>
         val episode = Episode.values.find(_.toString == e.name).get
@@ -116,8 +116,6 @@ object StarWarsQueryCompiler extends QueryCompiler(StarWarsSchema) {
         Select(f, Nil, Unique(FieldEquals("id", id), child)).rightIor
     }
   ))
-
-  val phases = List(selectElaborator)
 }
 
 object StarWarsQueryInterpreter extends DataTypeQueryInterpreter[Id](

--- a/modules/doobie/src/main/scala/doobiemapping.scala
+++ b/modules/doobie/src/main/scala/doobiemapping.scala
@@ -372,7 +372,7 @@ object DoobieMapping {
     }
   }
 
-  class StagingElaborator(mapping: DoobieMapping) extends Phase {
+  class StagingElaborator(mapping: DoobieMapping) extends Elaborator {
     val stagingJoin = (c: Cursor, q: Query) => q match {
       case Select(fieldName, _, _) =>
         val obj = c.tpe.underlyingObject

--- a/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldData.scala
@@ -162,7 +162,7 @@ object ComposedQueryCompiler extends QueryCompiler(ComposedSchema) {
     Mapping(CountryType, "currencies", "CurrencyComponent", countryCurrencyJoin)
   )
 
-  val phases = List(componentElaborator, selectElaborator)
+  val elaborator = componentElaborator andThen selectElaborator
 }
 
 object ComposedQueryInterpreter {

--- a/modules/doobie/src/test/scala/world/WorldData.scala
+++ b/modules/doobie/src/test/scala/world/WorldData.scala
@@ -147,7 +147,7 @@ object WorldQueryCompiler extends QueryCompiler(WorldSchema) {
 
   val stagingElaborator = new StagingElaborator(WorldData)
 
-  val phases = List(selectElaborator, stagingElaborator)
+  val elaborator = selectElaborator andThen stagingElaborator
 }
 
 object WorldQueryInterpreter {


### PR DESCRIPTION
This occurred to me but I don't know if it's sensible or not. `QueryCompiler` is also a monoid with "or else" composition but I'm not sure it's useful because you need to know which interpreter to pass the result to.