### PR TITLE
Add support for field aliases and multiple root fields

### DIFF
--- a/modules/core/src/main/scala/datatype.scala
+++ b/modules/core/src/main/scala/datatype.scala
@@ -7,7 +7,7 @@ import cats.Monad
 import cats.implicits._
 import io.circe.Json
 
-import Query.{ Select, Wrap }
+import Query.{ PossiblyRenamedSelect, Select, Wrap }
 import QueryInterpreter.{ mkErrorResult, ProtoJson }
 import ScalarType._
 
@@ -44,11 +44,11 @@ class DataTypeQueryInterpreter[F[_]: Monad](
 
   def runRootValue(query: Query, rootTpe: Type): F[Result[ProtoJson]] =
     query match {
-      case Select(fieldName, _, child) =>
+      case PossiblyRenamedSelect(Select(fieldName, _, child), resultName) =>
         if (root.isDefinedAt(fieldName)) {
           val (tpe, focus) = root(fieldName)
           val cursor = DataTypeCursor(tpe, focus, fields, attrs, narrows)
-          runValue(Wrap(fieldName, child), rootTpe.field(fieldName), cursor).pure[F]
+          runValue(Wrap(resultName, child), rootTpe.field(fieldName), cursor).pure[F]
         } else
           mkErrorResult(s"No root field '$fieldName'").pure[F]
       case _ =>

--- a/modules/core/src/test/scala/compiler/CompilerSpec.scala
+++ b/modules/core/src/test/scala/compiler/CompilerSpec.scala
@@ -87,6 +87,32 @@ final class CompilerSuite extends CatsSuite {
     assert(res == Ior.Right(expected))
   }
 
+  test("field alias") {
+    val text = """
+      {
+        user(id: 4) {
+          id
+          name
+          smallPic: profilePic(size: 64)
+          bigPic: profilePic(size: 1024)
+        }
+      }
+    """
+
+    val expected =
+      Select("user", List(IntBinding("id", 4)),
+        Group(List(
+          Select("id", Nil, Empty),
+          Select("name", Nil, Empty),
+          Rename("smallPic", Select("profilePic", List(IntBinding("size", 64)), Empty)),
+          Rename("bigPic", Select("profilePic", List(IntBinding("size", 1024)), Empty))
+        ))
+      )
+
+    val res = QueryParser.parseText(text)
+    assert(res == Ior.Right(expected))
+  }
+
   test("introspection query") {
     val text = """
       query IntrospectionQuery {

--- a/modules/core/src/test/scala/composed/ComposedData.scala
+++ b/modules/core/src/test/scala/composed/ComposedData.scala
@@ -31,7 +31,7 @@ import CurrencyData.{ Currency, CurrencyType, currencies }
 
 object CurrencyQueryInterpreter extends DataTypeQueryInterpreter[Id](
   {
-    case "currency" => (ListType(CurrencyType), currencies)
+    case "fx" => (ListType(CurrencyType), currencies)
   },
   {
     case (c: Currency, "code")         => c.code
@@ -44,8 +44,8 @@ object CurrencyQueryCompiler extends QueryCompiler(CurrencySchema) {
 
   val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
-      case Select("currency", List(StringBinding("code", code)), child) =>
-        Select("currency", Nil, Unique(FieldEquals("code", code), child)).rightIor
+      case Select("fx", List(StringBinding("code", code)), child) =>
+        Select("fx", Nil, Unique(FieldEquals("code", code), child)).rightIor
     }
   ))
 
@@ -107,8 +107,8 @@ object ComposedQueryCompiler extends QueryCompiler(ComposedSchema) {
 
   val selectElaborator =  new SelectElaborator(Map(
     QueryType -> {
-      case Select("currency", List(StringBinding("code", code)), child) =>
-        Select("currency", Nil, Unique(FieldEquals("code", code), child)).rightIor
+      case Select("fx", List(StringBinding("code", code)), child) =>
+        Select("fx", Nil, Unique(FieldEquals("code", code), child)).rightIor
       case Select("country", List(StringBinding("code", code)), child) =>
         Select("country", Nil, Unique(FieldEquals("code", code), child)).rightIor
       case Select("countries", _, child) =>
@@ -119,7 +119,7 @@ object ComposedQueryCompiler extends QueryCompiler(ComposedSchema) {
   val countryCurrencyJoin = (c: Cursor, q: Query) =>
     (c.focus, q) match {
       case (c: Country, Select("currency", _, child)) =>
-        Select("currency", Nil, Unique(FieldEquals("code", c.currencyCode), child)).rightIor
+        Select("fx", Nil, Unique(FieldEquals("code", c.currencyCode), child)).rightIor
       case _ =>
         mkErrorResult(s"Unexpected cursor focus type in countryCurrencyJoin")
     }
@@ -127,6 +127,7 @@ object ComposedQueryCompiler extends QueryCompiler(ComposedSchema) {
   val componentElaborator = ComponentElaborator(
     Mapping(QueryType, "country", "CountryComponent"),
     Mapping(QueryType, "countries", "CountryComponent"),
+    Mapping(QueryType, "fx", "CurrencyComponent"),
     Mapping(CountryType, "currency", "CurrencyComponent", countryCurrencyJoin)
   )
 

--- a/modules/core/src/test/scala/composed/ComposedSchema.scala
+++ b/modules/core/src/test/scala/composed/ComposedSchema.scala
@@ -16,7 +16,7 @@ object ComposedSchema extends Schema {
       description = None,
       fields = List(
         Field("country", None, List(CodeArg), NullableType(TypeRef("Country")), false, None),
-        Field("currency", None, List(CodeArg), NullableType(TypeRef("Currency")), false, None),
+        Field("fx", None, List(CodeArg), NullableType(TypeRef("Currency")), false, None),
         Field("countries", None, Nil, ListType(TypeRef("Country")), false, None)
       ),
       interfaces = Nil
@@ -84,7 +84,7 @@ object CurrencySchema extends Schema {
       name = "Query",
       description = None,
       fields = List(
-        Field("currency", None, List(CodeArg), NullableType(TypeRef("Currency")), false, None)
+        Field("fx", None, List(CodeArg), NullableType(TypeRef("Currency")), false, None)
       ),
       interfaces = Nil
     ),

--- a/modules/core/src/test/scala/parser/ParserSpec.scala
+++ b/modules/core/src/test/scala/parser/ParserSpec.scala
@@ -122,4 +122,66 @@ final class ParserSuite extends CatsSuite {
       case Some(List(Left(q))) => assert(q == expected)
     }
   }
+
+  test("field alias") {
+    val text = """
+      {
+        user(id: 4) {
+          id
+          name
+          smallPic: profilePic(size: 64)
+          bigPic: profilePic(size: 1024)
+        }
+      }
+    """
+
+    val expected =
+      QueryShorthand(
+        List(
+          Field(None, Name("user"), List((Name("id"), IntValue(4))), Nil,
+            List(
+              Field(None, Name("id"), Nil, Nil, Nil),
+              Field(None, Name("name"), Nil, Nil, Nil),
+              Field(Some(Name("smallPic")), Name("profilePic"), List((Name("size"), IntValue(64))), Nil, Nil),
+              Field(Some(Name("bigPic")), Name("profilePic"), List((Name("size"), IntValue(1024))), Nil, Nil)
+            )
+          )
+        )
+      )
+
+    Parser.Document.parseOnly(text).option match {
+      case Some(List(Left(q))) => assert(q == expected)
+    }
+  }
+
+  test("multiple root fields") {
+    val text = """
+      {
+        luke: character(id: "1000") {
+          name
+        }
+        darth: character(id: "1001") {
+          name
+        }
+      }
+    """
+
+    val expected =
+      QueryShorthand(
+        List(
+          Field(Some(Name("luke")), Name("character"), List((Name("id"), StringValue("1000"))), Nil,
+            List(
+              Field(None, Name("name"), Nil, Nil, Nil))),
+          Field(Some(Name("darth")), Name("character"), List((Name("id"), StringValue("1001"))), Nil,
+            List(
+              Field(None, Name("name"), Nil, Nil, Nil)
+            )
+          )
+        )
+      )
+
+    Parser.Document.parseOnly(text).option match {
+      case Some(List(Left(q))) => assert(q == expected)
+    }
+  }
 }

--- a/modules/core/src/test/scala/starwars/StarWarsSpec.scala
+++ b/modules/core/src/test/scala/starwars/StarWarsSpec.scala
@@ -199,4 +199,61 @@ final class StarWarsSpec extends CatsSuite {
 
     assert(res == expected)
   }
+
+  test("field alias") {
+    val query = """
+      query {
+        luke: character(id: "1000") {
+          handle: name
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "luke" : {
+            "handle" : "Luke Skywalker"
+          }
+        }
+      }
+    """
+
+    val compiledQuery = StarWarsQueryCompiler.compile(query).right.get
+    val res = StarWarsQueryInterpreter.run(compiledQuery, StarWarsSchema.queryType)
+
+    assert(res == expected)
+  }
+
+  test("multiple root queries") {
+    val query = """
+      query {
+        luke: character(id: "1000") {
+          name
+        }
+        darth: character(id: "1001") {
+          name
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "luke" : {
+            "name" : "Luke Skywalker"
+          },
+          "darth" : {
+            "name" : "Darth Vader"
+          }
+        }
+      }
+    """
+
+    val compiledQuery = StarWarsQueryCompiler.compile(query).right.get
+    val res = StarWarsQueryInterpreter.run(compiledQuery, StarWarsSchema.queryType)
+    //println(res)
+
+    assert(res == expected)
+  }
 }

--- a/modules/doobie/src/main/scala/doobiemapping.scala
+++ b/modules/doobie/src/main/scala/doobiemapping.scala
@@ -131,6 +131,8 @@ trait DoobieMapping {
           loop(child, obj, (cols ++ acc._1, joins ++ acc._2, preds ++ acc._3, omts ++ acc._4))
         case Wrap(_, q) =>
           loop(q, obj, acc)
+        case Rename(_, q) =>
+          loop(q, obj, acc)
         case Group(queries) =>
           queries.foldLeft(acc) {
             case (acc, sibling) => loop(sibling, obj, acc)
@@ -401,6 +403,7 @@ object DoobieMapping {
 
           case n@Narrow(subtpe, child) => loop(child, subtpe, filtered).map(ec => n.copy(child = ec))
           case w@Wrap(_, child)        => loop(child, tpe, filtered).map(ec => w.copy(child = ec))
+          case r@Rename(_, child)      => loop(child, tpe, filtered).map(ec => r.copy(child = ec))
           case g@Group(queries)        => queries.traverse(q => loop(q, tpe, filtered)).map(eqs => g.copy(queries = eqs))
           case u@Unique(_, child)      => loop(child, tpe.nonNull, filtered + tpe.underlyingObject).map(ec => u.copy(child = ec))
           case f@Filter(_, child)      => loop(child, tpe.item, filtered + tpe.underlyingObject).map(ec => f.copy(child = ec))


### PR DESCRIPTION
It is now possible for a query to contain more than one root field as described in the spec discussion linked to in #13. Where the root queries differ only in their arguments they must be renamed using
field aliases (described in section 2.7 of the spec) to ensure that their result fields don't conflict.

Adding the support for renaming revealed a bug in the schema/interpreter composition mechanism which is now fixed.

Adding support for multiple root nodes revealed a bug in the handling of `Unique` queries where the expected type is nullable. Prior to this commit, if there was no unique match the query would fail incorrectly rather than returning a null value. This is now also fixed.

Fixes #12 and #13.