### PR TITLE
Filled out input values support

### DIFF
--- a/modules/core/src/main/scala/introspection.scala
+++ b/modules/core/src/main/scala/introspection.scala
@@ -128,7 +128,7 @@ object SchemaSchema extends Schema {
   import ScalarType._
 
   val NameArg = InputValue("name", None, StringType, None)
-  val IncludeDeprecatedArg = InputValue("includeDeprecated", None, BooleanType, Some(false))
+  val IncludeDeprecatedArg = InputValue("includeDeprecated", None, BooleanType, Some(BooleanValue(false)))
 
   val types = List(
     ObjectType(

--- a/modules/core/src/main/scala/parser.scala
+++ b/modules/core/src/main/scala/parser.scala
@@ -80,7 +80,7 @@ object Parser {
 
   lazy val FragmentDefinition =
     for {
-      _    <- string("fragment").token
+      _    <- keyword("fragment")
       name <- FragmentName
       cond <- TypeCondition
       dirs <- Directives
@@ -116,7 +116,7 @@ object Parser {
     } .map(Ast.Value.EnumValue)
 
   lazy val ListValue: Parser[Ast.Value.ListValue] =
-    squareBrackets(many(Value)).map(Ast.Value.ListValue).token
+    squareBrackets(many(Value <~ opt(keyword(",")))).map(Ast.Value.ListValue).token
 
   lazy val IntValue: Parser[Ast.Value.IntValue] =
     bigDecimal.token.filter(_.isValidInt).map(a => Ast.Value.IntValue(a.toInt))
@@ -131,7 +131,7 @@ object Parser {
     (keyword("true").as(true) | keyword("false").as(false)).map(Ast.Value.BooleanValue)
 
   lazy val ObjectValue: Parser[Ast.Value.ObjectValue] =
-    braces(many(ObjectField)).map(Ast.Value.ObjectValue).token
+    braces(many(ObjectField <~ opt(keyword(",")))).map(Ast.Value.ObjectValue).token
 
   lazy val ObjectField: Parser[(Ast.Name, Ast.Value)] =
     (Name <~ keyword(":")) ~ Value

--- a/modules/core/src/test/scala/compiler/InputValuesSpec.scala
+++ b/modules/core/src/test/scala/compiler/InputValuesSpec.scala
@@ -1,0 +1,145 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package compiler
+
+import cats.data.Ior
+import cats.tests.CatsSuite
+
+import edu.gemini.grackle._
+import Query._, Value._
+import QueryCompiler._
+
+final class InputValuesSuite extends CatsSuite {
+  test("null value") {
+    val text = """
+      query {
+        field {
+          subfield
+        }
+        field(arg: null) {
+          subfield
+        }
+        field(arg: 23) {
+          subfield
+        }
+      }
+    """
+
+    val expected =
+      Group(List(
+        Select("field", List(Binding("arg", AbsentValue)), Select("subfield", Nil, Empty)),
+        Select("field", List(Binding("arg", NullValue)), Select("subfield", Nil, Empty)),
+        Select("field", List(Binding("arg", IntValue(23))), Select("subfield", Nil, Empty))
+      ))
+
+    val compiled = InputValuesCompiler.compile(text, None)
+    //println(compiled)
+    assert(compiled == Ior.Right(expected))
+  }
+
+  test("list value") {
+    val text = """
+      query {
+        listField(arg: []) {
+          subfield
+        }
+        listField(arg: ["foo", "bar"]) {
+          subfield
+        }
+      }
+    """
+
+    val expected =
+      Group(List(
+        Select("listField", List(Binding("arg", ListValue(Nil))),
+          Select("subfield", Nil, Empty)
+        ),
+        Select("listField", List(Binding("arg", ListValue(List(StringValue("foo"),  StringValue("bar"))))),
+          Select("subfield", Nil, Empty)
+        )
+      ))
+
+    val compiled = InputValuesCompiler.compile(text, None)
+    //println(compiled)
+    assert(compiled == Ior.Right(expected))
+  }
+
+  test("input object value") {
+    val text = """
+      query {
+        objectField(arg: { foo: 23, bar: true, baz: "quux" }) {
+          subfield
+        }
+      }
+    """
+
+    val expected =
+      Select("objectField",
+        List(Binding("arg",
+          ObjectValue(List(
+            ("foo", IntValue(23)),
+            ("bar", BooleanValue(true)),
+            ("baz", StringValue("quux")),
+            ("defaulted", StringValue("quux")),
+            ("nullable", AbsentValue)
+          ))
+        )),
+        Select("subfield", Nil, Empty)
+      )
+
+    val compiled = InputValuesCompiler.compile(text, None)
+    //println(compiled)
+    assert(compiled == Ior.Right(expected))
+  }
+}
+
+object InputValuesSchema extends Schema {
+  import ScalarType._
+
+  val ArgArg = InputValue("arg", None, NullableType(IntType), None)
+  val ListArgArg = InputValue("arg", None, ListType(StringType), None)
+  val ObjectArgArg = InputValue("arg", None, TypeRef("InObj"), None)
+
+  val types = List(
+    ObjectType(
+      name = "Query",
+      description = None,
+      fields = List(
+        Field("field", None, List(ArgArg), TypeRef("Result"), false, None),
+        Field("listField", None, List(ListArgArg), TypeRef("Result"), false, None),
+        Field("objectField", None, List(ObjectArgArg), TypeRef("Result"), false, None),
+      ),
+      interfaces = Nil
+    ),
+    ObjectType(
+      name = "Result",
+      description = None,
+      fields = List(
+        Field("subfield", None, Nil, StringType, false, None),
+      ),
+      interfaces = Nil
+    ),
+    InputObjectType(
+      name = "InObj",
+      description = None,
+      inputFields = List(
+        InputValue("foo", None, IntType, None),
+        InputValue("bar", None, BooleanType, None),
+        InputValue("baz", None, StringType, None),
+        InputValue("defaulted", None, StringType, Some(StringValue("quux"))),
+        InputValue("nullable", None, NullableType(StringType), None)
+      )
+    )
+  )
+
+  val directives = Nil
+}
+
+object InputValuesCompiler extends QueryCompiler(InputValuesSchema) {
+  val selectElaborator = new SelectElaborator(Map(
+    InputValuesSchema.tpe("Query").dealias -> PartialFunction.empty
+  ))
+
+  val phases = List(selectElaborator)
+}

--- a/modules/core/src/test/scala/compiler/VariablesSpec.scala
+++ b/modules/core/src/test/scala/compiler/VariablesSpec.scala
@@ -42,13 +42,81 @@ final class VariablesSuite extends CatsSuite {
     //println(compiled)
     assert(compiled == Ior.Right(expected))
   }
+
+  test("list variable query") {
+    val text = """
+      query getProfile($ids: [ID!]) {
+        users(ids: $ids) {
+          name
+        }
+      }
+    """
+
+    val variables = json"""
+      {
+        "ids": [1, 2, 3]
+      }
+    """
+
+    val expected =
+      Select("users",
+        List(Binding("ids", ListValue(List(IDValue("1"), IDValue("2"), IDValue("3"))))),
+        Select("name", Nil, Empty)
+      )
+
+    val compiled = VariablesCompiler.compile(text, Some(variables))
+    //println(compiled)
+    assert(compiled == Ior.Right(expected))
+  }
+
+  test("object variable query") {
+    val text = """
+      query doSearch($pattern: Pattern) {
+        search(pattern: $pattern) {
+          name
+          id
+        }
+      }
+    """
+
+    val variables = json"""
+      {
+        "pattern": {
+          "name": "Foo",
+          "age": 23,
+          "id": 123
+        }
+      }
+    """
+
+    val expected =
+      Select("search",
+        List(Binding("pattern",
+          ObjectValue(List(
+            ("name", StringValue("Foo")),
+            ("age", IntValue(23)),
+            ("id", IDValue("123"))
+          ))
+        )),
+        Group(List(
+          Select("name", Nil, Empty),
+          Select("id", Nil, Empty)
+        ))
+      )
+
+    val compiled = VariablesCompiler.compile(text, Some(variables))
+    //println(compiled)
+    assert(compiled == Ior.Right(expected))
+  }
 }
 
 object VariablesSchema extends Schema {
   import ScalarType._
 
   val IdArg = InputValue("id", None, IDType, None)
+  val IdsArg = InputValue("ids", None, ListType(IDType), None)
   val SizeArg = InputValue("size", None, NullableType(IntType), None)
+  val PatternArg = InputValue("pattern", None, TypeRef("Pattern"), None)
 
   val types = List(
     ObjectType(
@@ -56,6 +124,8 @@ object VariablesSchema extends Schema {
       description = None,
       fields = List(
         Field("user", None, List(IdArg), TypeRef("User"), false, None),
+        Field("users", None, List(IdsArg), ListType(TypeRef("User")), false, None),
+        Field("search", None, List(PatternArg), ListType(TypeRef("User")), false, None),
       ),
       interfaces = Nil
     ),
@@ -68,6 +138,15 @@ object VariablesSchema extends Schema {
         Field("profilePic", None, List(SizeArg), StringType, false, None),
       ),
       interfaces = Nil
+    ),
+    InputObjectType(
+      name = "Pattern",
+      description = None,
+      inputFields = List(
+        InputValue("name", None, NullableType(StringType), None),
+        InputValue("age", None, NullableType(IntType), None),
+        InputValue("id", None, NullableType(IDType), None),
+      )
     )
   )
 

--- a/modules/doobie/src/test/scala/composed/ComposedWorldSchema.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldSchema.scala
@@ -3,12 +3,12 @@
 
 package composed
 
-import edu.gemini.grackle._
+import edu.gemini.grackle._, Value._
 
 object ComposedSchema extends Schema {
   import ScalarType._
 
-  val NamePatternArg = InputValue("namePattern", None, NullableType(StringType), Some("%"))
+  val NamePatternArg = InputValue("namePattern", None, NullableType(StringType), Some(StringValue("%")))
   val CodeArg = InputValue("code", None, NullableType(StringType), None)
 
   val types = List(
@@ -87,7 +87,7 @@ object ComposedSchema extends Schema {
 object WorldSchema extends Schema {
   import ScalarType._
 
-  val NamePatternArg = InputValue("namePattern", None, NullableType(StringType), Some("%"))
+  val NamePatternArg = InputValue("namePattern", None, NullableType(StringType), Some(StringValue("%")))
   val CodeArg = InputValue("code", None, NullableType(StringType), None)
 
   val types = List(

--- a/modules/doobie/src/test/scala/world/WorldSchema.scala
+++ b/modules/doobie/src/test/scala/world/WorldSchema.scala
@@ -3,12 +3,12 @@
 
 package world
 
-import edu.gemini.grackle._
+import edu.gemini.grackle._, Value._
 
 object WorldSchema extends Schema {
   import ScalarType._
 
-  val NamePatternArg = InputValue("namePattern", None, NullableType(StringType), Some("%"))
+  val NamePatternArg = InputValue("namePattern", None, NullableType(StringType), Some(StringValue("%")))
   val CodeArg = InputValue("code", None, NullableType(StringType), None)
   val LanguageArg = InputValue("language", None, NullableType(StringType), None)
 


### PR DESCRIPTION
* Added null, absent, list and object input values.
* Field arguments and variables support all input value types.
* Moved `InputValue` into schema in preparation for schema (de)serialization.
* Added parser support for optional commas between list elements and object fields.

Fixes #11, #14, #15, #16 and #17.