### PR TITLE
Fully integrate introspection

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,7 @@ lazy val core = project
       "io.circe"          %% "circe-core"             % circeVersion,
       "io.circe"          %% "circe-literal"          % circeVersion,
       "io.circe"          %% "circe-optics"           % circeOpticsVersion,
+      "io.circe"          %% "circe-parser"           % circeVersion,
       "org.typelevel"     %% "jawn-parser"            % jawnVersion,
     )
   )

--- a/modules/core/src/test/scala/composed/ComposedSpec.scala
+++ b/modules/core/src/test/scala/composed/ComposedSpec.scala
@@ -222,4 +222,42 @@ final class ComposedSpec extends CatsSuite {
 
     assert(res == expected)
   }
+
+  test("composed query with introspection") {
+    val query = """
+      query {
+        country(code: "GBR") {
+          __typename
+          name
+          currency {
+            __typename
+            code
+            exchangeRate
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "country" : {
+            "__typename" : "Country",
+            "name" : "United Kingdom",
+            "currency" : {
+              "__typename" : "Currency",
+              "code" : "GBP",
+              "exchangeRate" : 1.25
+            }
+          }
+        }
+      }
+    """
+
+    val compiledQuery = ComposedQueryCompiler.compile(query).right.get
+    val res = ComposedQueryInterpreter.run(compiledQuery, ComposedSchema.queryType)
+    //println(res)
+
+    assert(res == expected)
+  }
 }

--- a/modules/doobie/src/main/scala/doobiemapping.scala
+++ b/modules/doobie/src/main/scala/doobiemapping.scala
@@ -137,7 +137,7 @@ trait DoobieMapping {
           queries.foldLeft(acc) {
             case (acc, sibling) => loop(sibling, obj, acc)
           }
-        case Empty | (_: Component) | (_: Defer) | (_: UntypedNarrow) => acc
+        case Empty | (_: Component) | (_: Introspection) | (_: Defer) | (_: UntypedNarrow) => acc
       }
     }
 
@@ -409,6 +409,7 @@ object DoobieMapping {
           case u@Unique(_, child)      => loop(child, tpe.nonNull, filtered + tpe.underlyingObject).map(ec => u.copy(child = ec))
           case f@Filter(_, child)      => loop(child, tpe.item, filtered + tpe.underlyingObject).map(ec => f.copy(child = ec))
           case c: Component            => c.rightIor
+          case i: Introspection        => i.rightIor
           case d: Defer                => d.rightIor
           case Empty                   => Empty.rightIor
 

--- a/modules/doobie/src/test/scala/composed/ComposedWorldSpec.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldSpec.scala
@@ -115,4 +115,44 @@ final class ComposedWorldSpec extends CatsSuite {
 
     assert(res == expected)
   }
+
+  test("composed query with introspection") {
+    val query = """
+      query {
+        country(code: "GBR") {
+          __typename
+          name
+          currencies {
+            __typename
+            code
+            exchangeRate
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "country" : {
+            "__typename" : "Country",
+            "name" : "United Kingdom",
+            "currencies" : [
+              {
+                "__typename" : "Currency",
+                "code" : "GBP",
+                "exchangeRate" : 1.25
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val compiledQuery = ComposedQueryCompiler.compile(query).right.get
+    val res = ComposedQueryInterpreter.fromTransactor(xa).run(compiledQuery, ComposedSchema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
 }

--- a/modules/doobie/src/test/scala/world/WorldSpec.scala
+++ b/modules/doobie/src/test/scala/world/WorldSpec.scala
@@ -767,4 +767,32 @@ final class WorldSpec extends CatsSuite {
 
     assert(res == expected)
   }
+
+  test("query with introspection") {
+    val query = """
+      query {
+        country(code: "GBR") {
+          __typename
+          name
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "country" : {
+            "__typename" : "Country",
+            "name" : "United Kingdom"
+          }
+        }
+      }
+    """
+
+    val compiledQuery = WorldQueryCompiler.compile(query).right.get
+    val res = WorldQueryInterpreter.fromTransactor(xa).run(compiledQuery, WorldSchema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
 }


### PR DESCRIPTION
* Introspection queries are now supported by all interpreters and standalone introspection interpreter has been dropped.
* Added support for `__typename`.
* Fixed union type issues revealed in interactions with introspection.
* Adapted the demo service interface for integrated introspection and brought GET query handling up to par with POST.

Fixes #34.