### PR TITLE
Added simple shapeless-based derivation for ADT backed models

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val generic = project
 lazy val demo = project
   .in(file("demo"))
   .enablePlugins(AutomateHeaderPlugin)
-  .dependsOn(core, doobie)
+  .dependsOn(core, doobie, generic)
   .settings(commonSettings)
   .settings(
     name := "gsp-graphql-demo",

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ val jawnVersion                 = "0.14.3"
 val kindProjectorVersion        = "0.10.3"
 val logbackVersion              = "1.2.3"
 val log4catsVersion             = "1.0.1"
+val shapelessVersion            = "2.3.3"
 val slf4jVersion                = "1.7.29"
 
 inThisBuild(Seq(
@@ -19,7 +20,7 @@ inThisBuild(Seq(
 ) ++ gspPublishSettings)
 
 lazy val commonSettings = Seq(
-  //scalacOptions --= Seq("-Wunused:params", "-Wunused:imports", "-Wunused:patvars", "-Wdead-code", "-Wunused:locals", "-Wunused:privates"),
+  //scalacOptions --= Seq("-Wunused:params", "-Wunused:imports", "-Wunused:patvars", "-Wdead-code", "-Wunused:locals", "-Wunused:privates", "-Wunused:implicits"),
   libraryDependencies ++= Seq(
     "org.typelevel"     %% "cats-testkit"           % catsVersion % "test",
     "org.typelevel"     %% "cats-testkit-scalatest" % catsTestkitScalaTestVersion % "test"
@@ -33,6 +34,7 @@ lazy val noPublishSettings = Seq(
 lazy val modules: List[ProjectReference] = List(
   core,
   doobie,
+  generic,
   demo
 )
 
@@ -78,6 +80,26 @@ lazy val doobie = project
 
       "org.tpolecat"      %% "doobie-postgres"        % doobieVersion % "test",
       "org.slf4j"         %  "slf4j-simple"           % slf4jVersion % "test"
+    )
+  )
+
+lazy val generic = project
+  .in(file("modules/generic"))
+  .enablePlugins(AutomateHeaderPlugin)
+  .disablePlugins(RevolverPlugin)
+  .dependsOn(core)
+  .settings(commonSettings)
+  .settings(
+    name := "gsp-graphql-generic",
+    libraryDependencies ++= Seq(
+      "org.tpolecat"      %% "atto-core"              % attoVersion,
+      "org.typelevel"     %% "cats-core"              % catsVersion,
+      "io.circe"          %% "circe-core"             % circeVersion,
+      "io.circe"          %% "circe-literal"          % circeVersion,
+      "io.circe"          %% "circe-optics"           % circeOpticsVersion,
+      "io.circe"          %% "circe-parser"           % circeVersion,
+      "org.typelevel"     %% "jawn-parser"            % jawnVersion,
+      "com.chuusai"       %% "shapeless"              % shapelessVersion,
     )
   )
 

--- a/modules/core/src/main/scala/datatype.scala
+++ b/modules/core/src/main/scala/datatype.scala
@@ -8,7 +8,7 @@ import cats.implicits._
 import io.circe.Json
 
 import Query.{ PossiblyRenamedSelect, Select, Wrap }
-import QueryInterpreter.{ mkErrorResult, ProtoJson }
+import QueryInterpreter.{ mkOneError, mkErrorResult, ProtoJson }
 import ScalarType._
 
 /**
@@ -74,10 +74,9 @@ case class DataTypeCursor(
   def asLeaf: Result[Json] = (tpe.dealias, focus) match {
     case (StringType,  s: String)  => Json.fromString(s).rightIor
     case (IntType,     i: Int)     => Json.fromInt(i).rightIor
-    case (FloatType,   d: Double)  => Json.fromDouble(d) match {
-        case Some(j) => j.rightIor
-        case None => mkErrorResult(s"Unrepresentable double %d")
-      }
+    case (IntType,     l: Long)    => Json.fromLong(l).rightIor
+    case (FloatType,   f: Float)   => Json.fromFloat(f).toRightIor(mkOneError(s"Unrepresentable float %d"))
+    case (FloatType,   d: Double)  => Json.fromDouble(d).toRightIor(mkOneError(s"Unrepresentable double %d"))
     case (BooleanType, b: Boolean) => Json.fromBoolean(b).rightIor
     case (_: EnumType, e: Enumeration#Value) => Json.fromString(e.toString).rightIor
     case _ => mkErrorResult(s"Expected Scalar type, found $tpe for focus ${focus}")

--- a/modules/generic/src/main/scala/derivation.scala
+++ b/modules/generic/src/main/scala/derivation.scala
@@ -1,0 +1,158 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle
+package generic
+
+import scala.annotation.tailrec
+
+import cats.Monad
+import cats.implicits._
+import io.circe.{ Encoder, Json }
+import shapeless.{ Coproduct, Generic, ::, HList, HNil, Inl, Inr, LabelledGeneric, Typeable }
+import shapeless.ops.hlist.{ LiftAll => PLiftAll }
+import shapeless.ops.coproduct.{ LiftAll => CLiftAll }
+import shapeless.ops.record.Keys
+
+import Query.{ PossiblyRenamedSelect, Select, Wrap }
+import QueryInterpreter.{ mkErrorResult, mkOneError, ProtoJson }
+import ShapelessUtils._
+
+object semiauto {
+  final def deriveObjectCursorBuilder[T](implicit builder: => DerivedObjectCursorBuilder[T]): DerivedObjectCursorBuilder[T] = builder
+  final def deriveLeafCursorBuilder[T](implicit builder: DerivedLeafCursorBuilder[T]): DerivedLeafCursorBuilder[T] = builder
+  final def deriveInterfaceCursorBuilder[T](implicit builder: DerivedInterfaceCursorBuilder[T]): DerivedInterfaceCursorBuilder[T] = builder
+}
+
+trait ObjectCursorBuilder[T] extends CursorBuilder[T] {
+  def ref(nme: String): CursorBuilder[T]
+  def renamedField(from: String, to: String): CursorBuilder[T]
+  def transformFieldNames(f: String => String): CursorBuilder[T]
+  def transformField[U](fieldName: String)(f: T => Result[U])(implicit cb: CursorBuilder[U]): CursorBuilder[T]
+}
+
+trait DerivedLeafCursorBuilder[T] extends CursorBuilder[T]
+
+object DerivedLeafCursorBuilder {
+  def apply[T](implicit cb: DerivedLeafCursorBuilder[T]): DerivedLeafCursorBuilder[T] = cb
+
+  class LeafCursor[T](val focus: T, val tpe: Type, encoder: Encoder[T]) extends AbstractCursor[T] {
+    override def isLeaf: Boolean = true
+    override def asLeaf: Result[Json] = encoder(focus).rightIor
+  }
+
+  implicit def leafCursorBuilder[T](implicit encoder: Encoder[T]): DerivedLeafCursorBuilder[T] =
+    new DerivedLeafCursorBuilder[T] {
+      def build(focus: T, tpe: Type): Result[Cursor] = new LeafCursor(focus, tpe, encoder).rightIor
+    }
+}
+
+trait DerivedObjectCursorBuilder[T] extends ObjectCursorBuilder[T]
+
+object DerivedObjectCursorBuilder {
+  def apply[T](implicit cb: DerivedObjectCursorBuilder[T]): DerivedObjectCursorBuilder[T] = cb
+
+  implicit def productCursorBuilder[T <: Product, R <: HList, L <: HList]
+    (implicit
+      gen: Generic.Aux[T, R],
+      elems0: => PLiftAll[CursorBuilder, R],
+      lgen: LabelledGeneric.Aux[T, L],
+      keys0: Keys[L],
+      tp: Typeable[T]
+    ): DerivedObjectCursorBuilder[T] = {
+      identity(gen)  // unused implicit warning without these
+      identity(lgen) // remove when @nowarn lands in 2.13.2
+
+      def fieldMap = {
+        val keys: List[String] = unsafeToList[Symbol](keys0()).map(_.name)
+        val elems = unsafeToList[CursorBuilder[Any]](elems0.instances)
+        keys.zip(elems.zipWithIndex).map {
+          case (fieldName, (elem, idx)) =>
+            (fieldName, (t: T, tpe: Type) => elem.build(t.productElement(idx), tpe.field(fieldName)))
+        }.toMap
+      }
+      new Impl[T](tp.describe, fieldMap)
+    }
+
+  class Impl[T](nme: String, fieldMap0: => Map[String, (T, Type) => Result[Cursor]]) extends DerivedObjectCursorBuilder[T] {
+    lazy val fieldMap = fieldMap0
+
+    def build(focus: T, tpe: Type): Result[Cursor] =
+      CursorImpl(nme, fieldMap, focus, tpe).rightIor
+
+    def ref(nme0: String): CursorBuilder[T] =
+      new Impl(nme0, fieldMap0)
+    def renamedField(from: String, to: String): CursorBuilder[T] =
+      transformFieldNames { case `from` => to ; case other => other }
+    def transformFieldNames(f: String => String): CursorBuilder[T] =
+      new Impl(nme, fieldMap0.map { case (k, v) => (f(k), v) })
+    def transformField[U](fieldName: String)(f: T => Result[U])(implicit cb: CursorBuilder[U]): CursorBuilder[T] =
+      new Impl(nme, fieldMap0.updated(fieldName, (focus: T, tpe: Type) => f(focus).flatMap(f => cb.build(f, tpe))))
+  }
+
+  case class CursorImpl[T](nme: String, fieldMap: Map[String, (T, Type) => Result[Cursor]], focus: T, tpe: Type)
+    extends AbstractCursor[T] {
+    override def hasField(fieldName: String): Boolean = fieldMap.contains(fieldName)
+
+    override def field(fieldName: String): Result[Cursor] = {
+      fieldMap.get(fieldName).toRightIor(mkOneError(s"No field '$fieldName' for type $tpe")).flatMap(f => f(focus, tpe.field(fieldName)))
+    }
+
+    override def narrowsTo(subtpe: TypeRef): Boolean =
+      subtpe <:< tpe && subtpe.name == nme
+
+    override def narrow(subtpe: TypeRef): Result[Cursor] =
+      if (narrowsTo(subtpe)) copy(tpe = subtpe).rightIor
+      else mkErrorResult(s"Focus ${focus} of static type $tpe cannot be narrowed to $subtpe")
+  }
+}
+
+trait DerivedInterfaceCursorBuilder[T] extends CursorBuilder[T]
+
+object DerivedInterfaceCursorBuilder {
+  implicit def coproductCursorBuilder[T, R <: Coproduct]
+    (implicit
+      gen: Generic.Aux[T, R],
+      elems0: => CLiftAll[CursorBuilder, R]
+    ): DerivedInterfaceCursorBuilder[T] = {
+      def elems = unsafeToList[CursorBuilder[T]](elems0.instances).toArray
+      def sel(t: T) = {
+        @tailrec
+        def loop(c: Coproduct, acc: Int): Int = c match {
+          case Inl(_) => acc
+          case Inr(tl) => loop(tl, acc+1)
+        }
+        loop(gen.to(t), 0)
+      }
+      new Impl[T](sel, elems)
+    }
+
+  class Impl[T](sel: T => Int, elems: => Array[CursorBuilder[T]])  extends DerivedInterfaceCursorBuilder[T] {
+    def build(focus: T, tpe: Type): Result[Cursor] =
+      elems(sel(focus)).build(focus, tpe)
+  }
+}
+
+class GenericQueryInterpreter[F[_]: Monad](root: PartialFunction[String, Result[Cursor]]) extends QueryInterpreter[F] {
+  def runRootValue(query: Query, rootTpe: Type): F[Result[ProtoJson]] =
+    (query match {
+      case PossiblyRenamedSelect(Select(fieldName, _, child), resultName) =>
+        if (root.isDefinedAt(fieldName))
+          root(fieldName).flatMap(cursor => runValue(Wrap(resultName, child), rootTpe.field(fieldName), cursor))
+        else
+          mkErrorResult(s"No root field '$fieldName'")
+      case _ =>
+        mkErrorResult(s"Bad root query '${query.render}' in DataTypeQueryInterpreter")
+    }).pure[F]
+}
+
+object ShapelessUtils {
+  def unsafeToList[U](l: HList): List[U] = {
+    @tailrec
+    def loop(l: HList, acc: List[U]): List[U] = l match {
+      case HNil => acc.reverse
+      case hd :: tl => loop(tl, hd.asInstanceOf[U] :: acc)
+    }
+    loop(l, Nil)
+  }
+}

--- a/modules/generic/src/test/scala/derivation.scala
+++ b/modules/generic/src/test/scala/derivation.scala
@@ -1,0 +1,463 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle
+package generic
+
+import java.time._
+
+import cats.Id
+import cats.data.Ior
+import cats.implicits._
+import cats.tests.CatsSuite
+import io.circe.Json
+import io.circe.literal.JsonStringContext
+
+import Query._, Predicate._, Value._
+import QueryCompiler._
+import QueryInterpreter.{ mkErrorResult, mkOneError }
+import ScalarType._
+import semiauto._
+
+object StarWarsData {
+  val schema =
+    Schema(
+      """
+        type Query {
+           hero(episode: Episode!): Character!
+           character(id: ID!): Character
+           human(id: ID!): Human
+           droid(id: ID!): Droid
+         }
+         enum Episode {
+           NEWHOPE
+           EMPIRE
+           JEDI
+         }
+         interface Character {
+           id: String!
+           name: String
+           friends: [Character!]
+           appearsIn: [Episode!]
+         }
+         type Human implements Character {
+           id: String!
+           name: String
+           friends: [Character!]
+           appearsIn: [Episode!]
+           homePlanet: String
+         }
+         type Droid implements Character {
+           id: String!
+           name: String
+           friends: [Character!]
+           appearsIn: [Episode!]
+           primaryFunction: String
+         }
+      """
+    ).right.get
+
+  val QueryType = schema.ref("Query")
+  val CharacterType = schema.ref("Character")
+  val HumanType = schema.ref("Human")
+  val DroidType = schema.ref("Droid")
+
+  object Episode extends Enumeration {
+    val NEWHOPE, EMPIRE, JEDI = Value
+  }
+
+  sealed trait Character {
+    def id: String
+    def name: Option[String]
+    def appearsIn: Option[List[Episode.Value]]
+    def friends: Option[List[String]]
+  }
+
+  object Character {
+    implicit val cursorBuilder: CursorBuilder[Character] =
+      deriveInterfaceCursorBuilder[Character]
+  }
+
+  case class Human(
+    id: String,
+    name: Option[String],
+    appearsIn: Option[List[Episode.Value]],
+    friends: Option[List[String]],
+    homePlanet: Option[String]
+  ) extends Character
+
+  object Human {
+    implicit val cursorBuilder: CursorBuilder[Human] =
+      deriveObjectCursorBuilder[Human]
+        .transformField("friends")(_.friends match {
+          case None => None.rightIor
+          case Some(ids) =>
+            ids.traverse(id => characters.find(_.id == id).toRightIor(mkOneError(s"Bad id '$id'"))).map(_.some)
+        })
+  }
+
+  case class Droid(
+    id: String,
+    name: Option[String],
+    appearsIn: Option[List[Episode.Value]],
+    friends: Option[List[String]],
+    primaryFunction: Option[String]
+  ) extends Character
+
+  object Droid {
+    implicit val cursorBuilder: CursorBuilder[Droid] =
+      deriveObjectCursorBuilder[Droid]
+        .transformField("friends")(_.friends match {
+          case None => None.rightIor
+          case Some(ids) =>
+            ids.traverse(id => characters.find(_.id == id).toRightIor(mkOneError(s"Bad id '$id'"))).map(_.some)
+        })
+  }
+
+  val characters: List[Character] = List(
+    Human(
+      id = "1000",
+      name = Some("Luke Skywalker"),
+      friends = Some(List("1002", "1003", "2000", "2001")),
+      appearsIn = Some(List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI)),
+      homePlanet = Some("Tatooine")
+    ),
+    Human(
+      id = "1001",
+      name = Some("Darth Vader"),
+      friends = Some(List("1004")),
+      appearsIn = Some(List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI)),
+      homePlanet = Some("Tatooine")
+    ),
+    Human(
+      id = "1002",
+      name = Some("Han Solo"),
+      friends = Some(List("1000", "1003", "2001")),
+      appearsIn = Some(List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI)),
+      homePlanet = None
+    ),
+    Human(
+      id = "1003",
+      name = Some("Leia Organa"),
+      friends = Some(List("1000", "1002", "2000", "2001")),
+      appearsIn = Some(List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI)),
+      homePlanet = Some("Alderaan")
+    ),
+    Human(
+      id = "1004",
+      name = Some("Wilhuff Tarkin"),
+      friends = Some(List("1001")),
+      appearsIn = Some(List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI)),
+      homePlanet = None
+    ),
+    Droid(
+      id = "2000",
+      name = Some("C-3PO"),
+      friends = Some(List("1000", "1002", "1003", "2001")),
+      appearsIn = Some(List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI)),
+      primaryFunction = Some("Protocol")
+    ),
+    Droid(
+      id = "2001",
+      name = Some("R2-D2"),
+      friends = Some(List("1000", "1002", "1003")),
+      appearsIn = Some(List(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI)),
+      primaryFunction = Some("Astromech")
+    )
+  )
+
+  import Episode._
+
+  val Some(lukeSkywalker: Human) = characters.find(_.id == "1000")
+  val Some(r2d2: Droid) = characters.find(_.id == "2001")
+
+  // Mapping from Episode to its hero Character
+  lazy val hero: Map[Value, Character] = Map(
+    NEWHOPE -> r2d2,
+    EMPIRE -> lukeSkywalker,
+    JEDI -> r2d2
+  )
+}
+
+import StarWarsData._
+
+object StarWarsQueryCompiler extends QueryCompiler(schema) {
+  val selectElaborator = new SelectElaborator(Map(
+    QueryType -> {
+      case Select("hero", List(Binding("episode", TypedEnumValue(e))), child) =>
+        Episode.values.find(_.toString == e.name).map { episode =>
+          Select("hero", Nil, Unique(FieldEquals("id", hero(episode).id), child)).rightIor
+        }.getOrElse(mkErrorResult(s"Unknown episode '${e.name}'"))
+
+      case Select(f@("character" | "human" | "droid"), List(Binding("id", IDValue(id))), child) =>
+        Select(f, Nil, Unique(FieldEquals("id", id), child)).rightIor
+    }
+  ))
+
+  val phases = List(selectElaborator)
+}
+
+object StarWarsQueryInterpreter extends GenericQueryInterpreter[Id](
+  {
+    case "hero" | "character" =>
+      CursorBuilder[List[Character]].build(characters, ListType(CharacterType))
+    case "human" =>
+      CursorBuilder[List[Human]].build(characters.collect { case h: Human => h }, ListType(HumanType))
+    case "droid" =>
+      CursorBuilder[List[Droid]].build(characters.collect { case d: Droid => d }, ListType(DroidType))
+  },
+)
+
+final class DerivationSpec extends CatsSuite {
+  test("primitive types have leaf cursor builders") {
+    val i =
+      for {
+        c <- CursorBuilder[Int].build(23, IntType)
+        _  = assert(c.isLeaf)
+        l  <- c.asLeaf
+      } yield l
+    assert(i == Ior.Right(Json.fromInt(23)))
+
+    val s =
+      for {
+        c <- CursorBuilder[String].build("foo", StringType)
+        _  = assert(c.isLeaf)
+        l  <- c.asLeaf
+      } yield l
+    assert(s == Ior.Right(Json.fromString("foo")))
+
+    val b =
+      for {
+        c <- CursorBuilder[Boolean].build(true, BooleanType)
+        _  = assert(c.isLeaf)
+        l  <- c.asLeaf
+      } yield l
+    assert(b == Ior.Right(Json.fromBoolean(true)))
+
+    val f =
+      for {
+        c <- CursorBuilder[Double].build(13.0, FloatType)
+        _  = assert(c.isLeaf)
+        l  <- c.asLeaf
+      } yield l
+    assert(f == Ior.Right(Json.fromDouble(13.0).get))
+  }
+
+  test("types with a Circe Encoder instance have leaf cursor builders") {
+    val z =
+      for {
+        c <- DerivedLeafCursorBuilder[ZonedDateTime].build(ZonedDateTime.parse("2020-03-25T16:24:06.081Z"), StringType)
+        _  = assert(c.isLeaf)
+        l  <- c.asLeaf
+      } yield l
+    assert(z == Ior.Right(Json.fromString("2020-03-25T16:24:06.081Z")))
+  }
+
+  test("enumeration types have leaf cursor builders") {
+    val e =
+      for {
+        c <- CursorBuilder[Episode.Value].build(Episode.JEDI, StringType)
+        _  = assert(c.isLeaf)
+        l  <- c.asLeaf
+      } yield l
+    assert(e == Ior.Right(Json.fromString("JEDI")))
+  }
+
+  test("product types have cursor builders") {
+    val name =
+      for {
+        c <- CursorBuilder[Human].build(lukeSkywalker, HumanType)
+        f <- c.field("name")
+        n <- f.asNullable.flatMap(_.toRightIor(mkOneError("missing")))
+        l <- n.asLeaf
+      } yield l
+    assert(name == Ior.Right(Json.fromString("Luke Skywalker")))
+  }
+
+  test("cursor builders can be resolved for nested types") {
+    val appearsIn =
+      for {
+        c <- CursorBuilder[Character].build(lukeSkywalker, HumanType)
+        f <- c.field("appearsIn")
+        n <- f.asNullable.flatMap(_.toRightIor(mkOneError("missing")))
+        l <- n.asList
+        s <- l.traverse(_.asLeaf)
+      } yield s
+    assert(appearsIn == Ior.Right(List(Json.fromString("NEWHOPE"), Json.fromString("EMPIRE"), Json.fromString("JEDI"))))
+  }
+
+  test("default cursor builders can be customised by mapping fields") {
+    val friends =
+      for {
+        c <- CursorBuilder[Human].build(lukeSkywalker, HumanType)
+        f <- c.field("friends")
+        n <- f.asNullable.flatMap(_.toRightIor(mkOneError("missing")))
+        l <- n.asList
+        m <- l.traverse(_.field("name"))
+        p <- m.traverse(_.asNullable.flatMap(_.toRightIor(mkOneError("missing"))))
+        q <- p.traverse(_.asLeaf)
+      } yield q
+    assert(friends == Ior.Right(List(Json.fromString("Han Solo"), Json.fromString("Leia Organa"), Json.fromString("C-3PO"), Json.fromString("R2-D2"))))
+  }
+
+  test("sealed ADTs have narrowable cursor builders") {
+    val homePlanets =
+      for {
+        c <- CursorBuilder[Character].build(lukeSkywalker, HumanType)
+        h <- c.narrow(HumanType)
+        m <- h.field("homePlanet")
+        n <- m.asNullable.flatMap(_.toRightIor(mkOneError("missing")))
+        l <- n.asLeaf
+      } yield l
+    assert(homePlanets == Ior.Right(Json.fromString("Tatooine")))
+  }
+
+  test("simple query") {
+    val query = """
+      query {
+        character(id: "1000") {
+          name
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "character" : {
+            "name" : "Luke Skywalker"
+          }
+        }
+      }
+    """
+
+    val compiledQuery = StarWarsQueryCompiler.compile(query).right.get
+    val res = StarWarsQueryInterpreter.run(compiledQuery, StarWarsData.schema.queryType)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("subtype query") {
+    val query = """
+      query {
+        human(id: "1003") {
+          name
+          homePlanet
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "human" : {
+            "name" : "Leia Organa",
+            "homePlanet" : "Alderaan"
+          }
+        }
+      }
+    """
+
+    val compiledQuery = StarWarsQueryCompiler.compile(query).right.get
+    val res = StarWarsQueryInterpreter.run(compiledQuery, StarWarsData.schema.queryType)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("simple nested query (1)") {
+    val query = """
+      query {
+        character(id: "1000") {
+          name
+          friends {
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "character" : {
+            "name" : "Luke Skywalker",
+            "friends" : [
+              {
+                "name" : "Han Solo"
+              },
+              {
+                "name" : "Leia Organa"
+              },
+              {
+                "name" : "C-3PO"
+              },
+              {
+                "name" : "R2-D2"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val compiledQuery = StarWarsQueryCompiler.compile(query).right.get
+    val res = StarWarsQueryInterpreter.run(compiledQuery, StarWarsData.schema.queryType)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("fragment query") {
+    val query = """
+      query {
+        character(id: "1000") {
+          name
+          ... on Human {
+            homePlanet
+          }
+          friends {
+            name
+            ... on Human {
+              homePlanet
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "character" : {
+            "name" : "Luke Skywalker",
+            "homePlanet" : "Tatooine",
+            "friends" : [
+              {
+                "name" : "Han Solo",
+                "homePlanet" : null
+              },
+              {
+                "name" : "Leia Organa",
+                "homePlanet" : "Alderaan"
+              },
+              {
+                "name" : "C-3PO"
+              },
+              {
+                "name" : "R2-D2"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val compiledQuery = StarWarsQueryCompiler.compile(query).right.get
+    val res = StarWarsQueryInterpreter.run(compiledQuery, StarWarsData.schema.queryType)
+    //println(res)
+
+    assert(res == expected)
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.4
+sbt.version=1.3.8


### PR DESCRIPTION
A fairly simple minded `Cursor` derivation scheme for ADT-backed models.

This PR adds a type class `CursorBuilder[T]` which constructs `Cursors` for values of Scala type `T`. Instances are provides for primitive types, `List`, `Option` and Scala enumerations.

Circe-style semiauto derivation is provided for,
* sealed traits, which correspond to GraphQL interface types
* case classes, which correspond to GraphQL object types
* Any type with a Circe `Encoder` instance, which corresponds to a (custom) GraphQL scalar type.

Usage is similar to Circe,

```scala
import edu.gemini.grackle.generic.semiauto._

sealed trait Character {
  def id: String
  def name: Option[String]
  def appearsIn: Option[List[Episode.Value]]
  def friends: Option[List[String]]
}

object Character {
  implicit val cursorBuilder: CursorBuilder[Character] =
    deriveInterfaceCursorBuilder[Character]
}

case class Human(
  id: String,
  name: Option[String],
  appearsIn: Option[List[Episode.Value]],
  friends: Option[List[String]],
  homePlanet: Option[String]
) extends Character

object Human {
  implicit val cursorBuilder: CursorBuilder[Human] =
    deriveObjectCursorBuilder[Character]
}

object CustomScalars {
  implicit val zdtCursorBuilder: CursorBuilder[ZonedDateTime] =
    deriveLeafCursorBuilder[ZonedDateTime]
}
```

Derived `ObjectCursorBuilders` may be transformed,
* to map their field names
* to transform field values

The latter is particularly useful in situations where the GraphQL schema is naturally recursive, but where the Scala model ties the knot indirectly, eg. via an id. In this case the id can be mapped to the specified value by the cursor, allowing query navigation through the unfolding structure.

```scala
object Human {
  implicit val cursorBuilder: CursorBuilder[Human] =
    deriveObjectCursorBuilder[Human]
      .transformField("friends")(_.friends match {
        case None => None.rightIor
        case Some(ids) =>
          ids.traverse(id => characters.find(_.id == id)
            .toRightIor(mkOneError(s"Bad id '$id'"))).map(_.some)
      })
}
```