### PR TITLE
Allow components to construct lists as well as subobjects

### DIFF
--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -258,6 +258,7 @@ object QueryCompiler {
         case w@Wrap(_, child)         => transform(child, env, schema, tpe).map(ec => w.copy(child = ec))
         case r@Rename(_, child)       => transform(child, env, schema, tpe).map(ec => r.copy(child = ec))
         case g@Group(children)        => children.traverse(q => transform(q, env, schema, tpe)).map(eqs => g.copy(queries = eqs))
+        case g@GroupList(children)    => children.traverse(q => transform(q, env, schema, tpe)).map(eqs => g.copy(queries = eqs))
         case u@Unique(_, child)       => transform(child, env, schema, tpe.nonNull).map(ec => u.copy(child = ec))
         case f@Filter(_, child)       => transform(child, env, schema, tpe.item).map(ec => f.copy(child = ec))
         case c@Component(_, _, child) => transform(child, env, schema, tpe).map(ec => c.copy(child = ec))

--- a/modules/core/src/main/scala/query.scala
+++ b/modules/core/src/main/scala/query.scala
@@ -48,7 +48,12 @@ object Query {
 
   /** A Group of sibling queries at the same level */
   case class Group(queries: List[Query]) extends Query {
-    def render = queries.map(_.render).mkString(", ")
+    def render = queries.map(_.render).mkString("{", ", ", "}")
+  }
+
+  /** A Group of sibling queries as a list */
+  case class GroupList(queries: List[Query]) extends Query {
+    def render = queries.map(_.render).mkString("[", ", ", "]")
   }
 
   /** Picks out the unique element satisfying `pred` and continues with `child` */
@@ -483,11 +488,24 @@ abstract class QueryInterpreter[F[_]](implicit val F: Monad[F]) {
         } yield ProtoJson.fromFields(List((fieldName, pvalue)))
 
       case (Component(cid, join, PossiblyRenamedSelect(child, resultName)), _) =>
-        for {
-          cont          <- join(cursor, child)
-          componentName <- mkResult(rootName(cont))
-          renamedCont   <- mkResult(renameRoot(cont, resultName))
-        } yield ProtoJson.component(cid, renamedCont, joinType(child.name, componentName, tpe.field(child.name)))
+        join(cursor, child).flatMap {
+          case GroupList(conts) =>
+            conts.traverse { case cont =>
+              for {
+                componentName <- mkResult(rootName(cont))
+              } yield
+                ProtoJson.select(
+                  ProtoJson.component(cid, cont, joinType(child.name, componentName, tpe.field(child.name).item)),
+                  componentName
+                )
+            }.map(ProtoJson.fromValues)
+
+          case cont =>
+            for {
+              componentName <- mkResult(rootName(cont))
+              renamedCont   <- mkResult(renameRoot(cont, resultName))
+            } yield ProtoJson.component(cid, renamedCont, joinType(child.name, componentName, tpe.field(child.name)))
+        }
 
       case (Defer(join, child), _) =>
         for {
@@ -565,6 +583,8 @@ object QueryInterpreter {
     private[QueryInterpreter] case class ProtoObject(fields: List[(String, ProtoJson)])
     // A partially constructed array which has at least one deferred element.
     private[QueryInterpreter] case class ProtoArray(elems: List[ProtoJson])
+    // A result which will yield a selection from its child
+    private[QueryInterpreter] case class ProtoSelect(elem: ProtoJson, fieldName: String)
 
     /**
      * Delegate `query` to the componet interpreter idenitfied by
@@ -607,6 +627,20 @@ object QueryInterpreter {
         wrap(Json.fromValues(elems.asInstanceOf[List[Json]]))
       else
         wrap(ProtoArray(elems))
+
+    /**
+     * Select a value from a possibly partial object.
+     *
+     * If the object is complete the selection will be a coplete
+     * Json value.
+     */
+    def select(elem: ProtoJson, fieldName: String): ProtoJson =
+      elem match {
+        case j: Json =>
+          wrap(j.asObject.flatMap(_(fieldName)).getOrElse(Json.Null))
+        case _ =>
+          wrap(ProtoSelect(elem, fieldName))
+      }
 
     /**
      * Test whether the argument contains any deferred subtrees
@@ -683,10 +717,11 @@ object QueryInterpreter {
         pending.uncons match {
           case None => acc
           case Some((hd, tl)) => hd match {
-            case _: Json             => loop(tl, acc)
-            case d: DeferredJson     => loop(tl, d :: acc)
-            case ProtoObject(fields) => loop(Chain.fromSeq(fields.map(_._2)) ++ tl, acc)
-            case ProtoArray(elems)   => loop(Chain.fromSeq(elems) ++ tl, acc)
+            case _: Json              => loop(tl, acc)
+            case d: DeferredJson      => loop(tl, d :: acc)
+            case ProtoObject(fields)  => loop(Chain.fromSeq(fields.map(_._2)) ++ tl, acc)
+            case ProtoArray(elems)    => loop(Chain.fromSeq(elems) ++ tl, acc)
+            case ProtoSelect(elem, _) => loop(elem +: tl, acc)
           }
         }
 
@@ -713,6 +748,8 @@ object QueryInterpreter {
           case ProtoArray(elems) =>
             val elems0 = elems.map(loop)
             Json.fromValues(elems0)
+          case ProtoSelect(elem, fieldName) =>
+            loop(elem).asObject.flatMap(_(fieldName)).getOrElse(Json.Null)
         }
 
       loop(pj)

--- a/modules/core/src/main/scala/query.scala
+++ b/modules/core/src/main/scala/query.scala
@@ -631,7 +631,7 @@ object QueryInterpreter {
     /**
      * Select a value from a possibly partial object.
      *
-     * If the object is complete the selection will be a coplete
+     * If the object is complete the selection will be a complete
      * Json value.
      */
     def select(elem: ProtoJson, fieldName: String): ProtoJson =

--- a/modules/core/src/test/scala/composed/ComposedListSpec.scala
+++ b/modules/core/src/test/scala/composed/ComposedListSpec.scala
@@ -1,0 +1,247 @@
+// Copyright (c) 2016-2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package composed
+
+import edu.gemini.grackle._
+
+import cats.Id
+import cats.implicits._
+import cats.tests.CatsSuite
+import io.circe.literal.JsonStringContext
+
+import edu.gemini.grackle._
+import Query._, Predicate._, Value._
+import QueryCompiler._, ComponentElaborator.Mapping
+import QueryInterpreter.mkErrorResult
+
+object ComposedListData {
+  val collectionSchema =
+    Schema(
+      """
+        type Query {
+          collection: Collection!
+        }
+        type Collection {
+          itemIds: [String!]!
+        }
+      """
+    ).right.get
+
+  val itemSchema =
+    Schema(
+      """
+        type Query {
+          itemById(id: ID!): Item
+        }
+        type Item {
+          id: String!
+          name: String!
+        }
+      """
+    ).right.get
+
+  val composedSchema =
+    Schema(
+      """
+        type Query {
+          collection: Collection!
+          itemById(id: ID!): Item
+        }
+        type Collection {
+          itemIds: [String!]!
+          items: [Item!]!
+        }
+        type Item {
+          id: String!
+          name: String!
+        }
+      """
+    ).right.get
+
+  case class Collection(itemIds: List[String])
+  val collection = Collection(List("A", "B", "C"))
+
+  case class Item(id: String, name: String)
+  val items = List(Item("A", "foo"), Item("B", "bar"), Item("C", "baz"))
+}
+
+import ComposedListData._
+
+object CollectionQueryCompiler extends QueryCompiler(collectionSchema) {
+  val phases = Nil
+}
+
+object CollectionQueryInterpreter extends DataTypeQueryInterpreter[Id](
+  {
+    case "collection" => (collectionSchema.ref("Collection"), collection)
+  },
+  {
+    case (c: Collection, "itemIds") => c.itemIds
+  }
+)
+
+object ItemQueryCompiler extends QueryCompiler(itemSchema) {
+  val QueryType = itemSchema.ref("Query")
+
+  val selectElaborator = new SelectElaborator(Map(
+    QueryType -> {
+      case Select("itemById", List(Binding("id", IDValue(id))), child) =>
+        Select("itemById", Nil, Unique(FieldEquals("id", id), child)).rightIor
+    }
+  ))
+
+  val phases = List(selectElaborator)
+}
+
+object ItemQueryInterpreter extends DataTypeQueryInterpreter[Id](
+  {
+    case "itemById" => (ListType(itemSchema.ref("Item")), items)
+  },
+  {
+    case (i: Item, "id")   => i.id
+    case (i: Item, "name") => i.name
+  }
+)
+
+object ComposedListQueryCompiler extends QueryCompiler(composedSchema) {
+  val QueryType = composedSchema.ref("Query")
+  val CollectionType = composedSchema.ref("Collection")
+
+  val selectElaborator =  new SelectElaborator(Map(
+    QueryType -> {
+      case Select("itemById", List(Binding("id", IDValue(id))), child) =>
+        Select("itemById", Nil, Unique(FieldEquals("id", id), child)).rightIor
+    }
+  ))
+
+  val collectionItemJoin = (c: Cursor, q: Query) =>
+    (c.focus, q) match {
+      case (c: Collection, Select("items", _, child)) =>
+        GroupList(c.itemIds.map(id => Select("itemById", Nil, Unique(FieldEquals("id", id), child)))).rightIor
+      case _ =>
+        mkErrorResult(s"Unexpected cursor focus type in collectionItemJoin")
+    }
+
+  val componentElaborator = ComponentElaborator(
+    Mapping(QueryType, "collection", "CollectionComponent"),
+    Mapping(QueryType, "itemById", "ItemComponent"),
+    Mapping(CollectionType, "items", "ItemComponent", collectionItemJoin)
+  )
+
+  val phases = List(componentElaborator, selectElaborator)
+}
+
+object ComposedListQueryInterpreter extends
+  ComposedQueryInterpreter[Id](Map(
+    "CollectionComponent" -> CollectionQueryInterpreter,
+    "ItemComponent"       -> ItemQueryInterpreter
+  ))
+
+final class ComposedListSpec extends CatsSuite {
+  test("simple outer query") {
+    val query = """
+      query {
+        collection {
+          itemIds
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "collection" : {
+            "itemIds" : [
+              "A",
+              "B",
+              "C"
+            ]
+          }
+        }
+      }
+    """
+
+    val compiledQuery = CollectionQueryCompiler.compile(query).right.get
+    val res = CollectionQueryInterpreter.run(compiledQuery, collectionSchema.queryType)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("simple inner query") {
+    val query = """
+      query {
+        itemById(id: "A") {
+          id
+          name
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "itemById" : {
+            "id" : "A",
+            "name" : "foo"
+          }
+        }
+      }
+    """
+
+    val compiledQuery = ItemQueryCompiler.compile(query).right.get
+    val res = ItemQueryInterpreter.run(compiledQuery, itemSchema.queryType)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("composed query") {
+    val query = """
+      query {
+        collection {
+          itemIds
+          items {
+            id
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "collection" : {
+            "itemIds" : [
+              "A",
+              "B",
+              "C"
+            ],
+            "items" : [
+              {
+                "id" : "A",
+                "name" : "foo"
+              },
+              {
+                "id" : "B",
+                "name" : "bar"
+              },
+              {
+                "id" : "C",
+                "name" : "baz"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val compiledQuery = ComposedListQueryCompiler.compile(query).right.get
+    val res = ComposedListQueryInterpreter.run(compiledQuery, composedSchema.queryType)
+    //println(res)
+
+    assert(res == expected)
+  }
+}

--- a/modules/doobie/src/main/scala/doobiemapping.scala
+++ b/modules/doobie/src/main/scala/doobiemapping.scala
@@ -137,6 +137,10 @@ trait DoobieMapping {
           queries.foldLeft(acc) {
             case (acc, sibling) => loop(sibling, obj, acc)
           }
+        case GroupList(queries) =>
+          queries.foldLeft(acc) {
+            case (acc, sibling) => loop(sibling, obj, acc)
+          }
         case Empty | (_: Component) | (_: Introspection) | (_: Defer) | (_: UntypedNarrow) | (_: Skip) => acc
       }
     }
@@ -406,6 +410,7 @@ object DoobieMapping {
           case w@Wrap(_, child)        => loop(child, tpe, filtered).map(ec => w.copy(child = ec))
           case r@Rename(_, child)      => loop(child, tpe, filtered).map(ec => r.copy(child = ec))
           case g@Group(queries)        => queries.traverse(q => loop(q, tpe, filtered)).map(eqs => g.copy(queries = eqs))
+          case g@GroupList(queries)    => queries.traverse(q => loop(q, tpe, filtered)).map(eqs => g.copy(queries = eqs))
           case u@Unique(_, child)      => loop(child, tpe.nonNull, filtered + tpe.underlyingObject).map(ec => u.copy(child = ec))
           case f@Filter(_, child)      => loop(child, tpe.item, filtered + tpe.underlyingObject).map(ec => f.copy(child = ec))
           case c: Component            => c.rightIor


### PR DESCRIPTION
Prior to the PR it was only possible to delegate the construction of a field value to a component. As of this PR it is now possible to delegate the construction of list elements to a component.