### PR TITLE
Simplify model in StarsWars tests

### DIFF
--- a/demo/src/main/scala/starwars/StarWarsData.scala
+++ b/demo/src/main/scala/starwars/StarWarsData.scala
@@ -176,7 +176,7 @@ object StarWarsData {
   val Some(r2d2) = characters.find(_.id == "2001")
 
   // Mapping from Episode to its hero Character
-  lazy val hero: Map[Value, Character] = Map(
+  val hero: Map[Value, Character] = Map(
     NEWHOPE -> r2d2,
     EMPIRE -> lukeSkywalker,
     JEDI -> r2d2


### PR DESCRIPTION
Simplified the Star Wars model in core/test in the same way as was done in the demo project (by removing cyclic references via `lazy` and by-name constructor arguments).