### PR TITLE
Type/FieldMapping extends Product with Serializable

### DIFF
--- a/modules/core/src/main/scala/valuemapping.scala
+++ b/modules/core/src/main/scala/valuemapping.scala
@@ -14,8 +14,8 @@ import ScalarType._
 
 trait ValueMapping[F[_]] extends AbstractMapping[Monad, F] {
 
-  class ValueRoot(val tpe: Type, val fieldName: String, root0: => Any) extends RootMapping {
-    lazy val root: Any = root0
+  case class ValueRoot(val tpe: Type, val fieldName: String, root0: () => Any) extends RootMapping {
+    lazy val root: Any = root0()
     def cursor(query: Query): F[Result[Cursor]] = {
       val fieldTpe = tpe.field(fieldName)
       val cursorTpe = query match {
@@ -30,7 +30,7 @@ trait ValueMapping[F[_]] extends AbstractMapping[Monad, F] {
 
   object ValueRoot {
     def apply(fieldName: String, root: => Any): ValueRoot =
-      new ValueRoot(NoType, fieldName, root)
+      new ValueRoot(NoType, fieldName, () => root)
   }
 
   sealed trait ValueField0[T] extends FieldMapping

--- a/modules/doobie/src/main/scala/doobiemapping.scala
+++ b/modules/doobie/src/main/scala/doobiemapping.scala
@@ -280,9 +280,9 @@ trait DoobieMapping[F[_]] extends AbstractMapping[Sync, F] {
     case class DoobieObject(fieldName: String, subobject: Subobject) extends DoobieFieldMapping
   }
 
-  class DoobieLeafMapping[T](val tpe: Type, val encoder: Encoder[T], val meta: Meta[T]) extends LeafMapping[T]
+  case class DoobieLeafMapping[T](val tpe: Type, val encoder: Encoder[T], val meta: Meta[T]) extends LeafMapping[T]
   object DoobieLeafMapping {
-    def apply[T](tpe: Type)(implicit encoder: Encoder[T], meta: Meta[T]) =
+    def apply[T](tpe: Type)(implicit encoder: Encoder[T], meta: Meta[T], dummy: DummyImplicit) =
       new DoobieLeafMapping(tpe, encoder, meta)
   }
 

--- a/modules/generic/src/main/scala/genericmapping.scala
+++ b/modules/generic/src/main/scala/genericmapping.scala
@@ -18,15 +18,15 @@ import QueryInterpreter.{ mkErrorResult, mkOneError }
 import ShapelessUtils._
 
 trait GenericMapping[F[_]] extends AbstractMapping[Monad, F] {
-  class GenericRoot[T](val tpe: Type, val fieldName: String, t: T, cb: => CursorBuilder[T]) extends RootMapping {
-    lazy val cursorBuilder = cb
+  case class GenericRoot[T](val tpe: Type, val fieldName: String, t: T, cb: () => CursorBuilder[T]) extends RootMapping {
+    lazy val cursorBuilder = cb()
     def cursor(query: Query): F[Result[Cursor]] = cursorBuilder.build(t).pure[F]
     def withParent(tpe: Type): GenericRoot[T] =
-      new GenericRoot(tpe, fieldName, t, cursorBuilder)
+      new GenericRoot(tpe, fieldName, t, cb)
   }
 
   def GenericRoot[T](fieldName: String, t: T)(implicit cb: => CursorBuilder[T]): GenericRoot[T] =
-    new GenericRoot(NoType, fieldName, t, cb)
+    new GenericRoot(NoType, fieldName, t, () => cb)
 }
 
 object semiauto {


### PR DESCRIPTION
Change `TypeMapping` and `FieldMapping` to extends `Product with Serializable` to keep Wartremover happy in client projects.