### PR TITLE
Subobject fixes and enhancements

### DIFF
--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -260,7 +260,7 @@ object QueryCompiler {
         case u@Unique(_, child)       => transform(child, env, schema, tpe.nonNull).map(ec => u.copy(child = ec))
         case f@Filter(_, child)       => transform(child, env, schema, tpe.item).map(ec => f.copy(child = ec))
         case c@Component(_, _, child) => transform(child, env, schema, tpe).map(ec => c.copy(child = ec))
-        case d@Defer(_, child)        => transform(child, env, schema, tpe).map(ec => d.copy(child = ec))
+        case d@Defer(_, child, _)     => transform(child, env, schema, tpe).map(ec => d.copy(child = ec))
         case s@Skip(_, _, child)      => transform(child, env, schema, tpe).map(ec => s.copy(child = ec))
         case Empty                    => Empty.rightIor
       }

--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -344,6 +344,8 @@ sealed trait Type {
   def isNamed: Boolean = false
 
   def asNamed: Option[NamedType] = None
+
+  def isInterface: Boolean = false
 }
 
 // Move all below into object Type?
@@ -482,7 +484,9 @@ case class InterfaceType(
   description: Option[String],
   fields:      List[Field],
   interfaces:  List[NamedType]
-) extends Type with TypeWithFields
+) extends Type with TypeWithFields {
+  override def isInterface: Boolean = true
+}
 
 /**
  * Object types represent concrete instantiations of sets of fields.


### PR DESCRIPTION
+ Added support for interfaces and fragments on doobie backed models.
+ Attributes can now appear in predicates.
+ Attributes may now be nullable.
+ Joins though nullable columns are now supported enabling nullable subobjects.
+ Support Deferred queries which delegate to a top-level field.
+ Correctly rename deferred subqueries