### PR TITLE
Add support for array columns

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,8 +79,8 @@ lazy val doobie = project
       "org.typelevel"     %% "cats-effect"            % catsEffectVersion,
       "io.chrisdavenport" %% "log4cats-slf4j"         % log4catsVersion,
       "org.tpolecat"      %% "doobie-core"            % doobieVersion,
+      "org.tpolecat"      %% "doobie-postgres"        % doobieVersion,
 
-      "org.tpolecat"      %% "doobie-postgres"        % doobieVersion % "test",
       "ch.qos.logback"    %  "logback-classic"        % logbackVersion % "test",
       "com.dimafeng"      %% "testcontainers-scala-scalatest"  % testContainersVersion % "test",
       "com.dimafeng"      %% "testcontainers-scala-postgresql" % testContainersVersion % "test",

--- a/modules/doobie/src/test/resources/db/movies.sql
+++ b/modules/doobie/src/test/resources/db/movies.sql
@@ -5,18 +5,20 @@ CREATE TABLE movies (
     releasedate DATE NOT NULL,
     showtime TIME NOT NULL,
     nextshowing TIMESTAMP WITH TIME ZONE,
-    duration BIGINT NOT NULL
+    duration BIGINT NOT NULL,
+    categories VARCHAR[] NOT NULL,
+    features VARCHAR[] NOT NULL
 );
 
-COPY movies (id, title, genre, releasedate, showtime, nextshowing, duration) FROM STDIN WITH DELIMITER ',';
-6a7837fc-b463-4d32-b628-0f4b3065cb21,Celine et Julie Vont en Bateau,1,1974-10-07,19:35:00,2020-05-22T19:35:00Z,12300000
-11daf8c0-11c3-4453-bfe1-cb6e6e2f9115,Duelle,1,1975-09-15,19:20:00,2020-05-27T19:20:00Z,7260000
-aea9756f-621b-42d5-b130-71f3916c4ba3,L'Amour fou,1,1969-01-15,21:00:00,2020-05-27T21:00:00Z,15120000
-2ddb041f-86c2-4bd3-848c-990a3862634e,Last Year at Marienbad,1,1961-06-25,20:30:00,2020-05-26T20:30:00Z,5640000
-8ae5b13b-044c-4ff0-8b71-ccdb7d77cd88,Zazie dans le Métro,3,1960-10-28,20:15:00,2020-05-25T20:15:00Z,5340000
-9dce9deb-9188-4cc2-9685-9842b8abdd34,Alphaville,2,1965-05-05,19:45:00,2020-05-19T19:45:00Z,5940000
-1bf00ac6-91ab-4e51-b686-3fd5e2324077,Stalker,1,1979-05-13,15:30:00,2020-05-19T15:30:00Z,9660000
-6a878e06-6563-4a0c-acd9-d28dcfb2e91a,Weekend,3,1967-12-29,22:30:00,2020-05-19T22:30:00Z,6300000
-2a40415c-ea6a-413f-bbef-a80ae280c4ff,Daisies,3,1966-12-30,21:30:00,2020-05-15T21:30:00Z,4560000
-2f6dcb0a-4122-4a21-a1c6-534744dd6b85,Le Pont du Nord,1,1982-01-13,20:45:00,2020-05-11T20:45:00Z,7620000
+COPY movies (id, title, genre, releasedate, showtime, nextshowing, duration, categories, features) FROM STDIN WITH DELIMITER '|';
+6a7837fc-b463-4d32-b628-0f4b3065cb21|Celine et Julie Vont en Bateau|1|1974-10-07|19:35:00|2020-05-22T19:35:00Z|12300000|{"drama","comedy"}|{"hd","hls"}
+11daf8c0-11c3-4453-bfe1-cb6e6e2f9115|Duelle|1|1975-09-15|19:20:00|2020-05-27T19:20:00Z|7260000|{"drama"}|{"hd"}
+aea9756f-621b-42d5-b130-71f3916c4ba3|L'Amour fou|1|1969-01-15|21:00:00|2020-05-27T21:00:00Z|15120000|{"drama"}|{"hd"}
+2ddb041f-86c2-4bd3-848c-990a3862634e|Last Year at Marienbad|1|1961-06-25|20:30:00|2020-05-26T20:30:00Z|5640000|{"drama"}|{"hd"}
+8ae5b13b-044c-4ff0-8b71-ccdb7d77cd88|Zazie dans le Métro|3|1960-10-28|20:15:00|2020-05-25T20:15:00Z|5340000|{"drama","comedy"}|{"hd"}
+9dce9deb-9188-4cc2-9685-9842b8abdd34|Alphaville|2|1965-05-05|19:45:00|2020-05-19T19:45:00Z|5940000|{"drama","science fiction"}|{"hd"}
+1bf00ac6-91ab-4e51-b686-3fd5e2324077|Stalker|1|1979-05-13|15:30:00|2020-05-19T15:30:00Z|9660000|{"drama","science fiction"}|{"hd"}
+6a878e06-6563-4a0c-acd9-d28dcfb2e91a|Weekend|3|1967-12-29|22:30:00|2020-05-19T22:30:00Z|6300000|{"drama","comedy"}|{"hd"}
+2a40415c-ea6a-413f-bbef-a80ae280c4ff|Daisies|3|1966-12-30|21:30:00|2020-05-15T21:30:00Z|4560000|{"drama","comedy"}|{"hd"}
+2f6dcb0a-4122-4a21-a1c6-534744dd6b85|Le Pont du Nord|1|1982-01-13|20:45:00|2020-05-11T20:45:00Z|7620000|{"drama"}|{"hd"}
 \.

--- a/modules/doobie/src/test/scala/scalars/MovieSpec.scala
+++ b/modules/doobie/src/test/scala/scalars/MovieSpec.scala
@@ -313,4 +313,39 @@ final class MovieSpec extends DatabaseSuite {
 
     assert(res == expected)
   }
+
+  test("query with arrays") {
+    val query = """
+      query {
+        movieById(id: "6a7837fc-b463-4d32-b628-0f4b3065cb21") {
+          categories
+          features
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "movieById" : {
+            "categories" : [
+              "drama",
+              "comedy"
+            ],
+            "features" : [
+              "HD",
+              "HLS"
+            ]
+          }
+        }
+      }
+    """
+
+    val compiledQuery = mapping.compiler.compile(query).right.get
+    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
+
 }


### PR DESCRIPTION
Fields of non-object array types can now be mapped to SQL array columns.

For GraphQL lists of `String`, `Int`, `Float` and `Boolean` this is handled automatically.

For custom scalars and enums a `DoobieLeafMapping` must be added for list type because `Meta`s for SQL arrays can't be straightforwardly derived from `Meta`s for the elements. It will typically also be necessary to add a (non-doobie) `LeafMapping` for the elements to capture the circe `Encoder` for the element type.