### PR TITLE
Initial support for sorting and limiting query results

### DIFF
--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -263,6 +263,8 @@ object QueryCompiler {
         case c@Component(_, _, child) => transform(child, env, schema, tpe).map(ec => c.copy(child = ec))
         case d@Defer(_, child, _)     => transform(child, env, schema, tpe).map(ec => d.copy(child = ec))
         case s@Skip(_, _, child)      => transform(child, env, schema, tpe).map(ec => s.copy(child = ec))
+        case l@Limit(_, child)        => transform(child, env, schema, tpe).map(ec => l.copy(child = ec))
+        case o@OrderBy(_, child)      => transform(child, env, schema, tpe).map(ec => o.copy(child = ec))
         case Empty                    => Empty.rightIor
       }
   }

--- a/modules/core/src/test/scala/compiler/Predicates.scala
+++ b/modules/core/src/test/scala/compiler/Predicates.scala
@@ -73,7 +73,7 @@ object ItemMapping extends ValueMapping[Id] {
   override val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("itemByTag", List(Binding("tag", IDValue(tag))), child) =>
-        Select("itemByTag", Nil, Filter(Contains(FieldPath(List("tags")), Const(tag)), child)).rightIor
+        Select("itemByTag", Nil, Filter(Contains(CollectFieldPath(List("tags")), Const(tag)), child)).rightIor
       case Select("itemByTagCount", List(Binding("count", IntValue(count))), child) =>
         Select("itemByTagCount", Nil, Filter(Eql(FieldPath(List("tagCount")), Const(count)), child)).rightIor
       case Select("itemByTagCountVA", List(Binding("count", IntValue(count))), child) =>

--- a/modules/doobie/src/test/scala/world/WorldSpec.scala
+++ b/modules/doobie/src/test/scala/world/WorldSpec.scala
@@ -910,4 +910,76 @@ final class WorldSpec extends DatabaseSuite {
 
     assert(res == expected)
   }
+
+  test("simple query with limit") {
+    val query = """
+      query {
+        countries(limit: 3) {
+          name
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : [
+            {
+              "name" : "Aruba"
+            },
+            {
+              "name" : "Afghanistan"
+            },
+            {
+              "name" : "Angola"
+            }
+          ]
+        }
+      }
+    """
+
+    val compiledQuery = mapping.compiler.compile(query).right.get
+    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("simple query with limit, filter and ordering") {
+    val query = """
+      query {
+        countries(limit: 3, minPopulation: 1, byPopulation: true) {
+          name
+          population
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : [
+            {
+              "name" : "Pitcairn",
+              "population" : 50
+            },
+            {
+              "name" : "Cocos (Keeling) Islands",
+              "population" : 600
+            },
+            {
+              "name" : "Holy See (Vatican City State)",
+              "population" : 1000
+            }
+          ]
+        }
+      }
+    """
+
+    val compiledQuery = mapping.compiler.compile(query).right.get
+    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
 }


### PR DESCRIPTION
* Added `OrderBy` and `Limit` nodes to the query algebra. Currently these operations are handled directly by Grackle rather than being translated to SQL by the Doobie mapping.

* Also expanded the set of supported operators to include a fuller set of relations, bitwise operators and some string functions.

It should be possible to translate the `OrderBy` and `Limit` nodes to SQL `ORDER BY` and `LIMIT` clauses, but currently doing so would only work correctly in the case where a GraphQL object doesn't extend across more than one row. Right now we don't have a mechanism for detecting that case.