### PR TITLE
Doobie object/interface mapping enhancements

### DIFF
--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -169,6 +169,17 @@ sealed trait Type {
   def hasField(fieldName: String): Boolean =
     field(fieldName) != NoType
 
+  /**
+   * `true` if this type has a field named `fieldName` which is undefined in
+   * some interface it implements
+   */
+  def variantField(fieldName: String): Boolean =
+    underlyingObject match {
+      case ObjectType(_, _, _, interfaces) =>
+        hasField(fieldName) && interfaces.exists(!_.hasField(fieldName))
+      case _ => false
+    }
+
   def withField[T](fieldName: String)(body: Type => Result[T]): Result[T] = {
     val childTpe = field(fieldName)
     if (childTpe =:= NoType) mkErrorResult(s"Unknown field '$fieldName' in '$this'")

--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -393,6 +393,35 @@ object JoinType {
 }
 
 /**
+ * Represents an occurence of a type at a position within the graph determined
+ * by a path prefix.
+ */
+case class RootedType(path: List[String], tpe: Type) {
+  def dealias: RootedType = copy(tpe = tpe.dealias)
+  def underlyingObject: RootedType = copy(tpe = tpe.underlyingObject)
+  def nonNull: RootedType = copy(tpe = tpe.nonNull)
+  def item: RootedType = copy(tpe = tpe.item)
+
+  def field(fieldName: String): RootedType =
+    RootedType(path :+ fieldName, tpe.field(fieldName))
+  def underlyingField(fieldName: String): RootedType =
+    RootedType(path :+ fieldName, tpe.underlyingField(fieldName))
+  def withUnderlyingField[T](fieldName: String)(body: RootedType => Result[T]): Result[T] =
+    tpe.withUnderlyingField(fieldName) { childTpe =>
+      body(RootedType(path :+ fieldName, childTpe))
+    }
+
+  def path(fns: List[String]): RootedType =
+    RootedType(path ++ fns, tpe.path(fns))
+}
+
+object RootedType {
+  def apply(tpe: Type): RootedType = RootedType(Nil, tpe)
+
+  implicit def asType(rt: RootedType): Type = rt.tpe
+}
+
+/**
  * A by name reference to a type defined in `schema`.
  */
 case class TypeRef(schema: Schema, name: String) extends NamedType {

--- a/modules/core/src/main/scala/valuemapping.scala
+++ b/modules/core/src/main/scala/valuemapping.scala
@@ -61,8 +61,8 @@ trait ValueMapping[F[_]] extends AbstractMapping[Monad, F] {
     new ValueObjectMapping(tpe, fieldMappings.map(_.withParent(tpe)), classTag)
 
   case class ValueCursor(
-    tpe:     Type,
-    focus:   Any
+    tpe:   Type,
+    focus: Any
   ) extends Cursor {
     def isLeaf: Boolean =
       tpe.dealias match {
@@ -111,7 +111,7 @@ trait ValueMapping[F[_]] extends AbstractMapping[Monad, F] {
 
     def narrowsTo(subtpe: TypeRef): Boolean =
       subtpe <:< tpe &&
-        typeMapping(subtpe).map {
+        objectMapping(RootedType(subtpe)).map {
           case ValueObjectMapping(_, _, classTag) =>
             classTag.runtimeClass.isInstance(focus)
           case _ => false
@@ -125,10 +125,10 @@ trait ValueMapping[F[_]] extends AbstractMapping[Monad, F] {
         mkErrorResult(s"Focus ${focus} of static type $tpe cannot be narrowed to $subtpe")
 
     def hasField(fieldName: String): Boolean =
-      tpe.hasField(fieldName) && fieldMapping(tpe, fieldName).isDefined
+      tpe.hasField(fieldName) && fieldMapping(RootedType(tpe), fieldName).isDefined
 
     def field(fieldName: String): Result[Cursor] =
-      fieldMapping(tpe, fieldName) match {
+      fieldMapping(RootedType(tpe), fieldName) match {
         case Some(ValueField(_, f)) =>
           copy(tpe = tpe.field(fieldName), focus = f.asInstanceOf[Any => Any](focus)).rightIor
         case Some(CursorField(_, f, _)) =>
@@ -138,10 +138,10 @@ trait ValueMapping[F[_]] extends AbstractMapping[Monad, F] {
       }
 
     def hasAttribute(attrName: String): Boolean =
-      !tpe.hasField(attrName) && fieldMapping(tpe, attrName).isDefined
+      !tpe.hasField(attrName) && fieldMapping(RootedType(tpe), attrName).isDefined
 
     def attribute(attrName: String): Result[Any] =
-      fieldMapping(tpe, attrName) match {
+      fieldMapping(RootedType(tpe), attrName) match {
         case Some(ValueAttribute(_, f)) =>
           f.asInstanceOf[Any => Any](focus).rightIor
         case Some(CursorAttribute(_, f)) =>

--- a/modules/core/src/test/scala/starwars/StarWarsSpec.scala
+++ b/modules/core/src/test/scala/starwars/StarWarsSpec.scala
@@ -256,4 +256,68 @@ final class StarWarsSpec extends CatsSuite {
 
     assert(res == expected)
   }
+
+  test("fragments") {
+    val query = """
+      query {
+        character(id: "1000") {
+          name
+          friends {
+            name
+            ... on Human {
+              homePlanet
+              appearsIn
+            }
+            ... on Droid {
+              primaryFunction
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "character" : {
+            "name" : "Luke Skywalker",
+            "friends" : [
+              {
+                "name" : "Han Solo",
+                "homePlanet" : null,
+                "appearsIn" : [
+                  "NEWHOPE",
+                  "EMPIRE",
+                  "JEDI"
+                ]
+              },
+              {
+                "name" : "Leia Organa",
+                "homePlanet" : "Alderaan",
+                "appearsIn" : [
+                  "NEWHOPE",
+                  "EMPIRE",
+                  "JEDI"
+                ]
+              },
+              {
+                "name" : "C-3PO",
+                "primaryFunction" : "Protocol"
+              },
+              {
+                "name" : "R2-D2",
+                "primaryFunction" : "Astromech"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val compiledQuery = StarWarsMapping.compiler.compile(query).right.get
+    val res = StarWarsMapping.interpreter.run(compiledQuery, StarWarsMapping.schema.queryType)
+    //println(res)
+
+    assert(res == expected)
+  }
 }

--- a/modules/doobie/src/test/resources/db/embedding.sql
+++ b/modules/doobie/src/test/resources/db/embedding.sql
@@ -1,0 +1,24 @@
+CREATE TABLE films (
+    title TEXT PRIMARY KEY,
+    synopsis_short TEXT,
+    synopsis_long TEXT
+);
+
+CREATE TABLE series (
+    title TEXT PRIMARY KEY,
+    synopsis_short TEXT,
+    synopsis_long TEXT
+);
+
+COPY films (title, synopsis_short, synopsis_long) FROM STDIN WITH DELIMITER '|';
+Film 1|Short film 1|Long film 1
+Film 2|Short film 2|Long film 2
+Film 3|Short film 3|Long film 3
+\.
+
+
+COPY series (title, synopsis_short, synopsis_long) FROM STDIN WITH DELIMITER '|';
+Series 1|Short series 1|Long series 1
+Series 2|Short series 2|Long series 2
+Series 3|Short series 3|Long series 3
+\.

--- a/modules/doobie/src/test/resources/db/interfaces.sql
+++ b/modules/doobie/src/test/resources/db/interfaces.sql
@@ -1,0 +1,35 @@
+CREATE TABLE entities (
+    id TEXT PRIMARY KEY,
+    entity_type INTEGER NOT NULL,
+    title TEXT,
+    synopsis_short TEXT,
+    synopsis_long TEXT,
+    film_rating TEXT,
+    series_number_of_episodes INTEGER
+);
+
+CREATE TABLE episodes (
+    id TEXT PRIMARY KEY,
+    series_id TEXT NOT NULL,
+    title TEXT,
+    synopsis_short TEXT,
+    synopsis_long TEXT
+);
+
+COPY entities (id, entity_type, title, synopsis_short, synopsis_long, film_rating, series_number_of_episodes) FROM STDIN WITH DELIMITER '|' NULL AS '';
+1|1|Film 1|Short film 1|Long film 1|PG|
+2|1|Film 2|Short film 2|Long film 2|U|
+3|1|Film 3|Short film 3|Long film 3|15|
+4|2|Series 1|Short series 1|Long series 1||5
+5|2|Series 2|Short series 2|Long series 2||6
+6|2|Series 3|Short series 3|Long series 3||7
+\.
+
+COPY episodes (id, series_id, title, synopsis_short, synopsis_long) FROM STDIN WITH DELIMITER '|' NULL AS '';
+1|4|S1E1|Short S1E1|Long S1E1
+2|4|S1E2|Short S1E2|Long S1E2
+3|5|S2E1|Short S2E1|Long S2E1
+4|5|S2E2|Short S2E2|Long S2E2
+5|6|S3E1|Short S3E1|Long S3E1
+6|6|S3E2|Short S3E2|Long S3E2
+\.

--- a/modules/doobie/src/test/scala/embedding/EmbeddingData.scala
+++ b/modules/doobie/src/test/scala/embedding/EmbeddingData.scala
@@ -1,0 +1,93 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package embedding
+
+import cats.effect.Sync
+import doobie.Transactor
+import io.chrisdavenport.log4cats.Logger
+
+import edu.gemini.grackle._, doobie._
+
+class EmbeddingMapping[F[_]: Sync](val transactor: Transactor[F], val logger: Logger[F]) extends DoobieMapping[F] {
+  val schema =
+    Schema(
+      """
+        type Query {
+          films: [Film!]!
+          series: [Series!]!
+        }
+        type Film {
+          title: String!
+          synopses: Synopses!
+        }
+        type Series {
+          title: String!
+          synopses: Synopses!
+        }
+        type Synopses {
+          short: String!
+          long: String!
+        }
+      """
+    ).right.get
+
+  val QueryType = schema.ref("Query")
+  val FilmType = schema.ref("Film")
+  val SeriesType = schema.ref("Series")
+  val SynopsesType = schema.ref("Synopses")
+
+  import DoobieFieldMapping._
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            DoobieRoot("films"),
+            DoobieRoot("series")
+          )
+      ),
+      ObjectMapping(
+        tpe = FilmType,
+        fieldMappings =
+          List(
+            DoobieField("title", ColumnRef("films", "title"), key = true),
+            DoobieObject("synopses", Subobject(Nil))
+          )
+      ),
+      ObjectMapping(
+        tpe = SeriesType,
+        fieldMappings =
+          List(
+            DoobieField("title", ColumnRef("series", "title"), key = true),
+            DoobieObject("synopses", Subobject(Nil))
+          )
+      ),
+      ObjectMapping(
+        tpe = SynopsesType,
+        path = List("films", "synopses"),
+        fieldMappings =
+          List(
+            DoobieField("short", ColumnRef("films", "synopsis_short")),
+            DoobieField("long", ColumnRef("films", "synopsis_long"))
+          )
+      ),
+      ObjectMapping(
+        tpe = SynopsesType,
+        path = List("series", "synopses"),
+        fieldMappings =
+          List(
+            DoobieField("short", ColumnRef("series", "synopsis_short")),
+            DoobieField("long", ColumnRef("series", "synopsis_long"))
+          )
+      )
+    )
+}
+
+object EmbeddingMapping {
+  def fromTransactor[F[_] : Sync : Logger](transactor: Transactor[F]): EmbeddingMapping[F] =
+    new EmbeddingMapping[F](transactor, Logger[F])
+}
+

--- a/modules/doobie/src/test/scala/embedding/EmbeddingSpec.scala
+++ b/modules/doobie/src/test/scala/embedding/EmbeddingSpec.scala
@@ -1,0 +1,112 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package embedding
+
+import io.circe.literal.JsonStringContext
+
+import utils.DatabaseSuite
+
+final class EmbeddingSpec extends DatabaseSuite {
+  lazy val mapping = EmbeddingMapping.fromTransactor(xa)
+
+  test("simple embedded query (1)") {
+    val query = """
+      query {
+        films {
+          title
+          synopses {
+            short
+            long
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "films" : [
+            {
+              "title" : "Film 1",
+              "synopses" : {
+                "short" : "Short film 1",
+                "long" : "Long film 1"
+              }
+            },
+            {
+              "title" : "Film 2",
+              "synopses" : {
+                "short" : "Short film 2",
+                "long" : "Long film 2"
+              }
+            },
+            {
+              "title" : "Film 3",
+              "synopses" : {
+                "short" : "Short film 3",
+                "long" : "Long film 3"
+              }
+            }
+          ]
+        }
+      }
+    """
+
+    val compiledQuery = mapping.compiler.compile(query).right.get
+    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("simple embedded query (2)") {
+    val query = """
+      query {
+        series {
+          title
+          synopses {
+            short
+            long
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "series" : [
+            {
+              "title" : "Series 1",
+              "synopses" : {
+                "short" : "Short series 1",
+                "long" : "Long series 1"
+              }
+            },
+            {
+              "title" : "Series 2",
+              "synopses" : {
+                "short" : "Short series 2",
+                "long" : "Long series 2"
+              }
+            },
+            {
+              "title" : "Series 3",
+              "synopses" : {
+                "short" : "Short series 3",
+                "long" : "Long series 3"
+              }
+            }
+          ]
+        }
+      }
+    """
+
+    val compiledQuery = mapping.compiler.compile(query).right.get
+    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
+}

--- a/modules/doobie/src/test/scala/interfaces/InterfacesData.scala
+++ b/modules/doobie/src/test/scala/interfaces/InterfacesData.scala
@@ -1,0 +1,197 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package interfaces
+
+import cats.effect.Sync
+import cats.implicits._
+import cats.kernel.Eq
+import doobie.Transactor
+import doobie.util.meta.Meta
+import edu.gemini.grackle._
+import edu.gemini.grackle.doobie._
+import io.chrisdavenport.log4cats.Logger
+import io.circe.Encoder
+import edu.gemini.grackle.Query.Select
+import edu.gemini.grackle.Value.IDValue
+import edu.gemini.grackle.Query.Filter
+import edu.gemini.grackle.Predicate.Eql
+import edu.gemini.grackle.Predicate.AttrPath
+import edu.gemini.grackle.Predicate.Const
+import QueryInterpreter.mkErrorResult
+import edu.gemini.grackle.Predicate.ScalarFocus
+
+class InterfacesMapping[F[_]: Sync](val transactor: Transactor[F], val logger: Logger[F]) extends DoobieMapping[F] {
+  val schema =
+    Schema(
+      """
+        type Query {
+          entities: [Entity!]!
+        }
+        interface Entity {
+          id: ID!
+          entityType: EntityType!
+          title: String!
+          synopses: Synopses!
+        }
+        type Film implements Entity {
+          id: ID!
+          entityType: EntityType!
+          title: String!
+          synopses: Synopses!
+          rating: String
+        }
+        type Series implements Entity {
+          id: ID!
+          entityType: EntityType!
+          title: String!
+          numberOfEpisodes: Int!
+          episodes: [Episode!]!
+        }
+        type Episode {
+          id: ID!
+          title: String!
+          synopses: Synopses!
+        }
+        type Synopses {
+          short: String!
+          long: String!
+        }
+        enum EntityType {
+          FILM
+          SERIES
+        }
+      """
+    ).right.get
+
+  val QueryType = schema.ref("Query")
+  val EType = schema.ref("Entity")
+  val EntityTypeType = schema.ref("EntityType")
+  val FilmType = schema.ref("Film")
+  val SeriesType = schema.ref("Series")
+  val EpisodeType = schema.ref("Episode")
+  val SynopsesType = schema.ref("Synopses")
+
+  import DoobieFieldMapping._
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            DoobieRoot("entities"),
+          )
+      ),
+      DoobieInterfaceMapping(
+        tpe = EType,
+        discriminator = entityTypeDiscriminator,
+        fieldMappings =
+          List(
+            DoobieField("id", ColumnRef("entities", "id"), key = true),
+            DoobieField("entityType", ColumnRef("entities", "entity_type"), discriminator = true),
+            DoobieField("title", ColumnRef("entities", "title"))
+          )
+      ),
+      ObjectMapping(
+        tpe = FilmType,
+        fieldMappings =
+          List(
+            DoobieField("rating", ColumnRef("entities", "film_rating")),
+            DoobieObject("synopses", Subobject(Nil))
+          )
+      ),
+      ObjectMapping(
+        tpe = SeriesType,
+        fieldMappings =
+          List(
+            DoobieField("numberOfEpisodes", ColumnRef("entities", "series_number_of_episodes")),
+            DoobieObject("episodes", Subobject(
+              List(Join(ColumnRef("entities", "id"), ColumnRef("episodes", "series_id"))),
+              seriesEpisodeJoin
+            ))
+          )
+      ),
+      ObjectMapping(
+        tpe = EpisodeType,
+        fieldMappings =
+          List(
+            DoobieField("id", ColumnRef("episodes", "id"), key = true),
+            DoobieField("title", ColumnRef("episodes", "title")),
+            DoobieAttribute[String]("episodeId", ColumnRef("episodes", "series_id")),
+            DoobieObject("synopses", Subobject(Nil))
+          )
+      ),
+      ObjectMapping(
+        tpe = SynopsesType,
+        path = List("entities", "synopses"),
+        fieldMappings =
+          List(
+            DoobieField("short", ColumnRef("entities", "synopsis_short")),
+            DoobieField("long", ColumnRef("entities", "synopsis_long"))
+          )
+      ),
+      ObjectMapping(
+        tpe = SynopsesType,
+        path = List("entities", "episodes", "synopses"),
+        fieldMappings =
+          List(
+            DoobieField("short", ColumnRef("episodes", "synopsis_short")),
+            DoobieField("long", ColumnRef("episoes", "synopsis_long"))
+          )
+      ),
+      DoobieLeafMapping[EntityType](EntityTypeType)
+    )
+
+  def entityTypeDiscriminator(c: Cursor): Result[Type] = {
+    for {
+      et <- c.fieldAs[EntityType]("entityType")
+    } yield et match {
+      case EntityType.Film => FilmType
+      case EntityType.Series => SeriesType
+    }
+  }
+
+  def seriesEpisodeJoin(c: Cursor, q: Query): Result[Query] = q match {
+    case Select("episodes", Nil, child) =>
+      c.field("id").map { case ScalarFocus(IDValue(episodeId)) =>
+        Select("episodes", Nil, Filter(Eql(AttrPath(List("episodeId")), Const(episodeId)), child))
+      }
+    case _ => mkErrorResult("Bad staging join")
+  }
+}
+
+object InterfacesMapping {
+  def fromTransactor[F[_] : Sync : Logger](transactor: Transactor[F]): InterfacesMapping[F] =
+    new InterfacesMapping[F](transactor, Logger[F])
+}
+
+sealed trait EntityType extends Product with Serializable
+object EntityType {
+  case object Film extends EntityType
+  case object Series extends EntityType
+
+  implicit val entityTypeEq: Eq[EntityType] = Eq.fromUniversalEquals[EntityType]
+
+  def fromString(s: String): Option[EntityType] =
+    s.trim.toUpperCase match {
+      case "FILM"  => Some(Film)
+      case "SERIES" => Some(Series)
+      case _ => None
+    }
+
+  implicit val entityTypeEncoder: Encoder[EntityType] =
+    Encoder[String].contramap(_ match {
+      case Film => "FILM"
+      case Series => "SERIES"
+    })
+
+  implicit val entityTypeMeta: Meta[EntityType] =
+    Meta[Int].timap {
+      case 1 => Film
+      case 2 => Series
+    } {
+      case Film  => 1
+      case Series => 2
+    }
+}

--- a/modules/doobie/src/test/scala/interfaces/InterfacesSpec.scala
+++ b/modules/doobie/src/test/scala/interfaces/InterfacesSpec.scala
@@ -1,0 +1,479 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package interfaces
+
+import io.circe.literal.JsonStringContext
+
+import utils.DatabaseSuite
+
+final class InterfacesSpec extends DatabaseSuite {
+  lazy val mapping = InterfacesMapping.fromTransactor(xa)
+
+  test("simple interface query") {
+    val query = """
+      query {
+        entities {
+          id
+          entityType
+          title
+          synopses {
+            short
+            long
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "entities" : [
+            {
+              "id" : "1",
+              "entityType" : "FILM",
+              "title" : "Film 1",
+              "synopses" : {
+                "short" : "Short film 1",
+                "long" : "Long film 1"
+              }
+            },
+            {
+              "id" : "2",
+              "entityType" : "FILM",
+              "title" : "Film 2",
+              "synopses" : {
+                "short" : "Short film 2",
+                "long" : "Long film 2"
+              }
+            },
+            {
+              "id" : "3",
+              "entityType" : "FILM",
+              "title" : "Film 3",
+              "synopses" : {
+                "short" : "Short film 3",
+                "long" : "Long film 3"
+              }
+            },
+            {
+              "id" : "4",
+              "entityType" : "SERIES",
+              "title" : "Series 1",
+              "synopses" : {
+                "short" : "Short series 1",
+                "long" : "Long series 1"
+              }
+            },
+            {
+              "id" : "5",
+              "entityType" : "SERIES",
+              "title" : "Series 2",
+              "synopses" : {
+                "short" : "Short series 2",
+                "long" : "Long series 2"
+              }
+            },
+            {
+              "id" : "6",
+              "entityType" : "SERIES",
+              "title" : "Series 3",
+              "synopses" : {
+                "short" : "Short series 3",
+                "long" : "Long series 3"
+              }
+            }
+          ]
+        }
+      }
+    """
+
+    val compiledQuery = mapping.compiler.compile(query).right.get
+    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("interface query with fragment") {
+    val query = """
+      query {
+        entities {
+          id
+          entityType
+          title
+          ... on Film {
+            rating
+          }
+          ... on Series {
+            numberOfEpisodes
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "entities" : [
+            {
+              "id" : "1",
+              "entityType" : "FILM",
+              "title" : "Film 1",
+              "rating" : "PG"
+            },
+            {
+              "id" : "2",
+              "entityType" : "FILM",
+              "title" : "Film 2",
+              "rating" : "U"
+            },
+            {
+              "id" : "3",
+              "entityType" : "FILM",
+              "title" : "Film 3",
+              "rating" : "15"
+            },
+            {
+              "id" : "4",
+              "entityType" : "SERIES",
+              "title" : "Series 1",
+              "numberOfEpisodes" : 5
+            },
+            {
+              "id" : "5",
+              "entityType" : "SERIES",
+              "title" : "Series 2",
+              "numberOfEpisodes" : 6
+            },
+            {
+              "id" : "6",
+              "entityType" : "SERIES",
+              "title" : "Series 3",
+              "numberOfEpisodes" : 7
+            }
+          ]
+        }
+      }
+    """
+
+    val compiledQuery = mapping.compiler.compile(query).right.get
+    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("interface query with fragment, no explicit discriminator") {
+    val query = """
+      query {
+        entities {
+          id
+          title
+          ... on Film {
+            rating
+          }
+          ... on Series {
+            numberOfEpisodes
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "entities" : [
+            {
+              "id" : "1",
+              "title" : "Film 1",
+              "rating" : "PG"
+            },
+            {
+              "id" : "2",
+              "title" : "Film 2",
+              "rating" : "U"
+            },
+            {
+              "id" : "3",
+              "title" : "Film 3",
+              "rating" : "15"
+            },
+            {
+              "id" : "4",
+              "title" : "Series 1",
+              "numberOfEpisodes" : 5
+            },
+            {
+              "id" : "5",
+              "title" : "Series 2",
+              "numberOfEpisodes" : 6
+            },
+            {
+              "id" : "6",
+              "title" : "Series 3",
+              "numberOfEpisodes" : 7
+            }
+          ]
+        }
+      }
+    """
+
+    val compiledQuery = mapping.compiler.compile(query).right.get
+    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("interface query with introspection") {
+    val query = """
+      query {
+        entities {
+          __typename
+          entityType
+          id
+          title
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "entities" : [
+            {
+              "__typename" : "Film",
+              "entityType" : "FILM",
+              "id" : "1",
+              "title" : "Film 1"
+            },
+            {
+              "__typename" : "Film",
+              "entityType" : "FILM",
+              "id" : "2",
+              "title" : "Film 2"
+            },
+            {
+              "__typename" : "Film",
+              "entityType" : "FILM",
+              "id" : "3",
+              "title" : "Film 3"
+            },
+            {
+              "__typename" : "Series",
+              "entityType" : "SERIES",
+              "id" : "4",
+              "title" : "Series 1"
+            },
+            {
+              "__typename" : "Series",
+              "entityType" : "SERIES",
+              "id" : "5",
+              "title" : "Series 2"
+            },
+            {
+              "__typename" : "Series",
+              "entityType" : "SERIES",
+              "id" : "6",
+              "title" : "Series 3"
+            }
+          ]
+        }
+      }
+    """
+
+    val compiledQuery = mapping.compiler.compile(query).right.get
+    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("interface query with subobject list") {
+    val query = """
+      query {
+        entities {
+          id
+          title
+          ... on Film {
+            rating
+          }
+
+          ... on Series {
+            episodes {
+              id
+              title
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "entities" : [
+            {
+              "id" : "1",
+              "title" : "Film 1",
+              "rating" : "PG"
+            },
+            {
+              "id" : "2",
+              "title" : "Film 2",
+              "rating" : "U"
+            },
+            {
+              "id" : "3",
+              "title" : "Film 3",
+              "rating" : "15"
+            },
+            {
+              "id" : "4",
+              "title" : "Series 1",
+              "episodes" : [
+                {
+                  "id" : "1",
+                  "title" : "S1E1"
+                },
+                {
+                  "id" : "2",
+                  "title" : "S1E2"
+                }
+              ]
+            },
+            {
+              "id" : "5",
+              "title" : "Series 2",
+              "episodes" : [
+                {
+                  "id" : "3",
+                  "title" : "S2E1"
+                },
+                {
+                  "id" : "4",
+                  "title" : "S2E2"
+                }
+              ]
+            },
+            {
+              "id" : "6",
+              "title" : "Series 3",
+              "episodes" : [
+                {
+                  "id" : "5",
+                  "title" : "S3E1"
+                },
+                {
+                  "id" : "6",
+                  "title" : "S3E2"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    """
+
+    val compiledQuery = mapping.compiler.compile(query).right.get
+    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("interface query with subobject list and embedded subobjects") {
+    val query = """
+      query {
+        entities {
+          ... on Series {
+            title
+            episodes {
+              id
+              title
+              synopses {
+                short
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "entities" : [
+            {},
+            {},
+            {},
+            {
+              "title" : "Series 1",
+              "episodes" : [
+                {
+                  "id" : "1",
+                  "title" : "S1E1",
+                  "synopses" : {
+                    "short" : "Short S1E1"
+                  }
+                },
+                {
+                  "id" : "2",
+                  "title" : "S1E2",
+                  "synopses" : {
+                    "short" : "Short S1E2"
+                  }
+                }
+              ]
+            },
+            {
+              "title" : "Series 2",
+              "episodes" : [
+                {
+                  "id" : "3",
+                  "title" : "S2E1",
+                  "synopses" : {
+                    "short" : "Short S2E1"
+                  }
+                },
+                {
+                  "id" : "4",
+                  "title" : "S2E2",
+                  "synopses" : {
+                    "short" : "Short S2E2"
+                  }
+                }
+              ]
+            },
+            {
+              "title" : "Series 3",
+              "episodes" : [
+                {
+                  "id" : "5",
+                  "title" : "S3E1",
+                  "synopses" : {
+                    "short" : "Short S3E1"
+                  }
+                },
+                {
+                  "id" : "6",
+                  "title" : "S3E2",
+                  "synopses" : {
+                    "short" : "Short S3E2"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      }
+    """
+
+    val compiledQuery = mapping.compiler.compile(query).right.get
+    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
+}


### PR DESCRIPTION
+ Doobie object mappings can now be parametrized with a GraphQL path prefix allowing occurrences of a structured GraphQL type to be mapped to a different set of tables/columns depending on which parent type they are embedded in.

+ GraphQL interfaces are now supported by an explicit mapping in Doobie models, allowing a discriminator to be specified, allowing the implementers of a common interface to mapped to a single set of rows/columns with a function distinguishing the concrete GraphQL type of the rows fetched. Fields which are variant between different implementers are transparently made nullable wrt the corresponding doobie `Metas`.