### PR TITLE
Ensure required columns for computed fields/attributes

### DIFF
--- a/modules/core/src/main/scala/mapping.scala
+++ b/modules/core/src/main/scala/mapping.scala
@@ -124,15 +124,15 @@ trait Mapping[F[_]] {
       Some((lm.tpe, lm.encoder))
   }
 
-  case class CursorField[T](fieldName: String, f: Cursor => Result[T], encoder: Encoder[T]) extends FieldMapping {
+  case class CursorField[T](fieldName: String, f: Cursor => Result[T], encoder: Encoder[T], required: List[String]) extends FieldMapping {
     def withParent(tpe: Type): CursorField[T] = this
   }
   object CursorField {
-    def apply[T](fieldName: String, f: Cursor => Result[T])(implicit encoder: Encoder[T], di: DummyImplicit): CursorField[T] =
-      new CursorField(fieldName, f, encoder)
+    def apply[T](fieldName: String, f: Cursor => Result[T], required: List[String] = Nil)(implicit encoder: Encoder[T], di: DummyImplicit): CursorField[T] =
+      new CursorField(fieldName, f, encoder, required)
   }
 
-  case class CursorAttribute[T](fieldName: String, f: Cursor => Result[T]) extends FieldMapping {
+  case class CursorAttribute[T](fieldName: String, f: Cursor => Result[T], required: List[String] = Nil) extends FieldMapping {
     def withParent(tpe: Type): CursorAttribute[T] = this
   }
 

--- a/modules/core/src/main/scala/valuemapping.scala
+++ b/modules/core/src/main/scala/valuemapping.scala
@@ -132,7 +132,7 @@ trait ValueMapping[F[_]] extends AbstractMapping[Monad, F] {
       fieldMapping(path, tpe, fieldName) match {
         case Some(ValueField(_, f)) =>
           copy(tpe = tpe.field(fieldName), focus = f.asInstanceOf[Any => Any](focus), path = fieldName :: path).rightIor
-        case Some(CursorField(_, f, _)) =>
+        case Some(CursorField(_, f, _, _)) =>
           f(this).map(res => copy(tpe = tpe.field(fieldName), focus = res))
         case _ =>
           mkErrorResult(s"No field '$fieldName' for type $tpe")
@@ -145,7 +145,7 @@ trait ValueMapping[F[_]] extends AbstractMapping[Monad, F] {
       fieldMapping(path, tpe, attrName) match {
         case Some(ValueAttribute(_, f)) =>
           f.asInstanceOf[Any => Any](focus).rightIor
-        case Some(CursorAttribute(_, f)) =>
+        case Some(CursorAttribute(_, f, _)) =>
           f(this)
         case _ =>
           mkErrorResult(s"No attribute '$attrName' for type $tpe")

--- a/modules/doobie/src/test/scala/scalars/MovieData.scala
+++ b/modules/doobie/src/test/scala/scalars/MovieData.scala
@@ -177,12 +177,12 @@ class MovieMapping[F[_]: Sync](val transactor: Transactor[F], val logger: Logger
             DoobieField("releaseDate", ColumnRef("movies", "releasedate")),
             DoobieField("showTime", ColumnRef("movies", "showtime")),
             DoobieField("nextShowing", ColumnRef("movies", "nextshowing")),
-            CursorField("nextEnding", nextEnding),
+            CursorField("nextEnding", nextEnding, List("nextShowing", "duration")),
             DoobieField("duration", ColumnRef("movies", "duration")),
             DoobieField("categories", ColumnRef("movies", "categories")),
             DoobieField("features", ColumnRef("movies", "features")),
             DoobieField("rating", ColumnRef("movies", "rating")),
-            CursorAttribute("isLong", isLong)
+            CursorAttribute("isLong", isLong, List("duration"))
           )
       ),
       DoobieLeafMapping[UUID](UUIDType),

--- a/modules/doobie/src/test/scala/scalars/MovieSpec.scala
+++ b/modules/doobie/src/test/scala/scalars/MovieSpec.scala
@@ -280,6 +280,44 @@ final class MovieSpec extends DatabaseSuite {
     assert(res == expected)
   }
 
+  test("query with standalone computed field") {
+    val query = """
+      query {
+        moviesShownBetween(from: "2020-05-01T10:30:00Z", to: "2020-05-19T18:00:00Z") {
+          title
+          nextEnding
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "moviesShownBetween" : [
+            {
+              "title" : "Stalker",
+              "nextEnding" : "2020-05-19T18:11:00Z"
+            },
+            {
+              "title" : "Daisies",
+              "nextEnding" : "2020-05-15T22:46:00Z"
+            },
+            {
+              "title" : "Le Pont du Nord",
+              "nextEnding" : "2020-05-11T22:52:00Z"
+            }
+          ]
+        }
+      }
+    """
+
+    val compiledQuery = mapping.compiler.compile(query).right.get
+    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
+
   test("query with computed attribute") {
     val query = """
       query {
@@ -301,6 +339,37 @@ final class MovieSpec extends DatabaseSuite {
             {
               "title" : "L'Amour fou",
               "duration" : "PT4H12M"
+            }
+          ]
+        }
+      }
+    """
+
+    val compiledQuery = mapping.compiler.compile(query).right.get
+    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("query with standaloe computed attribute") {
+    val query = """
+      query {
+        longMovies {
+          title
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "longMovies" : [
+            {
+              "title" : "Celine et Julie Vont en Bateau"
+            },
+            {
+              "title" : "L'Amour fou"
             }
           ]
         }


### PR DESCRIPTION
Adds a required fields/attributes member to `CursorField` and `CursorAttribute` allowing the Doobie mapping to ensure that columns which are not otherwise referenced are fetched and available for the evaluation of the computed field or attribute.