### PR TITLE
Mapping validation additions

### DIFF
--- a/modules/core/src/main/scala/valuemapping.scala
+++ b/modules/core/src/main/scala/valuemapping.scala
@@ -38,13 +38,16 @@ trait ValueMapping[F[_]] extends AbstractMapping[Monad, F] {
     implicit def wrap[T](fm: FieldMapping): ValueField0[T] = Wrap(fm)
     case class Wrap[T](fm: FieldMapping) extends ValueField0[T] {
       def fieldName = fm.fieldName
+      def isPublic = fm.isPublic
       def withParent(tpe: Type): FieldMapping = fm.withParent(tpe)
     }
   }
   case class ValueField[T](fieldName: String, f: T => Any) extends ValueField0[T] {
+    def isPublic = true
     def withParent(tpe: Type): ValueField[T] = this
   }
   case class ValueAttribute[T](fieldName: String, f: T => Any) extends ValueField0[T] {
+    def isPublic = false
     def withParent(tpe: Type): ValueAttribute[T] = this
   }
 

--- a/modules/core/src/test/scala/mapping/MappingValidationSpec.scala
+++ b/modules/core/src/test/scala/mapping/MappingValidationSpec.scala
@@ -4,23 +4,60 @@
 package mapping
 
 import cats.Id
+import cats.data.Chain
+import cats.implicits._
 import cats.tests.CatsSuite
+import io.circe.Json
+
+import edu.gemini.grackle.{Schema, ValueMapping}
+
 import compiler.MovieMapping
 import composed.CountryData
-import edu.gemini.grackle.{Schema, ValueMapping}
 
 class MappingValidationSpec extends CatsSuite {
 
   test("validate ValueMapping") {
-    assert(MovieMapping.validate.isEmpty)
+    val expected = Chain.empty[Json]
+
+    val res = MovieMapping.validate
+
+    assert(res == expected)
   }
 
   test("validate missing typeMapping") {
-    assert(UnvalidatedTypeMapping.validate.headOption.get.noSpaces.contains("Country"))
+    val expected =
+      Chain(
+        Json.fromString("Found mapping for unknown type Country"),
+        Json.fromString("Found mapping for unknown field code of type Country")
+      )
+
+    val res = UnvalidatedTypeMapping.validate
+
+    assert(res == expected)
   }
 
   test("validate missing fieldMapping") {
-    assert(UnvalidatedFieldMapping.validate.headOption.get.noSpaces.contains("name"))
+    val expected =
+      Chain(
+        Json.fromString("Found mapping for unknown field name of type Country")
+      )
+
+    val res = UnvalidatedFieldMapping.validate
+
+    assert(res == expected)
+  }
+
+  test("validate missing cursor field/attribute mapping") {
+    val expected =
+      Chain(
+        Json.fromString("Found mapping for unknown field computedField0 of type Country"),
+        Json.fromString("Found mapping for unknown field computedField1 of type Country"),
+        Json.fromString("No field/attribute mapping for missingField in object mapping for Country"),
+        Json.fromString("No field/attribute mapping for missingAttr in object mapping for Country")
+      )
+    val res = UnvalidatedCursorMapping.validate
+
+    assert(res == expected)
   }
 }
 
@@ -90,7 +127,51 @@ object UnvalidatedFieldMapping extends ValueMapping[Id] {
         fieldMappings =
           List(
             ValueField("code", _.code),
-            ValueField("name", _.name)
+            ValueField("name", _.name),
+            ValueAttribute("attr", _ => ()) // Attribute, so don't report as missing from schema
+          )
+      )
+    )
+}
+
+object UnvalidatedCursorMapping extends ValueMapping[Id] {
+  import CountryData._
+
+  val schema =
+    Schema(
+      """
+        type Query {
+          country(code: String): Country
+        }
+        type Country {
+          code: String!
+          computed: String!
+        }
+      """
+    ).right.get
+
+  val QueryType = schema.ref("Query")
+  val CountryType = schema.ref("Country")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            ValueRoot("country", countries)
+          )
+      ),
+      ValueObjectMapping[Country](
+        tpe = CountryType,
+        fieldMappings =
+          List(
+            ValueField("code", _.code),
+            ValueAttribute("attr", x => x),
+            CursorField("computedField0", _ => ().rightIor, List("code")),
+            CursorField("computedField1", _ => ().rightIor, List("missingField")),
+            CursorAttribute("computedAttr0", _ => ().rightIor, List("attr")),
+            CursorAttribute("computedAttr1", _ => ().rightIor, List("missingAttr"))
           )
       )
     )

--- a/modules/doobie/src/main/scala/doobiemapping.scala
+++ b/modules/doobie/src/main/scala/doobiemapping.scala
@@ -411,6 +411,7 @@ trait DoobieMapping[F[_]] extends AbstractCirceMapping[Sync, F] {
     nullable: Boolean,
     discriminator: Boolean
   ) extends FieldMapping {
+    def isPublic = false
     def withParent(tpe: Type): FieldMapping = this
   }
 
@@ -424,6 +425,7 @@ trait DoobieMapping[F[_]] extends AbstractCirceMapping[Sync, F] {
     new DoobieAttribute(fieldName, col, meta, key, nullable, discriminator)
 
   sealed trait DoobieFieldMapping extends FieldMapping {
+    def isPublic = true
     def withParent(tpe: Type): FieldMapping = this
   }
 


### PR DESCRIPTION
+ CursorFields/Attributes now have a list of required mappings so we can check for their presence.
+ We shouldn't report attributes as missing fields.