### PR TITLE
Added basic support for monitoring doobie backed queries

### DIFF
--- a/demo/src/main/scala/starwars/StarWarsService.scala
+++ b/demo/src/main/scala/starwars/StarWarsService.scala
@@ -4,14 +4,12 @@
 package starwars
 
 import cats.{ Applicative }
-import cats.data.Ior
 import cats.effect.Sync
 import cats.implicits._
 import io.circe.{ Json, ParsingFailure, parser }
 import org.http4s.{ HttpRoutes, InvalidMessageBodyFailure, ParseFailure, QueryParamDecoder }
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
-import edu.gemini.grackle.QueryInterpreter
 
 // #service
 trait StarWarsService[F[_]]{
@@ -60,12 +58,7 @@ object StarWarsService {
   def service[F[_]](implicit F: Applicative[F]): StarWarsService[F] =
     new StarWarsService[F]{
       def runQuery(op: Option[String], vars: Option[Json], query: String): F[Json] =
-        StarWarsMapping.compiler.compile(query, vars) match {
-          case Ior.Right(compiledQuery) =>
-            StarWarsMapping.interpreter.run(compiledQuery, StarWarsMapping.QueryType).pure[F]
-          case invalid =>
-            QueryInterpreter.mkInvalidResponse(invalid).pure[F]
-        }
+        StarWarsMapping.compileAndRun(query, op, vars).pure[F]
     }
 }
 // #service

--- a/modules/circe/src/main/scala/circemapping.scala
+++ b/modules/circe/src/main/scala/circemapping.scala
@@ -11,9 +11,7 @@ import io.circe.Json
 import QueryInterpreter.{mkErrorResult, mkOneError}
 import ScalarType._
 
-trait CirceMapping[F[_]] extends AbstractCirceMapping[Monad, F]
-
-trait AbstractCirceMapping[+M[f[_]] <: Monad[f], F[_]] extends AbstractMapping[M, F] {
+abstract class CirceMapping[F[_]: Monad] extends Mapping[F] {
   case class CirceRoot(val tpe: Type, val fieldName: String, root: Json) extends RootMapping {
     def cursor(query: Query): F[Result[Cursor]] = {
       val fieldTpe = tpe.field(fieldName)

--- a/modules/circe/src/test/scala/CirceSpec.scala
+++ b/modules/circe/src/test/scala/CirceSpec.scala
@@ -35,8 +35,7 @@ final class CirceSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = TestCirceMapping.compiler.compile(query).right.get
-    val res = TestCirceMapping.interpreter.run(compiledQuery, TestCirceMapping.schema.queryType)
+    val res = TestCirceMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -61,8 +60,7 @@ final class CirceSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = TestCirceMapping.compiler.compile(query).right.get
-    val res = TestCirceMapping.interpreter.run(compiledQuery, TestCirceMapping.schema.queryType)
+    val res = TestCirceMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -93,8 +91,7 @@ final class CirceSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = TestCirceMapping.compiler.compile(query).right.get
-    val res = TestCirceMapping.interpreter.run(compiledQuery, TestCirceMapping.schema.queryType)
+    val res = TestCirceMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -128,8 +125,7 @@ final class CirceSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = TestCirceMapping.compiler.compile(query).right.get
-    val res = TestCirceMapping.interpreter.run(compiledQuery, TestCirceMapping.schema.queryType)
+    val res = TestCirceMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -171,8 +167,7 @@ final class CirceSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = TestCirceMapping.compiler.compile(query).right.get
-    val res = TestCirceMapping.interpreter.run(compiledQuery, TestCirceMapping.schema.queryType)
+    val res = TestCirceMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -217,8 +212,7 @@ final class CirceSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = TestCirceMapping.compiler.compile(query).right.get
-    val res = TestCirceMapping.interpreter.run(compiledQuery, TestCirceMapping.schema.queryType)
+    val res = TestCirceMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)

--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -183,14 +183,14 @@ class QueryCompiler(schema: Schema, phases: List[Phase]) {
    *
    * Any errors are accumulated on the left.
    */
-  def compile(text: String, untypedEnv: Option[Json] = None, useIntrospection: Boolean = true): Result[Query] = {
+  def compile(text: String, name: Option[String] = None, untypedEnv: Option[Json] = None, useIntrospection: Boolean = true): Result[Query] = {
     val queryType = schema.queryType
 
     val allPhases =
       if (useIntrospection) IntrospectionElaborator :: VariablesAndSkipElaborator :: phases else VariablesAndSkipElaborator :: phases
 
     for {
-      parsed  <- QueryParser.parseText(text)
+      parsed  <- QueryParser.parseText(text, name)
       varDefs <- compileVarDefs(parsed.variables)
       env     <- compileEnv(varDefs, untypedEnv)
       query   <- allPhases.foldLeftM(parsed.query) { (acc, phase) => phase.transform(acc, env, schema, queryType) }

--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -6,11 +6,12 @@ package edu.gemini.grackle
 import atto.Atto._
 import cats.data.Ior
 import cats.implicits._
-import edu.gemini.grackle.Ast.{ObjectTypeDefinition, TypeDefinition}
-import edu.gemini.grackle.QueryInterpreter.{mkErrorResult, mkOneError}
-import edu.gemini.grackle.ScalarType._
-import edu.gemini.grackle.Value._
 import io.circe.Json
+
+import Ast.{ObjectTypeDefinition, TypeDefinition}
+import QueryInterpreter.{mkErrorResult, mkOneError}
+import ScalarType._
+import Value._
 
 /**
  * Representation of a GraphQL schema

--- a/modules/core/src/main/scala/valuemapping.scala
+++ b/modules/core/src/main/scala/valuemapping.scala
@@ -12,7 +12,7 @@ import io.circe.Json
 import QueryInterpreter.{mkErrorResult, mkOneError}
 import ScalarType._
 
-trait ValueMapping[F[_]] extends AbstractMapping[Monad, F] {
+abstract class ValueMapping[F[_]: Monad] extends Mapping[F] {
 
   case class ValueRoot(val tpe: Type, val fieldName: String, root0: () => Any) extends RootMapping {
     lazy val root: Any = root0()

--- a/modules/core/src/test/scala/compiler/Attributes.scala
+++ b/modules/core/src/test/scala/compiler/Attributes.scala
@@ -6,8 +6,6 @@ package compiler
 import cats.tests.CatsSuite
 import io.circe.literal.JsonStringContext
 
-import edu.gemini.grackle.QueryInterpreter.mkInvalidResponse
-
 final class AttributesSpec extends CatsSuite {
   test("fields only") {
     val query = """
@@ -44,8 +42,7 @@ final class AttributesSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = ItemMapping.compiler.compile(query).right.get
-    val res = ItemMapping.interpreter.run(compiledQuery, ItemMapping.QueryType)
+    val res = ItemMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -71,7 +68,7 @@ final class AttributesSpec extends CatsSuite {
       }
     """
 
-    val res = mkInvalidResponse(ItemMapping.compiler.compile(query))
+    val res = ItemMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -97,7 +94,7 @@ final class AttributesSpec extends CatsSuite {
       }
     """
 
-    val res = mkInvalidResponse(ItemMapping.compiler.compile(query))
+    val res = ItemMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)

--- a/modules/core/src/test/scala/compiler/FragmentSpec.scala
+++ b/modules/core/src/test/scala/compiler/FragmentSpec.scala
@@ -15,7 +15,7 @@ import QueryCompiler._
 
 final class FragmentSuite extends CatsSuite {
   test("simple fragment query") {
-    val text = """
+    val query = """
       query withFragments {
         user(id: 1) {
           friends {
@@ -89,17 +89,17 @@ final class FragmentSuite extends CatsSuite {
       }
     """
 
-    val compiled = FragmentMapping.compiler.compile(text)
+    val compiled = FragmentMapping.compiler.compile(query)
 
     assert(compiled == Ior.Right(expected))
 
-    val res = FragmentMapping.interpreter.run(compiled.right.get, FragmentMapping.schema.queryType)
+    val res = FragmentMapping.run(compiled.right.get, FragmentMapping.schema.queryType)
     //println(res)
     assert(res == expectedResult)
   }
 
   test("nested fragment query") {
-    val text = """
+    val query = """
       query withNestedFragments {
         user(id: 1) {
           friends {
@@ -177,17 +177,17 @@ final class FragmentSuite extends CatsSuite {
       }
     """
 
-    val compiled = FragmentMapping.compiler.compile(text)
+    val compiled = FragmentMapping.compiler.compile(query)
 
     assert(compiled == Ior.Right(expected))
 
-    val res = FragmentMapping.interpreter.run(compiled.right.get, FragmentMapping.schema.queryType)
+    val res = FragmentMapping.run(compiled.right.get, FragmentMapping.schema.queryType)
     //println(res)
     assert(res == expectedResult)
   }
 
   test("typed fragment query") {
-    val text = """
+    val query = """
       query FragmentTyping {
         profiles {
           id
@@ -254,17 +254,17 @@ final class FragmentSuite extends CatsSuite {
       }
     """
 
-    val compiled = FragmentMapping.compiler.compile(text)
+    val compiled = FragmentMapping.compiler.compile(query)
 
     assert(compiled == Ior.Right(expected))
 
-    val res = FragmentMapping.interpreter.run(compiled.right.get, FragmentMapping.schema.queryType)
+    val res = FragmentMapping.run(compiled.right.get, FragmentMapping.schema.queryType)
     //println(res)
     assert(res == expectedResult)
   }
 
   test("inline fragment query") {
-    val text = """
+    val query = """
       query inlineFragmentTyping {
         profiles {
           id
@@ -319,17 +319,17 @@ final class FragmentSuite extends CatsSuite {
       }
     """
 
-    val compiled = FragmentMapping.compiler.compile(text)
+    val compiled = FragmentMapping.compiler.compile(query)
 
     assert(compiled == Ior.Right(expected))
 
-    val res = FragmentMapping.interpreter.run(compiled.right.get, FragmentMapping.schema.queryType)
+    val res = FragmentMapping.run(compiled.right.get, FragmentMapping.schema.queryType)
     //println(res)
     assert(res == expectedResult)
   }
 
   test("typed union fragment query") {
-    val text = """
+    val query = """
       query FragmentUnionTyping {
         user: user(id: "1") {
           favourite {
@@ -419,11 +419,11 @@ final class FragmentSuite extends CatsSuite {
       }
     """
 
-    val compiled = FragmentMapping.compiler.compile(text)
+    val compiled = FragmentMapping.compiler.compile(query)
 
     assert(compiled == Ior.Right(expected))
 
-    val res = FragmentMapping.interpreter.run(compiled.right.get, FragmentMapping.schema.queryType)
+    val res = FragmentMapping.run(compiled.right.get, FragmentMapping.schema.queryType)
     //println(res)
     assert(res == expectedResult)
   }

--- a/modules/core/src/test/scala/compiler/InputValuesSpec.scala
+++ b/modules/core/src/test/scala/compiler/InputValuesSpec.scala
@@ -3,6 +3,7 @@
 
 package compiler
 
+import cats.Id
 import cats.data.Ior
 import cats.tests.CatsSuite
 
@@ -12,7 +13,7 @@ import QueryCompiler._
 
 final class InputValuesSuite extends CatsSuite {
   test("null value") {
-    val text = """
+    val query = """
       query {
         field {
           subfield
@@ -33,13 +34,13 @@ final class InputValuesSuite extends CatsSuite {
         Select("field", List(Binding("arg", IntValue(23))), Select("subfield", Nil, Empty))
       ))
 
-    val compiled = InputValuesMapping.compiler.compile(text, None)
+    val compiled = InputValuesMapping.compiler.compile(query, None)
     //println(compiled)
     assert(compiled == Ior.Right(expected))
   }
 
   test("list value") {
-    val text = """
+    val query = """
       query {
         listField(arg: []) {
           subfield
@@ -60,13 +61,13 @@ final class InputValuesSuite extends CatsSuite {
         )
       ))
 
-    val compiled = InputValuesMapping.compiler.compile(text, None)
+    val compiled = InputValuesMapping.compiler.compile(query, None)
     //println(compiled)
     assert(compiled == Ior.Right(expected))
   }
 
   test("input object value") {
-    val text = """
+    val query = """
       query {
         objectField(arg: { foo: 23, bar: true, baz: "quux" }) {
           subfield
@@ -88,13 +89,13 @@ final class InputValuesSuite extends CatsSuite {
         Select("subfield", Nil, Empty)
       )
 
-    val compiled = InputValuesMapping.compiler.compile(text, None)
+    val compiled = InputValuesMapping.compiler.compile(query, None)
     //println(compiled)
     assert(compiled == Ior.Right(expected))
   }
 }
 
-object InputValuesMapping {
+object InputValuesMapping extends Mapping[Id] {
   val schema =
     Schema(
       """
@@ -118,9 +119,9 @@ object InputValuesMapping {
 
   val QueryType = schema.ref("Query")
 
-  val selectElaborator = new SelectElaborator(Map(
+  val typeMappings = Nil
+
+  override val selectElaborator = new SelectElaborator(Map(
     QueryType -> PartialFunction.empty
   ))
-
-  val compiler = new QueryCompiler(schema, List(selectElaborator))
 }

--- a/modules/core/src/test/scala/compiler/Predicates.scala
+++ b/modules/core/src/test/scala/compiler/Predicates.scala
@@ -125,8 +125,7 @@ final class PredicatesSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = ItemMapping.compiler.compile(query).right.get
-    val res = ItemMapping.interpreter.run(compiledQuery, ItemMapping.QueryType)
+    val res = ItemMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -156,8 +155,7 @@ final class PredicatesSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = ItemMapping.compiler.compile(query).right.get
-    val res = ItemMapping.interpreter.run(compiledQuery, ItemMapping.QueryType)
+    val res = ItemMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -198,8 +196,7 @@ final class PredicatesSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = ItemMapping.compiler.compile(query).right.get
-    val res = ItemMapping.interpreter.run(compiledQuery, ItemMapping.QueryType)
+    val res = ItemMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)

--- a/modules/core/src/test/scala/compiler/ScalarsSpec.scala
+++ b/modules/core/src/test/scala/compiler/ScalarsSpec.scala
@@ -268,8 +268,7 @@ final class ScalarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = MovieMapping.compiler.compile(query).right.get
-    val res = MovieMapping.interpreter.run(compiledQuery, MovieMapping.QueryType)
+    val res = MovieMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -306,8 +305,7 @@ final class ScalarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = MovieMapping.compiler.compile(query).right.get
-    val res = MovieMapping.interpreter.run(compiledQuery, MovieMapping.QueryType)
+    val res = MovieMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -344,8 +342,7 @@ final class ScalarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = MovieMapping.compiler.compile(query).right.get
-    val res = MovieMapping.interpreter.run(compiledQuery, MovieMapping.QueryType)
+    val res = MovieMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -378,8 +375,7 @@ final class ScalarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = MovieMapping.compiler.compile(query).right.get
-    val res = MovieMapping.interpreter.run(compiledQuery, MovieMapping.QueryType)
+    val res = MovieMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -416,8 +412,7 @@ final class ScalarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = MovieMapping.compiler.compile(query).right.get
-    val res = MovieMapping.interpreter.run(compiledQuery, MovieMapping.QueryType)
+    val res = MovieMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -454,8 +449,7 @@ final class ScalarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = MovieMapping.compiler.compile(query).right.get
-    val res = MovieMapping.interpreter.run(compiledQuery, MovieMapping.QueryType)
+    val res = MovieMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)

--- a/modules/core/src/test/scala/compiler/SkipIncludeSpec.scala
+++ b/modules/core/src/test/scala/compiler/SkipIncludeSpec.scala
@@ -3,6 +3,7 @@
 
 package compiler
 
+import cats.Id
 import cats.data.Ior
 import cats.tests.CatsSuite
 import io.circe.literal.JsonStringContext
@@ -12,7 +13,7 @@ import Query._
 
 final class SkipIncludeSuite extends CatsSuite {
   test("skip/include field") {
-    val text = """
+    val query = """
       query ($yup: Boolean, $nope: Boolean) {
         a: field @skip(if: $yup) {
           subfieldA
@@ -42,13 +43,14 @@ final class SkipIncludeSuite extends CatsSuite {
         Rename("c", Select("field", Nil, Select("subfieldA", Nil, Empty)))
       ))
 
-    val compiled = SkipIncludeMapping.compiler.compile(text, Some(variables))
+    val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
     //println(compiled)
+
     assert(compiled == Ior.Right(expected))
   }
 
   test("skip/include fragment spread") {
-    val text = """
+    val query = """
       query ($yup: Boolean, $nope: Boolean) {
         a: field {
           ...frag @skip(if: $yup)
@@ -99,13 +101,14 @@ final class SkipIncludeSuite extends CatsSuite {
         Rename("d", Select("field", Nil, Empty))
       ))
 
-    val compiled = SkipIncludeMapping.compiler.compile(text, Some(variables))
+    val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
     //println(compiled)
+
     assert(compiled == Ior.Right(expected))
   }
 
   test("fragment spread with nested skip/include") {
-    val text = """
+    val query = """
       query ($yup: Boolean, $nope: Boolean) {
         field {
           ...frag
@@ -135,13 +138,14 @@ final class SkipIncludeSuite extends CatsSuite {
         ))
       )
 
-    val compiled = SkipIncludeMapping.compiler.compile(text, Some(variables))
+    val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
     //println(compiled)
+
     assert(compiled == Ior.Right(expected))
   }
 
   test("skip/include inline fragment") {
-    val text = """
+    val query = """
       query ($yup: Boolean, $nope: Boolean) {
         a: field {
           ... on Value @skip(if: $yup) {
@@ -199,13 +203,14 @@ final class SkipIncludeSuite extends CatsSuite {
         Rename("d", Select("field", Nil, Empty))
       ))
 
-    val compiled = SkipIncludeMapping.compiler.compile(text, Some(variables))
+    val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
     //println(compiled)
+
     assert(compiled == Ior.Right(expected))
   }
 
   test("inline fragment with nested skip/include") {
-    val text = """
+    val query = """
       query ($yup: Boolean, $nope: Boolean) {
         field {
           ... on Value {
@@ -233,13 +238,14 @@ final class SkipIncludeSuite extends CatsSuite {
         ))
       )
 
-    val compiled = SkipIncludeMapping.compiler.compile(text, Some(variables))
+    val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
     //println(compiled)
+
     assert(compiled == Ior.Right(expected))
   }
 }
 
-object SkipIncludeMapping {
+object SkipIncludeMapping extends Mapping[Id] {
   val schema =
     Schema(
       """
@@ -253,5 +259,5 @@ object SkipIncludeMapping {
       """
     ).right.get
 
-  val compiler = new QueryCompiler(schema, Nil)
+  val typeMappings = Nil
 }

--- a/modules/core/src/test/scala/composed/ComposedData.scala
+++ b/modules/core/src/test/scala/composed/ComposedData.scala
@@ -139,7 +139,7 @@ object CountryMapping extends ValueMapping[Id] {
 
 /* Composition */
 
-object ComposedMapping extends SimpleMapping[Id] {
+object ComposedMapping extends Mapping[Id] {
   val schema =
     Schema(
       """

--- a/modules/core/src/test/scala/composed/ComposedListSpec.scala
+++ b/modules/core/src/test/scala/composed/ComposedListSpec.scala
@@ -123,7 +123,7 @@ object ItemMapping extends ValueMapping[Id] {
   ))
 }
 
-object ComposedListMapping extends SimpleMapping[Id] {
+object ComposedListMapping extends Mapping[Id] {
   val schema =
     Schema(
       """
@@ -210,8 +210,7 @@ final class ComposedListSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = CollectionMapping.compiler.compile(query).right.get
-    val res = CollectionMapping.interpreter.run(compiledQuery, CollectionMapping.schema.queryType)
+    val res = CollectionMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -238,8 +237,7 @@ final class ComposedListSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = ItemMapping.compiler.compile(query).right.get
-    val res = ItemMapping.interpreter.run(compiledQuery, ItemMapping.schema.queryType)
+    val res = ItemMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -281,8 +279,7 @@ final class ComposedListSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = ComposedListMapping.compiler.compile(query).right.get
-    val res = ComposedListMapping.interpreter.run(compiledQuery, ComposedListMapping.schema.queryType)
+    val res = ComposedListMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -319,8 +316,7 @@ final class ComposedListSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = ComposedListMapping.compiler.compile(query).right.get
-    val res = ComposedListMapping.interpreter.run(compiledQuery, ComposedListMapping.schema.queryType)
+    val res = ComposedListMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -369,8 +365,7 @@ final class ComposedListSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = ComposedListMapping.compiler.compile(query).right.get
-    val res = ComposedListMapping.interpreter.run(compiledQuery, ComposedListMapping.schema.queryType)
+    val res = ComposedListMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -416,8 +411,7 @@ final class ComposedListSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = ComposedListMapping.compiler.compile(query).right.get
-    val res = ComposedListMapping.interpreter.run(compiledQuery, ComposedListMapping.schema.queryType)
+    val res = ComposedListMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)

--- a/modules/core/src/test/scala/composed/ComposedSpec.scala
+++ b/modules/core/src/test/scala/composed/ComposedSpec.scala
@@ -28,8 +28,7 @@ final class ComposedSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = CurrencyMapping.compiler.compile(query).right.get
-    val res = CurrencyMapping.interpreter.run(compiledQuery, CurrencyMapping.schema.queryType)
+    val res = ComposedMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -54,8 +53,7 @@ final class ComposedSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = CountryMapping.compiler.compile(query).right.get
-    val res = CountryMapping.interpreter.run(compiledQuery, CountryMapping.schema.queryType)
+    val res = ComposedMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -88,8 +86,7 @@ final class ComposedSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = ComposedMapping.compiler.compile(query).right.get
-    val res = ComposedMapping.interpreter.run(compiledQuery, ComposedMapping.schema.queryType)
+    val res = ComposedMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -138,8 +135,7 @@ final class ComposedSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = ComposedMapping.compiler.compile(query).right.get
-    val res = ComposedMapping.interpreter.run(compiledQuery, ComposedMapping.schema.queryType)
+    val res = ComposedMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -182,8 +178,7 @@ final class ComposedSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = ComposedMapping.compiler.compile(query).right.get
-    val res = ComposedMapping.interpreter.run(compiledQuery, ComposedMapping.schema.queryType)
+    val res = ComposedMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -216,8 +211,7 @@ final class ComposedSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = ComposedMapping.compiler.compile(query).right.get
-    val res = ComposedMapping.interpreter.run(compiledQuery, ComposedMapping.schema.queryType)
+    val res = ComposedMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -254,8 +248,7 @@ final class ComposedSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = ComposedMapping.compiler.compile(query).right.get
-    val res = ComposedMapping.interpreter.run(compiledQuery, ComposedMapping.schema.queryType)
+    val res = ComposedMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)

--- a/modules/core/src/test/scala/introspection/IntrospectionSpec.scala
+++ b/modules/core/src/test/scala/introspection/IntrospectionSpec.scala
@@ -26,7 +26,7 @@ final class IntrospectionSuite extends CatsSuite {
   }
 
   test("simple type query") {
-    val text = """
+    val query = """
       {
         __type(name: "User") {
           name
@@ -64,14 +64,14 @@ final class IntrospectionSuite extends CatsSuite {
       }
     """
 
-    val compiled = TestMapping.compiler.compile(text)
-    val res = TestMapping.interpreter.run(compiled.right.get, TestMapping.schema.queryType)
+    val res = TestMapping.compileAndRun(query)
     //println(res)
+
     assert(res == expected)
   }
 
   test("kind/name/description/ofType query") {
-    val text = """
+    val query = """
       {
         __type(name: "KindTest") {
           name
@@ -221,14 +221,14 @@ final class IntrospectionSuite extends CatsSuite {
       }
     """
 
-    val compiled = TestMapping.compiler.compile(text)
-    val res = TestMapping.interpreter.run(compiled.right.get, TestMapping.schema.queryType)
+    val res = TestMapping.compileAndRun(query)
     //println(res)
+
     assert(res == expected)
   }
 
   test("fields query") {
-    val text = """
+    val query = """
       {
         __type(name: "KindTest") {
           name
@@ -342,14 +342,14 @@ final class IntrospectionSuite extends CatsSuite {
       }
     """
 
-    val compiled = TestMapping.compiler.compile(text)
-    val res = TestMapping.interpreter.run(compiled.right.get, TestMapping.schema.queryType)
+    val res = TestMapping.compileAndRun(query)
     //println(res)
+
     assert(res == expected)
   }
 
   test("interfaces query") {
-    val text = """
+    val query = """
       {
         __type(name: "KindTest") {
           name
@@ -429,14 +429,14 @@ final class IntrospectionSuite extends CatsSuite {
       }
     """
 
-    val compiled = TestMapping.compiler.compile(text)
-    val res = TestMapping.interpreter.run(compiled.right.get, TestMapping.schema.queryType)
+    val res = TestMapping.compileAndRun(query)
     //println(res)
+
     assert(res == expected)
   }
 
   test("possibleTypes query") {
-    val text = """
+    val query = """
       {
         __type(name: "KindTest") {
           name
@@ -523,14 +523,14 @@ final class IntrospectionSuite extends CatsSuite {
       }
     """
 
-    val compiled = TestMapping.compiler.compile(text)
-    val res = TestMapping.interpreter.run(compiled.right.get, TestMapping.schema.queryType)
+    val res = TestMapping.compileAndRun(query)
     //println(res)
+
     assert(res == expected)
   }
 
   test("enumValues query") {
-    val text = """
+    val query = """
       {
         __type(name: "KindTest") {
           name
@@ -613,14 +613,14 @@ final class IntrospectionSuite extends CatsSuite {
       }
     """
 
-    val compiled = TestMapping.compiler.compile(text)
-    val res = TestMapping.interpreter.run(compiled.right.get, TestMapping.schema.queryType)
+    val res = TestMapping.compileAndRun(query)
     //println(res)
+
     assert(res == expected)
   }
 
   test("deprecation excluded") {
-    val text = """
+    val query = """
       {
         __type(name: "DeprecationTest") {
           fields {
@@ -694,14 +694,14 @@ final class IntrospectionSuite extends CatsSuite {
       }
     """
 
-    val compiled = TestMapping.compiler.compile(text)
-    val res = TestMapping.interpreter.run(compiled.right.get, TestMapping.schema.queryType)
+    val res = TestMapping.compileAndRun(query)
     //println(res)
+
     assert(res == expected)
   }
 
   test("deprecation included") {
-    val text = """
+    val query = """
       {
         __type(name: "DeprecationTest") {
           fields {
@@ -785,14 +785,14 @@ final class IntrospectionSuite extends CatsSuite {
       }
     """
 
-    val compiled = TestMapping.compiler.compile(text)
-    val res = TestMapping.interpreter.run(compiled.right.get, TestMapping.schema.queryType)
+    val res = TestMapping.compileAndRun(query)
     //println(res)
+
     assert(res == expected)
   }
 
   test("simple schema query") {
-    val text = """
+    val query = """
       {
         __schema {
           queryType { name }
@@ -846,15 +846,15 @@ final class IntrospectionSuite extends CatsSuite {
       }
     """
 
-    val compiled = TestMapping.compiler.compile(text)
-    val res0 = TestMapping.interpreter.run(compiled.right.get, TestMapping.schema.queryType)
+    val res0 = TestMapping.compileAndRun(query)
     val res = stripStandardTypes(res0)
     //println(res)
+
     assert(res == expected)
   }
 
   test("standard introspection query") {
-    val text = """
+    val query = """
       |query IntrospectionQuery {
       |  __schema {
       |    queryType { name }
@@ -1114,15 +1114,15 @@ final class IntrospectionSuite extends CatsSuite {
       }
     """
 
-    val compiled = SmallMapping.compiler.compile(text)
-    val res0 = SmallMapping.interpreter.run(compiled.right.get, SmallMapping.schema.queryType)
+    val res0 = SmallMapping.compileAndRun(query)
     val res = stripStandardTypes(res0)
     //println(res)
+
     assert(res == expected)
   }
 
   test("typename query") {
-    val text = """
+    val query = """
       {
         users {
           __typename
@@ -1146,14 +1146,14 @@ final class IntrospectionSuite extends CatsSuite {
       }
     """
 
-    val compiled = SmallMapping.compiler.compile(text)
-    val res = SmallMapping.interpreter.run(compiled.right.get, SmallMapping.schema.queryType)
+    val res = SmallMapping.compileAndRun(query)
     //println(res)
+
     assert(res == expected)
   }
 
   test("typename query with narrowing") {
-    val text = """
+    val query = """
       {
         profiles {
           __typename
@@ -1175,14 +1175,14 @@ final class IntrospectionSuite extends CatsSuite {
       }
     """
 
-    val compiled = SmallMapping.compiler.compile(text)
-    val res = SmallMapping.interpreter.run(compiled.right.get, SmallMapping.schema.queryType)
+    val res = SmallMapping.compileAndRun(query)
     //println(res)
+
     assert(res == expected)
   }
 
   test("mixed query") {
-    val text = """
+    val query = """
       {
         users {
           name
@@ -1222,14 +1222,14 @@ final class IntrospectionSuite extends CatsSuite {
       }
     """
 
-    val compiled = SmallMapping.compiler.compile(text)
-    val res = SmallMapping.interpreter.run(compiled.right.get, SmallMapping.schema.queryType)
+    val res = SmallMapping.compileAndRun(query)
     //println(res)
+
     assert(res == expected)
   }
 
   test("introspection disabled") {
-    val text = """
+    val query = """
       {
         __type(name: "User") {
           name
@@ -1243,13 +1243,24 @@ final class IntrospectionSuite extends CatsSuite {
       }
     """
 
-    val compiled = TestMapping.compiler.compile(text, None, useIntrospection = false)
+    val expected = json"""
+      {
+        "errors" : [
+          {
+            "message" : "Unknown field '__type' in 'Query'"
+          }
+        ]
+      }
+    """
+
+    val res = TestMapping.compileAndRun(query, useIntrospection = false)
     //println(res)
-    assert(compiled.isLeft)
+
+    assert(res == expected)
   }
 }
 
-object TestMapping extends SimpleMapping[Id] {
+object TestMapping extends Mapping[Id] {
   val schema =
     Schema(
       """

--- a/modules/core/src/test/scala/parser/ParserSpec.scala
+++ b/modules/core/src/test/scala/parser/ParserSpec.scala
@@ -11,7 +11,7 @@ import Ast._, OperationType._, OperationDefinition._, Selection._, Value._, Type
 
 final class ParserSuite extends CatsSuite {
   test("simple query") {
-    val text = """
+    val query = """
       query {
         character(id: 1000) {
           name
@@ -30,13 +30,13 @@ final class ParserSuite extends CatsSuite {
         )
       )
 
-    GraphQLParser.Document.parseOnly(text).option match {
+    GraphQLParser.Document.parseOnly(query).option match {
       case Some(List(q)) => assert(q == expected)
     }
   }
 
   test("multiple parameters (commas)") {
-    val text = """
+    val query = """
       query {
         wibble(foo: "a", bar: "b", baz: 3) {
           quux
@@ -61,13 +61,13 @@ final class ParserSuite extends CatsSuite {
         )
       )
 
-    GraphQLParser.Document.parseOnly(text).option match {
+    GraphQLParser.Document.parseOnly(query).option match {
       case Some(List(q)) => assert(q == expected)
     }
   }
 
   test("multiple parameters (no commas)") {
-    val text = """
+    val query = """
       query {
         wibble(foo: "a" bar: "b" baz: 3) {
           quux
@@ -92,13 +92,13 @@ final class ParserSuite extends CatsSuite {
         )
       )
 
-    GraphQLParser.Document.parseOnly(text).option match {
+    GraphQLParser.Document.parseOnly(query).option match {
       case Some(List(q)) => assert(q == expected)
     }
   }
 
   test("introspection query") {
-    val text = """
+    val query = """
       query IntrospectionQuery {
         __schema {
           queryType {
@@ -139,13 +139,13 @@ final class ParserSuite extends CatsSuite {
         )
       )
 
-    GraphQLParser.Document.parseOnly(text).option match {
+    GraphQLParser.Document.parseOnly(query).option match {
       case Some(List(q)) => assert(q == expected)
     }
   }
 
   test("shorthand query") {
-    val text = """
+    val query = """
       {
         hero(episode: NEWHOPE) {
           name
@@ -180,13 +180,13 @@ final class ParserSuite extends CatsSuite {
         )
       )
 
-    GraphQLParser.Document.parseOnly(text).option match {
+    GraphQLParser.Document.parseOnly(query).option match {
       case Some(List(q)) => assert(q == expected)
     }
   }
 
   test("field alias") {
-    val text = """
+    val query = """
       {
         user(id: 4) {
           id
@@ -211,13 +211,13 @@ final class ParserSuite extends CatsSuite {
         )
       )
 
-    GraphQLParser.Document.parseOnly(text).option match {
+    GraphQLParser.Document.parseOnly(query).option match {
       case Some(List(q)) => assert(q == expected)
     }
   }
 
   test("multiple root fields") {
-    val text = """
+    val query = """
       {
         luke: character(id: "1000") {
           name
@@ -242,13 +242,13 @@ final class ParserSuite extends CatsSuite {
         )
       )
 
-    GraphQLParser.Document.parseOnly(text).option match {
+    GraphQLParser.Document.parseOnly(query).option match {
       case Some(List(q)) => assert(q == expected)
     }
   }
 
   test("variables") {
-    val text = """
+    val query = """
       query getZuckProfile($devicePicSize: Int) {
         user(id: 4) {
           id
@@ -273,13 +273,13 @@ final class ParserSuite extends CatsSuite {
         )
       )
 
-    GraphQLParser.Document.parseOnly(text).option match {
+    GraphQLParser.Document.parseOnly(query).option match {
       case Some(List(q)) => assert(q == expected)
     }
   }
 
   test("comments") {
-    val text = """
+    val query = """
       #comment at start of document
       query IntrospectionQuery { #comment at end of line
         __schema {
@@ -324,7 +324,7 @@ final class ParserSuite extends CatsSuite {
         )
       )
 
-    GraphQLParser.Document.parseOnly(text).option match {
+    GraphQLParser.Document.parseOnly(query).option match {
       case Some(List(q)) => assert(q == expected)
     }
   }

--- a/modules/core/src/test/scala/sdl/SDLSpec.scala
+++ b/modules/core/src/test/scala/sdl/SDLSpec.scala
@@ -11,12 +11,12 @@ import Ast._, OperationType._, Type.{ List => _, _ }
 
 final class SDLSuite extends CatsSuite {
   test("parse schema definition") {
-    val text = """
-    schema {
-      query: MyQuery
-      mutation: MyMutation
-      subscription: MySubscription
-    }
+    val schema = """
+      schema {
+        query: MyQuery
+        mutation: MyMutation
+        subscription: MySubscription
+      }
     """
 
     val expected =
@@ -31,13 +31,13 @@ final class SDLSuite extends CatsSuite {
         )
       )
 
-    val res = GraphQLParser.Document.parseOnly(text).option
+    val res = GraphQLParser.Document.parseOnly(schema).option
     //println(res)
     assert(res == Some(expected))
   }
 
   test("parse scalar type definition") {
-    val text = """
+    val schema = """
       "A scalar type"
       scalar Url
 
@@ -51,13 +51,13 @@ final class SDLSuite extends CatsSuite {
         ScalarTypeDefinition(Name("Time"), Some("A scalar type"), List(Directive(Name("deprecated"), Nil)))
       )
 
-    val res = GraphQLParser.Document.parseOnly(text).option
+    val res = GraphQLParser.Document.parseOnly(schema).option
     //println(res)
     assert(res == Some(expected))
   }
 
   test("parse object type definition") {
-    val text = """
+    val schema = """
       "An object type"
       type Query {
         posts: [Post]
@@ -83,13 +83,13 @@ final class SDLSuite extends CatsSuite {
         )
       )
 
-    val res = GraphQLParser.Document.parseOnly(text).option
+    val res = GraphQLParser.Document.parseOnly(schema).option
     //println(res)
     assert(res == Some(expected))
   }
 
   test("parse interface type definition") {
-    val text = """
+    val schema = """
       "An interface type"
       interface Post {
         "A field"
@@ -115,13 +115,13 @@ final class SDLSuite extends CatsSuite {
         )
       )
 
-    val res = GraphQLParser.Document.parseOnly(text).option
+    val res = GraphQLParser.Document.parseOnly(schema).option
     //println(res)
     assert(res == Some(expected))
   }
 
   test("parse union type definition") {
-    val text = """
+    val schema = """
       "A union type"
       union ThisOrThat = This | That
     """
@@ -136,13 +136,13 @@ final class SDLSuite extends CatsSuite {
         )
       )
 
-    val res = GraphQLParser.Document.parseOnly(text).option
+    val res = GraphQLParser.Document.parseOnly(schema).option
     //println(res)
     assert(res == Some(expected))
   }
 
   test("parse enum type definition") {
-    val text = """
+    val schema = """
       "An enum type"
       enum Direction {
         NORTH
@@ -164,13 +164,13 @@ final class SDLSuite extends CatsSuite {
         )
       )
 
-    val res = GraphQLParser.Document.parseOnly(text).option
+    val res = GraphQLParser.Document.parseOnly(schema).option
     //println(res)
     assert(res == Some(expected))
   }
 
   test("parse input object type definition") {
-    val text = """
+    val schema = """
       "An input object type"
       input Point2D {
         x: Float
@@ -189,13 +189,13 @@ final class SDLSuite extends CatsSuite {
         )
       )
 
-    val res = GraphQLParser.Document.parseOnly(text).option
+    val res = GraphQLParser.Document.parseOnly(schema).option
     //println(res)
     assert(res == Some(expected))
   }
 
   test("parse directive definition") {
-    val text = """
+    val schema = """
       "A directive"
       directive @delegateField(name: String!) repeatable on OBJECT | INTERFACE
     """
@@ -213,13 +213,13 @@ final class SDLSuite extends CatsSuite {
         )
       )
 
-    val res = GraphQLParser.Document.parseOnly(text).option
+    val res = GraphQLParser.Document.parseOnly(schema).option
     //println(res)
     assert(res == Some(expected))
   }
 
   test("deserialize schema (1)") {
-    val text =
+    val schema =
     """|type Author {
        |  id: Int!
        |  firstName: String
@@ -237,14 +237,14 @@ final class SDLSuite extends CatsSuite {
        |  author(id: Int! = 23): Author
        |}""".stripMargin
 
-    val res = SchemaParser.parseText(text)
+    val res = SchemaParser.parseText(schema)
     val ser = res.map(_.toString)
     //println(ser.right.get)
-    assert(ser.right.get == text)
+    assert(ser.right.get == schema)
   }
 
   test("deserialize schema (2)") {
-    val text =
+    val schema =
     """|type Query {
        |  hero(episode: Episode!): Character!
        |  character(id: ID!): Character
@@ -279,14 +279,14 @@ final class SDLSuite extends CatsSuite {
        |  primaryFunction: String
        |}""".stripMargin
 
-    val res = SchemaParser.parseText(text)
+    val res = SchemaParser.parseText(schema)
     val ser = res.map(_.toString)
     //println(ser.right.get)
-    assert(ser.right.get == text)
+    assert(ser.right.get == schema)
   }
 
   test("deserialize schema (3)") {
-    val text =
+    val schema =
     """|type Query {
        |  whatsat(p: Point!): ThisOrThat!
        |}
@@ -302,9 +302,9 @@ final class SDLSuite extends CatsSuite {
        |  y: Int
        |}""".stripMargin
 
-    val res = SchemaParser.parseText(text)
+    val res = SchemaParser.parseText(schema)
     val ser = res.map(_.toString)
     //println(ser.right.get)
-    assert(ser.right.get == text)
+    assert(ser.right.get == schema)
   }
 }

--- a/modules/core/src/test/scala/starwars/StarWarsSpec.scala
+++ b/modules/core/src/test/scala/starwars/StarWarsSpec.scala
@@ -27,8 +27,7 @@ final class StarWarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = StarWarsMapping.compiler.compile(query).right.get
-    val res = StarWarsMapping.interpreter.run(compiledQuery, StarWarsMapping.schema.queryType)
+    val res = StarWarsMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -55,8 +54,7 @@ final class StarWarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = StarWarsMapping.compiler.compile(query).right.get
-    val res = StarWarsMapping.interpreter.run(compiledQuery, StarWarsMapping.schema.queryType)
+    val res = StarWarsMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -98,8 +96,7 @@ final class StarWarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = StarWarsMapping.compiler.compile(query).right.get
-    val res = StarWarsMapping.interpreter.run(compiledQuery, StarWarsMapping.schema.queryType)
+    val res = StarWarsMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -167,8 +164,7 @@ final class StarWarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = StarWarsMapping.compiler.compile(query).right.get
-    val res = StarWarsMapping.interpreter.run(compiledQuery, StarWarsMapping.schema.queryType)
+    val res = StarWarsMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -193,8 +189,7 @@ final class StarWarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = StarWarsMapping.compiler.compile(query).right.get
-    val res = StarWarsMapping.interpreter.run(compiledQuery, StarWarsMapping.schema.queryType)
+    val res = StarWarsMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -219,8 +214,8 @@ final class StarWarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = StarWarsMapping.compiler.compile(query).right.get
-    val res = StarWarsMapping.interpreter.run(compiledQuery, StarWarsMapping.schema.queryType)
+    val res = StarWarsMapping.compileAndRun(query)
+    //println(res)
 
     assert(res == expected)
   }
@@ -250,8 +245,7 @@ final class StarWarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = StarWarsMapping.compiler.compile(query).right.get
-    val res = StarWarsMapping.interpreter.run(compiledQuery, StarWarsMapping.schema.queryType)
+    val res = StarWarsMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -314,8 +308,7 @@ final class StarWarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = StarWarsMapping.compiler.compile(query).right.get
-    val res = StarWarsMapping.interpreter.run(compiledQuery, StarWarsMapping.schema.queryType)
+    val res = StarWarsMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)

--- a/modules/doobie/src/test/resources/logback-test.xml
+++ b/modules/doobie/src/test/resources/logback-test.xml
@@ -8,4 +8,8 @@
   <root level="WARN">
     <appender-ref ref="STDOUT" />
   </root>
+
+  <logger name="utils.DatabaseSuite" level="INFO" additivity="false">
+    <appender-ref ref="STDOUT" />
+  </logger>
 </configuration>

--- a/modules/doobie/src/test/scala/coalesce/CoalesceData.scala
+++ b/modules/doobie/src/test/scala/coalesce/CoalesceData.scala
@@ -5,11 +5,11 @@ package coalesce
 
 import cats.effect.Sync
 import doobie.Transactor
-import io.chrisdavenport.log4cats.Logger
 
 import edu.gemini.grackle._, doobie._
 
-class CoalesceMapping[F[_]: Sync](val transactor: Transactor[F], val logger: Logger[F]) extends DoobieMapping[F] {
+trait CoalesceMapping[F[_]] extends DoobieMapping[F] {
+
   val schema =
     Schema(
       """
@@ -82,7 +82,7 @@ class CoalesceMapping[F[_]: Sync](val transactor: Transactor[F], val logger: Log
     )
 }
 
-object CoalesceMapping {
-  def fromTransactor[F[_] : Sync : Logger](transactor: Transactor[F]): CoalesceMapping[F] =
-    new CoalesceMapping[F](transactor, Logger[F])
+object CoalesceMapping extends TracedDoobieMappingCompanion {
+  def mkMapping[F[_]: Sync](transactor: Transactor[F], monitor: DoobieMonitor[F]): CoalesceMapping[F] =
+    new DoobieMapping(transactor, monitor) with CoalesceMapping[F]
 }

--- a/modules/doobie/src/test/scala/composed/ComposedWorldSpec.scala
+++ b/modules/doobie/src/test/scala/composed/ComposedWorldSpec.scala
@@ -39,8 +39,7 @@ final class ComposedWorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -95,8 +94,7 @@ final class ComposedWorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -135,8 +133,7 @@ final class ComposedWorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)

--- a/modules/doobie/src/test/scala/embedding/EmbeddingData.scala
+++ b/modules/doobie/src/test/scala/embedding/EmbeddingData.scala
@@ -5,11 +5,10 @@ package embedding
 
 import cats.effect.Sync
 import doobie.Transactor
-import io.chrisdavenport.log4cats.Logger
 
 import edu.gemini.grackle._, doobie._
 
-class EmbeddingMapping[F[_]: Sync](val transactor: Transactor[F], val logger: Logger[F]) extends DoobieMapping[F] {
+trait EmbeddingMapping[F[_]] extends DoobieMapping[F] {
   val schema =
     Schema(
       """
@@ -118,7 +117,7 @@ class EmbeddingMapping[F[_]: Sync](val transactor: Transactor[F], val logger: Lo
     )
 }
 
-object EmbeddingMapping {
-  def fromTransactor[F[_] : Sync : Logger](transactor: Transactor[F]): EmbeddingMapping[F] =
-    new EmbeddingMapping[F](transactor, Logger[F])
+object EmbeddingMapping extends DoobieMappingCompanion {
+  def mkMapping[F[_] : Sync](transactor: Transactor[F], monitor: DoobieMonitor[F]): EmbeddingMapping[F] =
+    new DoobieMapping(transactor, monitor) with EmbeddingMapping[F]
 }

--- a/modules/doobie/src/test/scala/embedding/EmbeddingSpec.scala
+++ b/modules/doobie/src/test/scala/embedding/EmbeddingSpec.scala
@@ -53,8 +53,7 @@ final class EmbeddingSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -103,8 +102,7 @@ final class EmbeddingSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -183,8 +181,7 @@ final class EmbeddingSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -309,8 +306,7 @@ final class EmbeddingSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)

--- a/modules/doobie/src/test/scala/interfaces/InterfacesData.scala
+++ b/modules/doobie/src/test/scala/interfaces/InterfacesData.scala
@@ -7,12 +7,11 @@ import cats.effect.Sync
 import cats.kernel.Eq
 import doobie.Transactor
 import doobie.util.meta.Meta
-import edu.gemini.grackle._
-import edu.gemini.grackle.doobie._
-import io.chrisdavenport.log4cats.Logger
 import io.circe.Encoder
 
-class InterfacesMapping[F[_]: Sync](val transactor: Transactor[F], val logger: Logger[F]) extends DoobieMapping[F] {
+import edu.gemini.grackle._, doobie._
+
+trait InterfacesMapping[F[_]] extends DoobieMapping[F] {
   val schema =
     Schema(
       """
@@ -149,9 +148,9 @@ class InterfacesMapping[F[_]: Sync](val transactor: Transactor[F], val logger: L
   }
 }
 
-object InterfacesMapping {
-  def fromTransactor[F[_] : Sync : Logger](transactor: Transactor[F]): InterfacesMapping[F] =
-    new InterfacesMapping[F](transactor, Logger[F])
+object InterfacesMapping extends DoobieMappingCompanion {
+  def mkMapping[F[_] : Sync](transactor: Transactor[F], monitor: DoobieMonitor[F]): InterfacesMapping[F] =
+    new DoobieMapping(transactor, monitor) with InterfacesMapping[F]
 }
 
 sealed trait EntityType extends Product with Serializable

--- a/modules/doobie/src/test/scala/interfaces/InterfacesSpec.scala
+++ b/modules/doobie/src/test/scala/interfaces/InterfacesSpec.scala
@@ -88,8 +88,7 @@ final class InterfacesSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -157,8 +156,7 @@ final class InterfacesSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -219,8 +217,7 @@ final class InterfacesSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -283,8 +280,7 @@ final class InterfacesSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -376,8 +372,7 @@ final class InterfacesSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -470,8 +465,7 @@ final class InterfacesSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)

--- a/modules/doobie/src/test/scala/jsonb/JsonbData.scala
+++ b/modules/doobie/src/test/scala/jsonb/JsonbData.scala
@@ -6,13 +6,12 @@ package jsonb
 import cats.effect.Sync
 import cats.implicits._
 import doobie.Transactor
-import io.chrisdavenport.log4cats.Logger
 
 import edu.gemini.grackle._, doobie._
 import Query._, Predicate._, Value._
 import QueryCompiler._
 
-class JsonbMapping[F[_]: Sync](val transactor: Transactor[F], val logger: Logger[F]) extends DoobieMapping[F] {
+trait JsonbMapping[F[_]] extends DoobieMapping[F] {
   val schema =
     Schema(
       """
@@ -89,8 +88,7 @@ class JsonbMapping[F[_]: Sync](val transactor: Transactor[F], val logger: Logger
   ))
 }
 
-object JsonbMapping {
-  def fromTransactor[F[_] : Sync : Logger](transactor: Transactor[F]): JsonbMapping[F] =
-    new JsonbMapping[F](transactor, Logger[F])
+object JsonbMapping extends DoobieMappingCompanion {
+  def mkMapping[F[_] : Sync](transactor: Transactor[F], monitor: DoobieMonitor[F]): JsonbMapping[F] =
+    new DoobieMapping(transactor, monitor) with JsonbMapping[F]
 }
-

--- a/modules/doobie/src/test/scala/jsonb/JsonbSpec.scala
+++ b/modules/doobie/src/test/scala/jsonb/JsonbSpec.scala
@@ -44,8 +44,7 @@ final class JsonbSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -86,8 +85,7 @@ final class JsonbSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -122,8 +120,7 @@ final class JsonbSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -187,8 +184,7 @@ final class JsonbSpec extends DatabaseSuite {
       }
       """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -234,8 +230,7 @@ final class JsonbSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -284,8 +279,7 @@ final class JsonbSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)

--- a/modules/doobie/src/test/scala/scalars/MovieData.scala
+++ b/modules/doobie/src/test/scala/scalars/MovieData.scala
@@ -16,7 +16,6 @@ import doobie.implicits.legacy.localdate._
 import doobie.implicits.legacy.instant._
 import doobie.postgres.implicits.UuidType
 import doobie.util.meta.Meta
-import io.chrisdavenport.log4cats.Logger
 import io.circe.Encoder
 
 import edu.gemini.grackle._, doobie._
@@ -95,7 +94,7 @@ object MovieData {
     Order.fromComparable[Duration]
 }
 
-class MovieMapping[F[_]: Sync](val transactor: Transactor[F], val logger: Logger[F]) extends DoobieMapping[F] {
+trait MovieMapping[F[_]] extends DoobieMapping[F] {
   import MovieData._
 
   val schema =
@@ -282,7 +281,7 @@ class MovieMapping[F[_]: Sync](val transactor: Transactor[F], val logger: Logger
   ))
 }
 
-object MovieMapping {
-  def fromTransactor[F[_] : Sync : Logger](transactor: Transactor[F]): MovieMapping[F] =
-    new MovieMapping[F](transactor, Logger[F])
+object MovieMapping extends DoobieMappingCompanion {
+  def mkMapping[F[_] : Sync](transactor: Transactor[F], monitor: DoobieMonitor[F]): MovieMapping[F] =
+    new DoobieMapping(transactor, monitor) with MovieMapping[F]
 }

--- a/modules/doobie/src/test/scala/scalars/MovieSpec.scala
+++ b/modules/doobie/src/test/scala/scalars/MovieSpec.scala
@@ -41,8 +41,7 @@ final class MovieSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -79,8 +78,7 @@ final class MovieSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -117,8 +115,7 @@ final class MovieSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -151,8 +148,7 @@ final class MovieSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -189,8 +185,7 @@ final class MovieSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -227,8 +222,7 @@ final class MovieSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -273,8 +267,7 @@ final class MovieSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -311,8 +304,7 @@ final class MovieSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -345,8 +337,7 @@ final class MovieSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -376,8 +367,7 @@ final class MovieSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -410,8 +400,7 @@ final class MovieSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)

--- a/modules/doobie/src/test/scala/world/WorldData.scala
+++ b/modules/doobie/src/test/scala/world/WorldData.scala
@@ -6,14 +6,13 @@ package world
 import cats.effect.Sync
 import cats.implicits._
 import doobie.Transactor
-import io.chrisdavenport.log4cats.Logger
 
 import edu.gemini.grackle._, doobie._
 import Query._, Predicate._, Value._
 import QueryCompiler._
 import DoobiePredicate._
 
-class WorldMapping[F[_]: Sync](val transactor: Transactor[F], val logger: Logger[F]) extends DoobieMapping[F] {
+trait WorldMapping[F[_]] extends DoobieMapping[F] {
   val schema =
     Schema(
       """
@@ -171,7 +170,7 @@ class WorldMapping[F[_]: Sync](val transactor: Transactor[F], val logger: Logger
   ))
 }
 
-object WorldMapping {
-  def fromTransactor[F[_] : Sync : Logger](transactor: Transactor[F]): WorldMapping[F] =
-    new WorldMapping[F](transactor, Logger[F])
+object WorldMapping extends DoobieMappingCompanion {
+  def mkMapping[F[_]: Sync](transactor: Transactor[F], monitor: DoobieMonitor[F]): WorldMapping[F] =
+    new DoobieMapping(transactor, monitor) with WorldMapping[F]
 }

--- a/modules/doobie/src/test/scala/world/WorldSpec.scala
+++ b/modules/doobie/src/test/scala/world/WorldSpec.scala
@@ -22,8 +22,7 @@ final class WorldSpec extends DatabaseSuite {
 
     val expected = 239
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     val resSize = root.data.countries.arr.getOption(res).map(_.size)
@@ -50,8 +49,7 @@ final class WorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -124,8 +122,7 @@ final class WorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -156,8 +153,7 @@ final class WorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -201,8 +197,7 @@ final class WorldSpec extends DatabaseSuite {
     }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -289,8 +284,7 @@ final class WorldSpec extends DatabaseSuite {
     }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -439,8 +433,7 @@ final class WorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -493,8 +486,7 @@ final class WorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -557,8 +549,7 @@ final class WorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -631,8 +622,7 @@ final class WorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -719,8 +709,7 @@ final class WorldSpec extends DatabaseSuite {
     }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -748,8 +737,7 @@ final class WorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -767,8 +755,7 @@ final class WorldSpec extends DatabaseSuite {
         }
       }
     """
-    val cquery    = mapping.compiler.compile(query).right.get
-    val json      = mapping.interpreter.run(cquery, mapping.schema.queryType).unsafeRunSync
+    val json      = mapping.compileAndRun(query).unsafeRunSync
     val countries = root.data.countries.arr.getOption(json).get
     val map       = countries.map(j => root.name.string.getOption(j).get -> root.cities.arr.getOption(j).get.length).toMap
     assert(map("Kazakstan")  == 21)
@@ -795,8 +782,7 @@ final class WorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -823,8 +809,7 @@ final class WorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query)
-    val res = mapping.interpreter.run(compiledQuery.right.get, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -851,8 +836,7 @@ final class WorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -879,8 +863,7 @@ final class WorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -907,8 +890,7 @@ final class WorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -949,8 +931,7 @@ final class WorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -983,8 +964,7 @@ final class WorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)
@@ -1021,8 +1001,7 @@ final class WorldSpec extends DatabaseSuite {
       }
     """
 
-    val compiledQuery = mapping.compiler.compile(query).right.get
-    val res = mapping.interpreter.run(compiledQuery, mapping.schema.queryType).unsafeRunSync
+    val res = mapping.compileAndRun(query).unsafeRunSync
     //println(res)
 
     assert(res == expected)

--- a/modules/generic/src/main/scala/genericmapping.scala
+++ b/modules/generic/src/main/scala/genericmapping.scala
@@ -17,7 +17,7 @@ import shapeless.ops.record.Keys
 import QueryInterpreter.{ mkErrorResult, mkOneError }
 import ShapelessUtils._
 
-trait GenericMapping[F[_]] extends AbstractMapping[Monad, F] {
+abstract class GenericMapping[F[_]: Monad] extends Mapping[F] {
   case class GenericRoot[T](val tpe: Type, val fieldName: String, t: T, cb: () => CursorBuilder[T]) extends RootMapping {
     lazy val cursorBuilder = cb()
     def cursor(query: Query): F[Result[Cursor]] = cursorBuilder.build(Nil, t).pure[F]

--- a/modules/generic/src/test/scala/derivation.scala
+++ b/modules/generic/src/test/scala/derivation.scala
@@ -335,8 +335,7 @@ final class DerivationSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = StarWarsMapping.compiler.compile(query).right.get
-    val res = StarWarsMapping.interpreter.run(compiledQuery, StarWarsMapping.schema.queryType)
+    val res = StarWarsMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -363,8 +362,7 @@ final class DerivationSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = StarWarsMapping.compiler.compile(query).right.get
-    val res = StarWarsMapping.interpreter.run(compiledQuery, StarWarsMapping.schema.queryType)
+    val res = StarWarsMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -406,8 +404,7 @@ final class DerivationSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = StarWarsMapping.compiler.compile(query).right.get
-    val res = StarWarsMapping.interpreter.run(compiledQuery, StarWarsMapping.schema.queryType)
+    val res = StarWarsMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -458,8 +455,7 @@ final class DerivationSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = StarWarsMapping.compiler.compile(query).right.get
-    val res = StarWarsMapping.interpreter.run(compiledQuery, StarWarsMapping.schema.queryType)
+    val res = StarWarsMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)

--- a/modules/generic/src/test/scala/recursion.scala
+++ b/modules/generic/src/test/scala/recursion.scala
@@ -112,8 +112,7 @@ final class MutualRecursionSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = MutualRecursionMapping.compiler.compile(query).right.get
-    val res = MutualRecursionMapping.interpreter.run(compiledQuery, MutualRecursionMapping.schema.queryType)
+    val res = MutualRecursionMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -146,8 +145,7 @@ final class MutualRecursionSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = MutualRecursionMapping.compiler.compile(query).right.get
-    val res = MutualRecursionMapping.interpreter.run(compiledQuery, MutualRecursionMapping.schema.queryType)
+    val res = MutualRecursionMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -184,8 +182,7 @@ final class MutualRecursionSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = MutualRecursionMapping.compiler.compile(query).right.get
-    val res = MutualRecursionMapping.interpreter.run(compiledQuery, MutualRecursionMapping.schema.queryType)
+    val res = MutualRecursionMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -230,8 +227,7 @@ final class MutualRecursionSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = MutualRecursionMapping.compiler.compile(query).right.get
-    val res = MutualRecursionMapping.interpreter.run(compiledQuery, MutualRecursionMapping.schema.queryType)
+    val res = MutualRecursionMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -262,8 +258,7 @@ final class MutualRecursionSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = MutualRecursionMapping.compiler.compile(query).right.get
-    val res = MutualRecursionMapping.interpreter.run(compiledQuery, MutualRecursionMapping.schema.queryType)
+    val res = MutualRecursionMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -302,8 +297,7 @@ final class MutualRecursionSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = MutualRecursionMapping.compiler.compile(query).right.get
-    val res = MutualRecursionMapping.interpreter.run(compiledQuery, MutualRecursionMapping.schema.queryType)
+    val res = MutualRecursionMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)

--- a/modules/generic/src/test/scala/scalars.scala
+++ b/modules/generic/src/test/scala/scalars.scala
@@ -255,8 +255,7 @@ final class DerivedScalarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = MovieMapping.compiler.compile(query).right.get
-    val res = MovieMapping.interpreter.run(compiledQuery, MovieMapping.QueryType)
+    val res = MovieMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -293,8 +292,7 @@ final class DerivedScalarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = MovieMapping.compiler.compile(query).right.get
-    val res = MovieMapping.interpreter.run(compiledQuery, MovieMapping.QueryType)
+    val res = MovieMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -331,8 +329,7 @@ final class DerivedScalarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = MovieMapping.compiler.compile(query).right.get
-    val res = MovieMapping.interpreter.run(compiledQuery, MovieMapping.QueryType)
+    val res = MovieMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -365,8 +362,7 @@ final class DerivedScalarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = MovieMapping.compiler.compile(query).right.get
-    val res = MovieMapping.interpreter.run(compiledQuery, MovieMapping.QueryType)
+    val res = MovieMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -403,8 +399,7 @@ final class DerivedScalarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = MovieMapping.compiler.compile(query).right.get
-    val res = MovieMapping.interpreter.run(compiledQuery, MovieMapping.QueryType)
+    val res = MovieMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)
@@ -441,8 +436,7 @@ final class DerivedScalarsSpec extends CatsSuite {
       }
     """
 
-    val compiledQuery = MovieMapping.compiler.compile(query).right.get
-    val res = MovieMapping.interpreter.run(compiledQuery, MovieMapping.QueryType)
+    val res = MovieMapping.compileAndRun(query)
     //println(res)
 
     assert(res == expected)


### PR DESCRIPTION
+ Added `DoobieMonitor` trait and threaded through `DoobieMapping`.
+ Added `QueryExecutor` trait to support polymorphism in the result type and to eliminate compile/run boilerplate.
+ Added `DoobieMappingCompanion` trait to factor out creation boilerplate.
+ Converted most mapping traits to abstract classes for simpler threading of monad instances.