### PR TITLE
SQL staging fixes

### DIFF
--- a/modules/sql/src/test/scala/SqlWorldSpec.scala
+++ b/modules/sql/src/test/scala/SqlWorldSpec.scala
@@ -718,6 +718,48 @@ trait SqlWorldSpec extends AnyFunSuite {
     assert(res == expected)
   }
 
+  test("recursive query (7)") {
+    val query = """
+      query {
+        cities(namePattern: "Monte-Carlo") {
+          name
+          country {
+            cities {
+              name
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "cities" : [
+            {
+              "name" : "Monte-Carlo",
+              "country" : {
+                "cities" : [
+                  {
+                    "name" : "Monte-Carlo"
+                  },
+                  {
+                    "name" : "Monaco-Ville"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync
+    //println(res)
+
+    assert(res == expected)
+  }
+
   test("country with no cities") {
     val query = """
       query {


### PR DESCRIPTION
Some fixes for grouping across stages where one or more groups might be empty or where we join through an object but don't explicitly refer to any of its fields.