### PR TITLE
Validate subselections and non-empty types

### DIFF
--- a/modules/core/src/main/scala/query.scala
+++ b/modules/core/src/main/scala/query.scala
@@ -207,6 +207,10 @@ object Query {
     }
   }
 
+  case object Skipped extends Query {
+    def render = "<skipped>"
+  }
+
   /** The terminal query */
   case object Empty extends Query {
     def render = ""

--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -573,7 +573,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
           case GroupBy(_, child) =>
             loop(child, path, obj, acc)
 
-          case Empty | Query.Component(_, _, _) | (_: Introspect) | (_: Defer) | (_: UntypedNarrow) | (_: Skip) => acc
+          case Empty | Skipped | Query.Component(_, _, _) | (_: Introspect) | (_: Defer) | (_: UntypedNarrow) | (_: Skip) => acc
         }
       }
 
@@ -790,6 +790,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
 
           case s: Skip                 => mkErrorResult(s"Unexpected Skip ${s.render}")
           case n: UntypedNarrow        => mkErrorResult(s"Unexpected UntypeNarrow ${n.render}")
+          case Skipped                 => mkErrorResult(s"Unexpected Skipped")
         }
       }
 


### PR DESCRIPTION
+ Reject subselections from leaf types
+ Enforce that subselections from non-leaf types are non-empty
+ Ensure that object/interface/union/enum and input object types define at least one member.