### PR TITLE
Added query minimizer utility and parser fixes

### DIFF
--- a/modules/core/src/main/scala/ast.scala
+++ b/modules/core/src/main/scala/ast.scala
@@ -75,7 +75,6 @@ object Ast {
     name:         Name,
     tpe:          Type,
     defaultValue: Option[Value],
-    directives:   List[Directive]
   )
 
   sealed trait Value

--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -61,7 +61,7 @@ object QueryParser {
     case Operation(opType, _, vds, _, sels) =>
       val q = parseSelections(sels, None, fragments)
       val vs = vds.map {
-        case VariableDefinition(nme, tpe, _, _) => UntypedVarDef(nme.value, tpe, None)
+        case VariableDefinition(nme, tpe, _) => UntypedVarDef(nme.value, tpe, None)
       }
       q.map(q => 
         opType match {
@@ -167,6 +167,129 @@ object QueryParser {
         }.map(ObjectValue)
     }
   }
+}
+
+object QueryMinimizer {
+  import Ast._
+
+  def minimizeText(text: String): Either[String, String] = {
+    for {
+      doc <- GraphQLParser.Document.parseOnly(text).either
+    } yield minimizeDocument(doc)
+  }
+
+  def minimizeDocument(doc: Document): String = {
+    import OperationDefinition._
+    import OperationType._
+    import Selection._
+    import Value._
+
+    def renderDefinition(defn: Definition): String =
+      defn match {
+        case e: ExecutableDefinition => renderExecutableDefinition(e)
+        case _ => ""
+      }
+
+    def renderExecutableDefinition(ex: ExecutableDefinition): String =
+      ex match {
+        case op: OperationDefinition => renderOperationDefinition(op)
+        case frag: FragmentDefinition => renderFragmentDefinition(frag)
+      }
+
+    def renderOperationDefinition(op: OperationDefinition): String =
+      op match {
+        case qs: QueryShorthand => renderSelectionSet(qs.selectionSet)
+        case op: Operation => renderOperation(op)
+      }
+
+    def renderOperation(op: Operation): String =
+      renderOperationType(op.operationType) +
+      op.name.map(nme => s" ${nme.value}").getOrElse("") +
+      renderVariableDefns(op.variables)+
+      renderDirectives(op.directives)+
+      renderSelectionSet(op.selectionSet)
+
+    def renderOperationType(op: OperationType): String =
+      op match {
+        case Query => "query"
+        case Mutation => "mutation"
+        case Subscription => "subscription"
+      }
+
+    def renderDirectives(dirs: List[Directive]): String =
+      dirs.map { case Directive(name, args) => s"@${name.value}${renderArguments(args)}" }.mkString
+
+    def renderVariableDefns(vars: List[VariableDefinition]): String =
+      vars match {
+        case Nil => ""
+        case _ =>
+          vars.map {
+            case VariableDefinition(name, tpe, default) =>
+              s"$$${name.value}:${tpe.name}${default.map(v => s"=${renderValue(v)}").getOrElse("")}"
+          }.mkString("(", ",", ")")
+      }
+
+    def renderSelectionSet(sels: List[Selection]): String =
+      sels match {
+        case Nil => ""
+        case _ => sels.map(renderSelection).mkString("{", ",", "}")
+      }
+
+    def renderSelection(sel: Selection): String =
+      sel match {
+        case f: Field => renderField(f)
+        case s: FragmentSpread => renderFragmentSpread(s)
+        case i: InlineFragment => renderInlineFragment(i)
+      }
+
+    def renderField(f: Field) = {
+      f.alias.map(a => s"${a.value}:").getOrElse("")+
+      f.name.value+
+      renderArguments(f.arguments)+
+      renderDirectives(f.directives)+
+      renderSelectionSet(f.selectionSet)
+    }
+
+    def renderArguments(args: List[(Name, Value)]): String =
+      args match {
+        case Nil => ""
+        case _ => args.map { case (n, v) => s"${n.value}:${renderValue(v)}" }.mkString("(", ",", ")")
+      }
+
+    def renderInputObject(args: List[(Name, Value)]): String =
+      args match {
+        case Nil => ""
+        case _ => args.map { case (n, v) => s"${n.value}:${renderValue(v)}" }.mkString("{", ",", "}")
+      }
+
+    def renderTypeCondition(tpe: Type): String =
+      s"on ${tpe.name}"
+
+    def renderFragmentDefinition(frag: FragmentDefinition): String =
+      s"fragment ${frag.name.value} ${renderTypeCondition(frag.typeCondition)}${renderDirectives(frag.directives)}${renderSelectionSet(frag.selectionSet)}"
+
+    def renderFragmentSpread(spread: FragmentSpread): String =
+      s"...${spread.name.value}${renderDirectives(spread.directives)}"
+
+    def renderInlineFragment(frag: InlineFragment): String =
+      s"...${frag.typeCondition.map(renderTypeCondition).getOrElse("")}${renderDirectives(frag.directives)}${renderSelectionSet(frag.selectionSet)}"
+
+    def renderValue(v: Value): String =
+      v match {
+        case Variable(name) => s"$$${name.value}"
+        case IntValue(value) => value.toString
+        case FloatValue(value) => value.toString
+        case StringValue(value) => s""""$value""""
+        case BooleanValue(value) => value.toString
+        case NullValue => "null"
+        case EnumValue(name) => name.value
+        case ListValue(values) => values.map(renderValue).mkString("[", ",", "]")
+        case ObjectValue(fields) => renderInputObject(fields)
+      }
+
+    doc.map(renderDefinition).mkString(",")
+  }
+
 }
 
 /**

--- a/modules/core/src/test/scala/arb/AstArb.scala
+++ b/modules/core/src/test/scala/arb/AstArb.scala
@@ -93,8 +93,7 @@ trait AstArb {
         variable     <- arbitrary[Name]
         tpe          <- arbitrary[Type]
         defaultValue <- option(genValueForType(tpe))
-        directives   <- shortListOf(arbitrary[Directive])
-      } yield VariableDefinition(variable, tpe, defaultValue, directives)
+      } yield VariableDefinition(variable, tpe, defaultValue)
     }
 
   implicit lazy val arbSelectionFragmentSpread: Arbitrary[Selection.FragmentSpread] =

--- a/modules/core/src/test/scala/minimizer/MinimizerSpec.scala
+++ b/modules/core/src/test/scala/minimizer/MinimizerSpec.scala
@@ -1,0 +1,632 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package minimizer
+
+import atto.Atto._
+import cats.tests.CatsSuite
+import org.scalatest.Assertion
+
+import edu.gemini.grackle.{ GraphQLParser, QueryMinimizer }
+
+final class MinimizerSuite extends CatsSuite {
+  def run(query: String, expected: String, echo: Boolean = false): Assertion = {
+    val Right(minimized) = QueryMinimizer.minimizeText(query)
+    if (echo)
+      println(minimized)
+
+    assert(minimized == expected)
+
+    val Some(parsed0) = GraphQLParser.Document.parseOnly(query).option
+    val Some(parsed1) = GraphQLParser.Document.parseOnly(minimized).option
+
+    assert(parsed0 == parsed1)
+  }
+
+  test("minimize simple query") {
+    val query = """
+      query {
+        character(id: 1000) {
+          name
+        }
+      }
+    """
+
+    val expected = """query{character(id:1000){name}}"""
+
+    run(query, expected)
+  }
+
+  test("minimize multiple parameters (commas)") {
+    val query = """
+      query {
+        wibble(foo: "a", bar: "b", baz: 3) {
+          quux
+        }
+      }
+    """
+
+    val expected = """query{wibble(foo:"a",bar:"b",baz:3){quux}}"""
+
+    run(query, expected)
+  }
+
+  test("minimize multiple parameters (no commas)") {
+    val query = """
+      query {
+        wibble(foo: "a" bar: "b" baz: 3) {
+          quux
+        }
+      }
+    """
+
+    val expected = """query{wibble(foo:"a",bar:"b",baz:3){quux}}"""
+
+    run(query, expected)
+  }
+
+  test("minimize introspection query") {
+    val query = """
+      query IntrospectionQuery {
+        __schema {
+          queryType {
+            name
+          }
+          mutationType {
+            name
+          }
+          subscriptionType {
+            name
+          }
+        }
+      }
+    """
+
+    val expected = """query IntrospectionQuery{__schema{queryType{name},mutationType{name},subscriptionType{name}}}"""
+
+    run(query, expected)
+  }
+
+  test("minimize shorthand query") {
+    val query = """
+      {
+        hero(episode: NEWHOPE) {
+          name
+          friends {
+            name
+            friends {
+              name
+            }
+          }
+        }
+      }
+    """
+
+    val expected = """{hero(episode:NEWHOPE){name,friends{name,friends{name}}}}"""
+
+    run(query, expected)
+  }
+
+  test("minimize field alias") {
+    val query = """
+      {
+        user(id: 4) {
+          id
+          name
+          smallPic: profilePic(size: 64)
+          bigPic: profilePic(size: 1024)
+        }
+      }
+    """
+
+    val expected = """{user(id:4){id,name,smallPic:profilePic(size:64),bigPic:profilePic(size:1024)}}"""
+
+    run(query, expected)
+  }
+
+  test("minimize multiple root fields") {
+    val query = """
+      {
+        luke: character(id: "1000") {
+          name
+        }
+        darth: character(id: "1001") {
+          name
+        }
+      }
+    """
+
+    val expected = """{luke:character(id:"1000"){name},darth:character(id:"1001"){name}}"""
+
+    run(query, expected)
+  }
+
+  test("minimize variables") {
+    val query = """
+      query getZuckProfile($devicePicSize: Int) {
+        user(id: 4) {
+          id
+          name
+          profilePic(size: $devicePicSize)
+        }
+      }
+    """
+
+    val expected = """query getZuckProfile($devicePicSize:Int){user(id:4){id,name,profilePic(size:$devicePicSize)}}"""
+
+    run(query, expected)
+  }
+
+  test("minimize comments") {
+    val query = """
+      #comment at start of document
+      query IntrospectionQuery { #comment at end of line
+        __schema {
+          queryType {
+            name#comment eol no space
+          }
+          mutationType {
+            name
+            #several comments
+            #one after another
+          }
+          subscriptionType {
+            name
+          }
+        }
+      }
+      #comment at end of document
+    """
+
+    val expected = """query IntrospectionQuery{__schema{queryType{name},mutationType{name},subscriptionType{name}}}"""
+
+    run(query, expected)
+  }
+
+
+  test("minimize simple fragment query") {
+    val query = """
+      query withFragments {
+        user(id: 1) {
+          friends {
+            ...friendFields
+          }
+          mutualFriends {
+            ...friendFields
+          }
+        }
+      }
+
+      fragment friendFields on User {
+        id
+        name
+        profilePic
+      }
+    """
+
+    val expected = """query withFragments{user(id:1){friends{...friendFields},mutualFriends{...friendFields}}},fragment friendFields on User{id,name,profilePic}"""
+
+    run(query, expected)
+  }
+
+  test("minimize nested fragment query") {
+    val query = """
+      query withNestedFragments {
+        user(id: 1) {
+          friends {
+            ...friendFields
+          }
+          mutualFriends {
+            ...friendFields
+          }
+        }
+      }
+
+      fragment friendFields on User {
+        id
+        name
+        ...standardProfilePic
+      }
+
+      fragment standardProfilePic on User {
+        profilePic
+      }
+    """
+
+    val expected = """query withNestedFragments{user(id:1){friends{...friendFields},mutualFriends{...friendFields}}},fragment friendFields on User{id,name,...standardProfilePic},fragment standardProfilePic on User{profilePic}"""
+
+    run(query, expected)
+  }
+
+  test("minimize typed fragment query") {
+    val query = """
+      query FragmentTyping {
+        profiles {
+          id
+          __typename
+          ...userFragment
+          ...pageFragment
+        }
+      }
+
+      fragment userFragment on User {
+        name
+      }
+
+      fragment pageFragment on Page {
+        title
+      }
+    """
+
+    val expected = """query FragmentTyping{profiles{id,__typename,...userFragment,...pageFragment}},fragment userFragment on User{name},fragment pageFragment on Page{title}"""
+
+    run(query, expected)
+  }
+
+  test("minimize inline fragment query") {
+    val query = """
+      query inlineFragmentTyping {
+        profiles {
+          id
+          ... on User {
+            name
+          }
+          ... on Page {
+            title
+          }
+        }
+      }
+    """
+
+    val expected = """query inlineFragmentTyping{profiles{id,...on User{name},...on Page{title}}}"""
+
+    run(query, expected)
+  }
+
+  test("minimize typed union fragment query") {
+    val query = """
+      query FragmentUnionTyping {
+        user: user(id: "1") {
+          favourite {
+            __typename
+            ...userFragment
+            ...pageFragment
+          }
+        }
+        page: user(id: "2") {
+          favourite {
+            __typename
+            ...userFragment
+            ...pageFragment
+          }
+        }
+      }
+
+      fragment userFragment on User {
+        id
+        name
+      }
+
+      fragment pageFragment on Page {
+        id
+        title
+      }
+    """
+
+    val expected = """query FragmentUnionTyping{user:user(id:"1"){favourite{__typename,...userFragment,...pageFragment}},page:user(id:"2"){favourite{__typename,...userFragment,...pageFragment}}},fragment userFragment on User{id,name},fragment pageFragment on Page{id,title}"""
+
+    run(query, expected)
+  }
+
+  test("minimize skip/include field") {
+    val query = """
+      query ($yup: Boolean, $nope: Boolean) {
+        a: field @skip(if: $yup) {
+          subfieldA
+        }
+        b: field @skip(if: $nope) {
+          subfieldB
+        }
+        c: field @include(if: $yup) {
+          subfieldA
+        }
+        d: field @include(if: $nope) {
+          subfieldB
+        }
+      }
+    """
+
+    val expected = """query($yup:Boolean,$nope:Boolean){a:field@skip(if:$yup){subfieldA},b:field@skip(if:$nope){subfieldB},c:field@include(if:$yup){subfieldA},d:field@include(if:$nope){subfieldB}}"""
+
+    run(query, expected)
+  }
+
+  test("minimize skip/include fragment spread") {
+    val query = """
+      query ($yup: Boolean, $nope: Boolean) {
+        a: field {
+          ...frag @skip(if: $yup)
+        }
+        b: field {
+          ...frag @skip(if: $nope)
+        }
+        c: field {
+          ...frag @include(if: $yup)
+        }
+        d: field {
+          ...frag @include(if: $nope)
+        }
+      }
+
+      fragment frag on Value {
+        subfieldA
+        subfieldB
+      }
+    """
+
+    val expected = """query($yup:Boolean,$nope:Boolean){a:field{...frag@skip(if:$yup)},b:field{...frag@skip(if:$nope)},c:field{...frag@include(if:$yup)},d:field{...frag@include(if:$nope)}},fragment frag on Value{subfieldA,subfieldB}"""
+
+    run(query, expected)
+  }
+
+  test("minimize fragment spread with nested skip/include") {
+    val query = """
+      query ($yup: Boolean, $nope: Boolean) {
+        field {
+          ...frag
+        }
+      }
+
+      fragment frag on Value {
+        a: subfieldA @skip(if: $yup)
+        b: subfieldB @skip(if: $nope)
+        c: subfieldA @include(if: $yup)
+        d: subfieldB @include(if: $nope)
+      }
+    """
+
+    val expected = """query($yup:Boolean,$nope:Boolean){field{...frag}},fragment frag on Value{a:subfieldA@skip(if:$yup),b:subfieldB@skip(if:$nope),c:subfieldA@include(if:$yup),d:subfieldB@include(if:$nope)}"""
+
+    run(query, expected)
+  }
+
+  test("minimize skip/include inline fragment") {
+    val query = """
+      query ($yup: Boolean, $nope: Boolean) {
+        a: field {
+          ... on Value @skip(if: $yup) {
+            subfieldA
+            subfieldB
+          }
+        }
+        b: field {
+          ... on Value @skip(if: $nope) {
+            subfieldA
+            subfieldB
+          }
+        }
+        c: field {
+          ... on Value @include(if: $yup) {
+            subfieldA
+            subfieldB
+          }
+        }
+        d: field {
+          ... on Value @include(if: $nope) {
+            subfieldA
+            subfieldB
+          }
+        }
+      }
+    """
+
+    val expected = """query($yup:Boolean,$nope:Boolean){a:field{...on Value@skip(if:$yup){subfieldA,subfieldB}},b:field{...on Value@skip(if:$nope){subfieldA,subfieldB}},c:field{...on Value@include(if:$yup){subfieldA,subfieldB}},d:field{...on Value@include(if:$nope){subfieldA,subfieldB}}}"""
+
+    run(query, expected)
+  }
+
+  test("minimize inline fragment with nested skip/include") {
+    val query = """
+      query ($yup: Boolean, $nope: Boolean) {
+        field {
+          ... on Value {
+            a: subfieldA @skip(if: $yup)
+            b: subfieldB @skip(if: $nope)
+            c: subfieldA @include(if: $yup)
+            d: subfieldB @include(if: $nope)
+          }
+        }
+      }
+    """
+
+    val expected = """query($yup:Boolean,$nope:Boolean){field{...on Value{a:subfieldA@skip(if:$yup),b:subfieldB@skip(if:$nope),c:subfieldA@include(if:$yup),d:subfieldB@include(if:$nope)}}}"""
+
+    run(query, expected)
+  }
+
+  test("minimize null value") {
+    val query = """
+      query {
+        field {
+          subfield
+        }
+        field(arg: null) {
+          subfield
+        }
+        field(arg: 23) {
+          subfield
+        }
+      }
+    """
+
+    val expected = """query{field{subfield},field(arg:null){subfield},field(arg:23){subfield}}"""
+
+    run(query, expected)
+  }
+
+  test("minimize list value") {
+    val query = """
+      query {
+        listField(arg: []) {
+          subfield
+        }
+        listField(arg: ["foo", "bar"]) {
+          subfield
+        }
+      }
+    """
+
+    val expected = """query{listField(arg:[]){subfield},listField(arg:["foo","bar"]){subfield}}"""
+
+    run(query, expected)
+  }
+
+  test("minimize input object value") {
+    val query = """
+      query {
+        objectField(arg: { foo: 23, bar: true, baz: "quux" }) {
+          subfield
+        }
+      }
+    """
+
+    val expected = """query{objectField(arg:{foo:23,bar:true,baz:"quux"}){subfield}}"""
+
+    run(query, expected)
+  }
+
+  test("minimize query with UUID argument and custom scalar results") {
+    val query = """
+      query {
+        movieById(id: "6a7837fc-b463-4d32-b628-0f4b3065cb21") {
+          id
+          title
+          genre
+          releaseDate
+          showTime
+          nextShowing
+          duration
+        }
+      }
+    """
+
+    val expected = """query{movieById(id:"6a7837fc-b463-4d32-b628-0f4b3065cb21"){id,title,genre,releaseDate,showTime,nextShowing,duration}}"""
+
+    run(query, expected)
+  }
+
+  test("minimize query with mapped enum argument") {
+    val query = """
+      query {
+        moviesByGenre(genre: COMEDY) {
+          title
+          genre
+        }
+      }
+    """
+
+    val expected = """query{moviesByGenre(genre:COMEDY){title,genre}}"""
+
+    run(query, expected)
+  }
+
+  test("standard introspection query") {
+    val query = """
+      |query IntrospectionQuery {
+      |  __schema {
+      |    queryType { name }
+      |    mutationType { name }
+      |    subscriptionType { name }
+      |    types {
+      |      ...FullType
+      |    }
+      |    directives {
+      |      name
+      |      description
+      |      locations
+      |      args {
+      |        ...InputValue
+      |      }
+      |    }
+      |  }
+      |}
+      |
+      |fragment FullType on __Type {
+      |  kind
+      |  name
+      |  description
+      |  fields(includeDeprecated: true) {
+      |    name
+      |    description
+      |    args {
+      |      ...InputValue
+      |    }
+      |    type {
+      |      ...TypeRef
+      |    }
+      |    isDeprecated
+      |    deprecationReason
+      |  }
+      |  inputFields {
+      |    ...InputValue
+      |  }
+      |  interfaces {
+      |    ...TypeRef
+      |  }
+      |  enumValues(includeDeprecated: true) {
+      |    name
+      |    description
+      |    isDeprecated
+      |    deprecationReason
+      |  }
+      |  possibleTypes {
+      |    ...TypeRef
+      |  }
+      |}
+      |
+      |fragment InputValue on __InputValue {
+      |  name
+      |  description
+      |  type { ...TypeRef }
+      |  defaultValue
+      |}
+      |
+      |fragment TypeRef on __Type {
+      |  kind
+      |  name
+      |  ofType {
+      |    kind
+      |    name
+      |    ofType {
+      |      kind
+      |      name
+      |      ofType {
+      |        kind
+      |        name
+      |        ofType {
+      |          kind
+      |          name
+      |          ofType {
+      |            kind
+      |            name
+      |            ofType {
+      |              kind
+      |              name
+      |              ofType {
+      |                kind
+      |                name
+      |              }
+      |            }
+      |          }
+      |        }
+      |      }
+      |    }
+      |  }
+      |}
+    """.stripMargin.trim
+
+    val expected = """query IntrospectionQuery{__schema{queryType{name},mutationType{name},subscriptionType{name},types{...FullType},directives{name,description,locations,args{...InputValue}}}},fragment FullType on __Type{kind,name,description,fields(includeDeprecated:true){name,description,args{...InputValue},type{...TypeRef},isDeprecated,deprecationReason},inputFields{...InputValue},interfaces{...TypeRef},enumValues(includeDeprecated:true){name,description,isDeprecated,deprecationReason},possibleTypes{...TypeRef}},fragment InputValue on __InputValue{name,description,type{...TypeRef},defaultValue},fragment TypeRef on __Type{kind,name,ofType{kind,name,ofType{kind,name,ofType{kind,name,ofType{kind,name,ofType{kind,name,ofType{kind,name,ofType{kind,name}}}}}}}}"""
+
+    run(query, expected)
+  }
+}

--- a/modules/core/src/test/scala/parser/ParserSpec.scala
+++ b/modules/core/src/test/scala/parser/ParserSpec.scala
@@ -267,7 +267,7 @@ final class ParserSuite extends CatsSuite {
 
     val expected =
       Operation(Query, Some(Name("getZuckProfile")),
-        List(VariableDefinition(Name("devicePicSize"), Named(Name("Int")), None, Nil)),
+        List(VariableDefinition(Name("devicePicSize"), Named(Name("Int")), None)),
         Nil,
         List(
           Field(None, Name("user"), List((Name("id"), IntValue(4))), Nil,


### PR DESCRIPTION
+ Added a simple query minimizer which parses a query and reconstructs it with all unnecessary whitespace stripped out.
+ The parser now correctly treats commas as whitespace.
+ Input variable definitions should not have directives.