### PR TITLE
Don't ignore invalid document tail.

### DIFF
--- a/modules/core/src/main/scala/parser.scala
+++ b/modules/core/src/main/scala/parser.scala
@@ -14,7 +14,7 @@ object GraphQLParser {
   def keyword(s: String) = token(string(s))
 
   lazy val Document: Parser[Ast.Document] =
-    many(whitespace | comment) ~> many(Definition)
+    many(whitespace | comment) ~> many(Definition) <~ endOfInput
 
   lazy val Definition =
     ExecutableDefinition | TypeSystemDefinition // | TypeSystemExtension

--- a/modules/core/src/test/scala/parser/ParserSpec.scala
+++ b/modules/core/src/test/scala/parser/ParserSpec.scala
@@ -337,4 +337,12 @@ final class ParserSuite extends CatsSuite {
       case _ => assert(false)
     }
   }
+
+  test("invalid document") {
+    GraphQLParser.Document.parseOnly("scalar Foo woozle").option match {
+      case Some(_) => fail("should have failed")
+      case None    => succeed
+    }
+  }
+
 }

--- a/modules/core/src/test/scala/starwars/StarWarsSpec.scala
+++ b/modules/core/src/test/scala/starwars/StarWarsSpec.scala
@@ -113,7 +113,7 @@ final class StarWarsSpec extends CatsSuite {
             appearsIn
           }
         }
-      }}
+      }
     """
 
     val expected = json"""


### PR DESCRIPTION
There was an issue with the parser where it would never actually fail, but instead would stop when it reached an invalid definition and yield the [possibly empty] valid prefix. This fixes it to require that the entire document be valid.