### PR TITLE
Include required fields/mappings for introspection only selections

### DIFF
--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -560,6 +560,9 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
 
             loop(child, fieldName :: path, fieldTpe, (cols, joins, List.empty[(List[String], Type, Predicate)], requiredMappings ++ joinMapping) |+| acc)
 
+          case _: Introspect =>
+            ((requiredCols, Nil, Nil, requiredMappings): Acc) |+| acc
+
           case Context(contextPath, child) =>
             loop(child, contextPath, tpe, acc)
 
@@ -589,7 +592,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
           case GroupBy(_, child) =>
             loop(child, path, obj, acc)
 
-          case Empty | Skipped | Query.Component(_, _, _) | (_: Introspect) | (_: Defer) | (_: UntypedNarrow) | (_: Skip) => acc
+          case Empty | Skipped | Query.Component(_, _, _) | (_: Defer) | (_: UntypedNarrow) | (_: Skip) => acc
         }
       }
 

--- a/modules/sql/src/test/scala/SqlInterfacesSpec.scala
+++ b/modules/sql/src/test/scala/SqlInterfacesSpec.scala
@@ -473,4 +473,46 @@ trait SqlInterfacesSpec extends AnyFunSuite {
 
     assert(res == expected)
   }
+
+  test("interface query with only introspection fields") {
+    val query = """
+      query {
+        entities {
+          __typename
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "entities" : [
+            {
+              "__typename" : "Film"
+            },
+            {
+              "__typename" : "Film"
+            },
+            {
+              "__typename" : "Film"
+            },
+            {
+              "__typename" : "Series"
+            },
+            {
+              "__typename" : "Series"
+            },
+            {
+              "__typename" : "Series"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assert(res == expected)
+  }
 }

--- a/modules/sql/src/test/scala/SqlUnionSpec.scala
+++ b/modules/sql/src/test/scala/SqlUnionSpec.scala
@@ -116,4 +116,39 @@ trait SqlUnionSpec extends AnyFunSuite {
 
     assert(res == expected)
   }
+
+  test("union query with only introspection") {
+    val query = """
+      query {
+        collection {
+          ... on ItemA {
+            __typename
+          }
+          ... on ItemB {
+            __typename
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "collection" : [
+            {
+              "__typename" : "ItemA"
+            },
+            {
+              "__typename" : "ItemB"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assert(res == expected)
+  }
 }


### PR DESCRIPTION
Previously if a sub-selection only contained introspection fields, the required fields and mappings wouldn't be included in the mapped query leading to a crash a runtime.