### PR TITLE
Added scoped environment to Cursor

### DIFF
--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -306,7 +306,7 @@ class QueryCompiler(schema: Schema, phases: List[Phase]) {
    *
    * Any errors are accumulated on the left.
    */
-  def compile(text: String, name: Option[String] = None, untypedEnv: Option[Json] = None, useIntrospection: Boolean = true): Result[Operation] = {
+  def compile(text: String, name: Option[String] = None, untypedVars: Option[Json] = None, useIntrospection: Boolean = true): Result[Operation] = {
 
     val allPhases =
       if (useIntrospection) IntrospectionElaborator :: VariablesAndSkipElaborator :: phases else VariablesAndSkipElaborator :: phases
@@ -314,9 +314,9 @@ class QueryCompiler(schema: Schema, phases: List[Phase]) {
     for {
       parsed  <- QueryParser.parseText(text, name)
       varDefs <- compileVarDefs(parsed.variables)
-      env     <- compileEnv(varDefs, untypedEnv)
+      vars    <- compileVars(varDefs, untypedVars)
       rootTpe <- parsed.rootTpe(schema)
-      query   <- allPhases.foldLeftM(parsed.query) { (acc, phase) => phase.transform(acc, env, schema, rootTpe) }
+      query   <- allPhases.foldLeftM(parsed.query) { (acc, phase) => phase.transform(acc, vars, schema, rootTpe) }
     } yield Operation(query, rootTpe)
   }
 
@@ -326,11 +326,11 @@ class QueryCompiler(schema: Schema, phases: List[Phase]) {
         compileType(untypedTpe).map(tpe => InputValue(name, None, tpe, default))
     }
 
-  def compileEnv(varDefs: VarDefs, untypedEnv: Option[Json]): Result[Env] =
-    untypedEnv match {
+  def compileVars(varDefs: VarDefs, untypedVars: Option[Json]): Result[Vars] =
+    untypedVars match {
       case None => Map.empty.rightIor
-      case Some(untypedEnv) =>
-        untypedEnv.asObject match {
+      case Some(untypedVars) =>
+        untypedVars.asObject match {
           case None =>
             mkErrorResult(s"Variables must be represented as a Json object")
           case Some(obj) =>
@@ -359,7 +359,7 @@ object QueryCompiler {
      * Transform the supplied query algebra term `query` with expected type
      * `tpe`.
      */
-    def transform(query: Query, env: Env, schema: Schema, tpe: Type): Result[Query] =
+    def transform(query: Query, vars: Vars, schema: Schema, tpe: Type): Result[Query] =
       query match {
         case s@Select(fieldName, _, child)    =>
           val childTpe = tpe.underlyingField(fieldName)
@@ -372,58 +372,59 @@ object QueryCompiler {
             else if (!isLeaf && child == Empty)
               mkErrorResult(s"Non-leaf field '$fieldName' of $obj must have a non-empty subselection set")
             else
-              transform(child, env, schema, childTpe).map(ec => s.copy(child = ec))
+              transform(child, vars, schema, childTpe).map(ec => s.copy(child = ec))
           }
 
         case UntypedNarrow(tpnme, child) =>
           schema.definition(tpnme) match {
             case None => mkErrorResult(s"Unknown type '$tpnme' in type condition")
             case Some(subtpe) =>
-              transform(child, env, schema, subtpe).map { ec =>
+              transform(child, vars, schema, subtpe).map { ec =>
                 if (tpe.underlyingObject =:= subtpe) ec else Narrow(schema.ref(tpnme), ec)
               }
           }
 
         case i@Introspect(_, child) if tpe =:= schema.queryType =>
-          transform(child, env, Introspection.schema, Introspection.schema.queryType).map(ec => i.copy(child = ec))
+          transform(child, vars, Introspection.schema, Introspection.schema.queryType).map(ec => i.copy(child = ec))
 
         case i@Introspect(_, child) =>
           val typenameTpe = ObjectType(s"__Typename", None, List(Field("__typename", None, Nil, StringType, false, None)), Nil)
-          transform(child, env, Introspection.schema, typenameTpe).map(ec => i.copy(child = ec))
+          transform(child, vars, Introspection.schema, typenameTpe).map(ec => i.copy(child = ec))
 
-        case n@Narrow(subtpe, child)  => transform(child, env, schema, subtpe).map(ec => n.copy(child = ec))
-        case w@Wrap(_, child)         => transform(child, env, schema, tpe).map(ec => w.copy(child = ec))
-        case r@Rename(_, child)       => transform(child, env, schema, tpe).map(ec => r.copy(child = ec))
-        case g@Group(children)        => children.traverse(q => transform(q, env, schema, tpe)).map(eqs => g.copy(queries = eqs))
-        case g@GroupList(children)    => children.traverse(q => transform(q, env, schema, tpe)).map(eqs => g.copy(queries = eqs))
-        case u@Unique(_, child)       => transform(child, env, schema, tpe.nonNull).map(ec => u.copy(child = ec))
-        case f@Filter(_, child)       => transform(child, env, schema, tpe.item).map(ec => f.copy(child = ec))
-        case c@Component(_, _, child) => transform(child, env, schema, tpe).map(ec => c.copy(child = ec))
-        case d@Defer(_, child, _)     => transform(child, env, schema, tpe).map(ec => d.copy(child = ec))
-        case s@Skip(_, _, child)      => transform(child, env, schema, tpe).map(ec => s.copy(child = ec))
-        case l@Limit(_, child)        => transform(child, env, schema, tpe).map(ec => l.copy(child = ec))
-        case o@OrderBy(_, child)      => transform(child, env, schema, tpe).map(ec => o.copy(child = ec))
-        case g@GroupBy(_, child)      => transform(child, env, schema, tpe).map(ec => g.copy(child = ec))
-        case c@Context(_, child)      => transform(child, env, schema, tpe).map(ec => c.copy(child = ec))
+        case n@Narrow(subtpe, child)  => transform(child, vars, schema, subtpe).map(ec => n.copy(child = ec))
+        case w@Wrap(_, child)         => transform(child, vars, schema, tpe).map(ec => w.copy(child = ec))
+        case r@Rename(_, child)       => transform(child, vars, schema, tpe).map(ec => r.copy(child = ec))
+        case g@Group(children)        => children.traverse(q => transform(q, vars, schema, tpe)).map(eqs => g.copy(queries = eqs))
+        case g@GroupList(children)    => children.traverse(q => transform(q, vars, schema, tpe)).map(eqs => g.copy(queries = eqs))
+        case u@Unique(_, child)       => transform(child, vars, schema, tpe.nonNull).map(ec => u.copy(child = ec))
+        case f@Filter(_, child)       => transform(child, vars, schema, tpe.item).map(ec => f.copy(child = ec))
+        case c@Component(_, _, child) => transform(child, vars, schema, tpe).map(ec => c.copy(child = ec))
+        case d@Defer(_, child, _)     => transform(child, vars, schema, tpe).map(ec => d.copy(child = ec))
+        case s@Skip(_, _, child)      => transform(child, vars, schema, tpe).map(ec => s.copy(child = ec))
+        case l@Limit(_, child)        => transform(child, vars, schema, tpe).map(ec => l.copy(child = ec))
+        case o@OrderBy(_, child)      => transform(child, vars, schema, tpe).map(ec => o.copy(child = ec))
+        case g@GroupBy(_, child)      => transform(child, vars, schema, tpe).map(ec => g.copy(child = ec))
+        case c@Context(_, child)      => transform(child, vars, schema, tpe).map(ec => c.copy(child = ec))
+        case e@Environment(_, child)  => transform(child, vars, schema, tpe).map(ec => e.copy(child = ec))
         case Skipped                  => Skipped.rightIor
         case Empty                    => Empty.rightIor
       }
   }
 
   object IntrospectionElaborator extends Phase {
-    override def transform(query: Query, env: Env, schema: Schema, tpe: Type): Result[Query] =
+    override def transform(query: Query, vars: Vars, schema: Schema, tpe: Type): Result[Query] =
       query match {
         case s@PossiblyRenamedSelect(Select("__typename" | "__schema" | "__type", _, _), _) =>
           Introspect(schema, s).rightIor
-        case _ => super.transform(query, env, schema, tpe)
+        case _ => super.transform(query, vars, schema, tpe)
       }
   }
 
   object VariablesAndSkipElaborator extends Phase {
-    override def transform(query: Query, env: Env, schema: Schema, tpe: Type): Result[Query] =
+    override def transform(query: Query, vars: Vars, schema: Schema, tpe: Type): Result[Query] =
       query match {
         case Group(children) =>
-          children.traverse(q => transform(q, env, schema, tpe)).map { eqs =>
+          children.traverse(q => transform(q, vars, schema, tpe)).map { eqs =>
             eqs.filterNot(_ == Skipped) match {
               case Nil => Skipped
               case eq :: Nil => eq
@@ -433,32 +434,32 @@ object QueryCompiler {
         case Select(fieldName, args, child) =>
           tpe.withUnderlyingField(fieldName) { childTpe =>
             for {
-              elaboratedChild <- transform(child, env, schema, childTpe)
-              elaboratedArgs  <- args.traverse(elaborateVariable(env))
+              elaboratedChild <- transform(child, vars, schema, childTpe)
+              elaboratedArgs  <- args.traverse(elaborateVariable(vars))
             } yield Select(fieldName, elaboratedArgs, elaboratedChild)
           }
         case Skip(skip, cond, child) =>
           for {
-            c  <- extractCond(env, cond)
-            elaboratedChild <- if(c == skip) Skipped.rightIor else transform(child, env, schema, tpe)
+            c  <- extractCond(vars, cond)
+            elaboratedChild <- if(c == skip) Skipped.rightIor else transform(child, vars, schema, tpe)
           } yield elaboratedChild
 
-        case _ => super.transform(query, env, schema, tpe)
+        case _ => super.transform(query, vars, schema, tpe)
       }
 
-    def elaborateVariable(env: Env)(b: Binding): Result[Binding] = b match {
+    def elaborateVariable(vars: Vars)(b: Binding): Result[Binding] = b match {
       case Binding(name, UntypedVariableValue(varName)) =>
-        env.get(varName) match {
+        vars.get(varName) match {
           case Some((_, value)) => Binding(name, value).rightIor
           case None => mkErrorResult(s"Undefined variable '$varName'")
         }
       case other => other.rightIor
     }
 
-    def extractCond(env: Env, value: Value): Result[Boolean] =
+    def extractCond(vars: Vars, value: Value): Result[Boolean] =
       value match {
         case UntypedVariableValue(varName) =>
-          env.get(varName) match {
+          vars.get(varName) match {
             case Some((tpe, BooleanValue(value))) if tpe.nonNull =:= BooleanType => value.rightIor
             case Some((_, _)) => mkErrorResult(s"Argument of skip/include must be boolean")
             case None => mkErrorResult(s"Undefined variable '$varName'")
@@ -506,7 +507,7 @@ object QueryCompiler {
    * 5. eliminates Skipped nodes.
    */
   class SelectElaborator(mapping: Map[TypeRef, PartialFunction[Select, Result[Query]]]) extends Phase {
-    override def transform(query: Query, env: Env, schema: Schema, tpe: Type): Result[Query] =
+    override def transform(query: Query, vars: Vars, schema: Schema, tpe: Type): Result[Query] =
       query match {
         case Select(fieldName, args, child) =>
           tpe.withUnderlyingField(fieldName) { childTpe =>
@@ -525,15 +526,21 @@ object QueryCompiler {
               mkErrorResult(s"Non-leaf field '$fieldName' of $obj must have a non-empty subselection set")
             else
               for {
-                elaboratedChild <- transform(child, env, schema, childTpe)
+                elaboratedChild <- transform(child, vars, schema, childTpe)
                 elaboratedArgs <- elaborateArgs(tpe, fieldName, args)
                 elaborated <- elaborator(Select(fieldName, elaboratedArgs, elaboratedChild))
               } yield elaborated
           }
 
+        case _: Rename =>
+          super.transform(query, vars, schema, tpe).map(_ match {
+            case Rename(nme, Environment(e, child)) => Environment(e, Rename(nme, child))
+            case q => q
+          })
+
         case Skipped => Empty.rightIor
 
-        case _ => super.transform(query, env, schema, tpe)
+        case _ => super.transform(query, vars, schema, tpe)
       }
 
     def elaborateArgs(tpe: Type, fieldName: String, args: List[Binding]): Result[List[Binding]] =
@@ -590,23 +597,23 @@ object QueryCompiler {
    *    from the parent query.
    */
   class ComponentElaborator[F[_]] private (cmapping: Map[(Type, String), (Mapping[F], (Cursor, Query) => Result[Query])]) extends Phase {
-    override def transform(query: Query, env: Env, schema: Schema, tpe: Type): Result[Query] =
+    override def transform(query: Query, vars: Vars, schema: Schema, tpe: Type): Result[Query] =
       query match {
         case PossiblyRenamedSelect(Select(fieldName, args, child), resultName) =>
           tpe.withUnderlyingField(fieldName) { childTpe =>
             schema.ref(tpe.underlyingObject).flatMap(ref => cmapping.get((ref, fieldName))) match {
               case Some((mapping, join)) =>
-                transform(child, env, schema, childTpe).map { elaboratedChild =>
+                transform(child, vars, schema, childTpe).map { elaboratedChild =>
                   Wrap(resultName, Component(mapping, join, PossiblyRenamedSelect(Select(fieldName, args, elaboratedChild), resultName)))
                 }
               case None =>
-                transform(child, env, schema, childTpe).map { elaboratedChild =>
+                transform(child, vars, schema, childTpe).map { elaboratedChild =>
                   PossiblyRenamedSelect(Select(fieldName, args, elaboratedChild), resultName)
                 }
             }
           }
 
-        case _ => super.transform(query, env, schema, tpe)
+        case _ => super.transform(query, vars, schema, tpe)
       }
   }
 

--- a/modules/core/src/main/scala/query.scala
+++ b/modules/core/src/main/scala/query.scala
@@ -4,9 +4,11 @@
 package edu.gemini.grackle
 
 import scala.annotation.tailrec
+
 import cats.kernel.{ Eq, Order }
 import cats.implicits._
 
+import Cursor.Env
 import Query._
 
 /** GraphQL query Algebra */
@@ -79,6 +81,10 @@ object Query {
 
   case class Context(path: List[String], child: Query) extends Query {
     def render = s"<context: $path ${child.render}>"
+  }
+
+  case class Environment(env: Env, child: Query) extends Query {
+    def render = s"<environment: $env ${child.render}>"
   }
 
   /**
@@ -213,7 +219,7 @@ object Query {
 
   type UntypedVarDefs = List[UntypedVarDef]
   type VarDefs = List[InputValue]
-  type Env = Map[String, (Type, Value)]
+  type Vars = Map[String, (Type, Value)]
 
   case class UntypedVarDef(name: String, tpe: Ast.Type, default: Option[Value])
 

--- a/modules/core/src/test/scala/compiler/Environment.scala
+++ b/modules/core/src/test/scala/compiler/Environment.scala
@@ -1,0 +1,317 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package compiler
+
+import cats.Id
+import cats.implicits._
+import cats.tests.CatsSuite
+import io.circe.literal.JsonStringContext
+
+import edu.gemini.grackle._
+import Cursor.Env
+import Query._, Value._
+import QueryCompiler._
+import QueryInterpreter.mkOneError
+
+object EnvironmentMapping extends ValueMapping[Id] {
+  val schema =
+    Schema(
+      """
+        type Query {
+          nested: Nested!
+          nestedSum(x: Int!, y: Int!): NestedSum!
+        }
+        type Nested {
+          sum(x: Int!, y: Int!): Int!
+          url: String!
+          nested: Nested!
+        }
+        type NestedSum {
+          sum: Int!
+          nestedSum(x: Int!, y: Int!): NestedSum!
+        }
+      """
+    ).right.get
+
+  val QueryType = schema.ref("Query")
+  val NestedType = schema.ref("Nested")
+  val NestedSumType = schema.ref("NestedSum")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            ValueRoot("nested", ()),
+            ValueRoot("nestedSum", ())
+          )
+      ),
+      ObjectMapping(
+        tpe = NestedType,
+        fieldMappings =
+          List(
+            CursorField("sum", sum),
+            CursorField("url", url),
+            ValueField[Unit]("nested", _ => ())
+          )
+      ),
+      ObjectMapping(
+        tpe = NestedSumType,
+        fieldMappings =
+          List(
+            CursorField("sum", sum),
+            ValueField[Unit]("nestedSum", _ => ())
+          )
+      )
+    )
+
+  def sum(c: Cursor): Result[Int] =
+    (for {
+      x <- c.env[Int]("x")
+      y <- c.env[Int]("y")
+    } yield x+y).toRightIor(mkOneError(s"Missing argument"))
+
+  def url(c: Cursor): Result[String] = {
+    c.env[Boolean]("secure").map(secure =>
+      if(secure) "https://localhost/" else "http://localhost/"
+    ).toRightIor(mkOneError(s"Missing argument"))
+  }
+
+  override val selectElaborator = new SelectElaborator(Map(
+    QueryType -> {
+      case Select("nestedSum", List(Binding("x", IntValue(x)), Binding("y", IntValue(y))), child) =>
+        Environment(Env("x" -> x, "y" -> y), Select("nestedSum", Nil, child)).rightIor
+    },
+    NestedType -> {
+      case Select("sum", List(Binding("x", IntValue(x)), Binding("y", IntValue(y))), child) =>
+        Environment(Env("x" -> x, "y" -> y), Select("sum", Nil, child)).rightIor
+    },
+    NestedSumType -> {
+      case Select("nestedSum", List(Binding("x", IntValue(x)), Binding("y", IntValue(y))), child) =>
+        Environment(Env("x" -> x, "y" -> y), Select("nestedSum", Nil, child)).rightIor
+    }
+  ))
+}
+
+final class EnvironmentSpec extends CatsSuite {
+  test("field computed from arguments (1)") {
+    val query = """
+      query {
+        nested {
+          sum(x: 13, y: 23)
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "nested" : {
+            "sum" : 36
+          }
+        }
+      }
+    """
+
+    val res = EnvironmentMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("field computed from arguments (2)") {
+    val query = """
+      query {
+        nested {
+          a: sum(x: 13, y: 23)
+          b: sum(x: 5, y: 7)
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "nested" : {
+            "a" : 36,
+            "b" : 12
+          }
+        }
+      }
+    """
+
+    val res = EnvironmentMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("field computed from arguments (3)") {
+    val query = """
+      query {
+        nested {
+          sum(x: 13, y: 23)
+          nested {
+            sum(x: 5, y: 7)
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "nested" : {
+            "sum" : 36,
+            "nested" : {
+              "sum" : 12
+            }
+          }
+        }
+      }
+    """
+
+    val res = EnvironmentMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("field computed from arguments (4)") {
+    val query = """
+      query {
+        nestedSum(x: 13, y: 23) {
+          sum
+          nestedSum(x: 5, y: 7) {
+            sum
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "nestedSum" : {
+            "sum" : 36,
+            "nestedSum" : {
+              "sum" : 12
+            }
+          }
+        }
+      }
+    """
+
+    val res = EnvironmentMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("field computed using external value (1)") {
+    val query = """
+      query {
+        nested {
+          url
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "errors" : [
+          {
+            "message" : "Missing argument"
+          }
+        ],
+        "data" : null
+      }
+    """
+
+    val res = EnvironmentMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("field computed using external value (2)") {
+    val query = """
+      query {
+        nested {
+          url
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "nested" : {
+            "url" : "https://localhost/"
+          }
+        }
+      }
+    """
+
+    val res = EnvironmentMapping.compileAndRun(query, env = Env("secure" -> true))
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("field computed using external value (3)") {
+    val query = """
+      query {
+        nested {
+          url
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "nested" : {
+            "url" : "http://localhost/"
+          }
+        }
+      }
+    """
+
+    val res = EnvironmentMapping.compileAndRun(query, env = Env("secure" -> false))
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("field computed using external value (4)") {
+    val query = """
+      query {
+        nested {
+          nested {
+            url
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "nested" : {
+            "nested" : {
+              "url" : "https://localhost/"
+            }
+          }
+        }
+      }
+    """
+
+    val res = EnvironmentMapping.compileAndRun(query, env = Env("secure" -> true))
+    //println(res)
+
+    assert(res == expected)
+  }
+}

--- a/modules/core/src/test/scala/compiler/SkipIncludeSpec.scala
+++ b/modules/core/src/test/scala/compiler/SkipIncludeSpec.scala
@@ -43,7 +43,7 @@ final class SkipIncludeSuite extends CatsSuite {
         Rename("c", Select("field", Nil, Select("subfieldA", Nil, Empty)))
       ))
 
-    val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
+    val compiled = SkipIncludeMapping.compiler.compile(query, untypedVars = Some(variables))
     //println(compiled)
 
     assert(compiled.map(_.query) == Ior.Right(expected))
@@ -101,7 +101,7 @@ final class SkipIncludeSuite extends CatsSuite {
         Rename("d", Select("field", Nil, Empty))
       ))
 
-    val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
+    val compiled = SkipIncludeMapping.compiler.compile(query, untypedVars = Some(variables))
     //println(compiled)
 
     assert(compiled.map(_.query) == Ior.Right(expected))
@@ -138,7 +138,7 @@ final class SkipIncludeSuite extends CatsSuite {
         ))
       )
 
-    val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
+    val compiled = SkipIncludeMapping.compiler.compile(query, untypedVars = Some(variables))
     //println(compiled)
 
     assert(compiled.map(_.query) == Ior.Right(expected))
@@ -203,7 +203,7 @@ final class SkipIncludeSuite extends CatsSuite {
         Rename("d", Select("field", Nil, Empty))
       ))
 
-    val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
+    val compiled = SkipIncludeMapping.compiler.compile(query, untypedVars = Some(variables))
     //println(compiled)
 
     assert(compiled.map(_.query) == Ior.Right(expected))
@@ -238,7 +238,7 @@ final class SkipIncludeSuite extends CatsSuite {
         ))
       )
 
-    val compiled = SkipIncludeMapping.compiler.compile(query, untypedEnv = Some(variables))
+    val compiled = SkipIncludeMapping.compiler.compile(query, untypedVars = Some(variables))
     //println(compiled)
 
     assert(compiled.map(_.query) == Ior.Right(expected))

--- a/modules/core/src/test/scala/compiler/VariablesSpec.scala
+++ b/modules/core/src/test/scala/compiler/VariablesSpec.scala
@@ -39,7 +39,7 @@ final class VariablesSuite extends CatsSuite {
         ))
       )
 
-    val compiled = VariablesMapping.compiler.compile(query, untypedEnv = Some(variables))
+    val compiled = VariablesMapping.compiler.compile(query, untypedVars = Some(variables))
     //println(compiled)
     assert(compiled.map(_.query) == Ior.Right(expected))
   }
@@ -65,7 +65,7 @@ final class VariablesSuite extends CatsSuite {
         Select("name", Nil, Empty)
       )
 
-    val compiled = VariablesMapping.compiler.compile(query, untypedEnv = Some(variables))
+    val compiled = VariablesMapping.compiler.compile(query, untypedVars = Some(variables))
     //println(compiled)
     assert(compiled.map(_.query) == Ior.Right(expected))
   }
@@ -105,7 +105,7 @@ final class VariablesSuite extends CatsSuite {
         ))
       )
 
-    val compiled = VariablesMapping.compiler.compile(query, untypedEnv = Some(variables))
+    val compiled = VariablesMapping.compiler.compile(query, untypedVars = Some(variables))
     //println(compiled)
     assert(compiled.map(_.query) == Ior.Right(expected))
   }

--- a/modules/doobie/src/main/scala/DoobieMappingCompanion.scala
+++ b/modules/doobie/src/main/scala/DoobieMappingCompanion.scala
@@ -13,6 +13,8 @@ import cats.implicits._
 import io.chrisdavenport.log4cats.Logger
 import io.circe.Json
 
+import Cursor.Env
+
 trait DoobieMappingCompanion {
   def mkMapping[F[_]: Sync](transactor: Transactor[F], monitor: DoobieMonitor[F]): Mapping[F]
 
@@ -43,11 +45,11 @@ trait TracedDoobieMappingCompanion {
     new QueryExecutor[F, (Json, List[List[DoobieStats]])] {
       implicit val M: Monad[F] = Sync[F]
 
-      def run(query: Query, rootTpe: Type): F[(Json, List[List[DoobieStats]])] =
-        stateMapping.run(query, rootTpe).run(Nil).map(_.swap)
+      def run(query: Query, rootTpe: Type, env: Env): F[(Json, List[List[DoobieStats]])] =
+        stateMapping.run(query, rootTpe, env).run(Nil).map(_.swap)
 
-      def compileAndRun(text: String, name: Option[String] = None, untypedEnv: Option[Json] = None, useIntrospection: Boolean = true): F[(Json, List[List[DoobieStats]])] =
-        stateMapping.compileAndRun(text, name, untypedEnv, useIntrospection).run(Nil).map(_.swap)
+      def compileAndRun(text: String, name: Option[String] = None, untypedVars: Option[Json] = None, useIntrospection: Boolean = true, env: Env = Env.empty): F[(Json, List[List[DoobieStats]])] =
+        stateMapping.compileAndRun(text, name, untypedVars, useIntrospection).run(Nil).map(_.swap)
     }
   }
 }

--- a/modules/generic/src/main/scala/genericmapping.scala
+++ b/modules/generic/src/main/scala/genericmapping.scala
@@ -14,6 +14,7 @@ import shapeless.ops.hlist.{ LiftAll => PLiftAll }
 import shapeless.ops.coproduct.{ LiftAll => CLiftAll }
 import shapeless.ops.record.Keys
 
+import Cursor.Env
 import QueryInterpreter.{ mkErrorResult, mkOneError }
 import ShapelessUtils._
 import org.tpolecat.sourcepos.SourcePos
@@ -23,7 +24,7 @@ abstract class GenericMapping[F[_]: Monad] extends Mapping[F] {
     implicit val pos: SourcePos
   ) extends RootMapping {
     lazy val cursorBuilder = cb()
-    def cursor(query: Query): F[Result[Cursor]] = cursorBuilder.build(Nil, t).pure[F]
+    def cursor(query: Query, env: Env): F[Result[Cursor]] = cursorBuilder.build(Nil, t, None, env).pure[F]
     def withParent(tpe: Type): GenericRoot[T] =
       new GenericRoot(tpe, fieldName, t, cb)
   }
@@ -59,39 +60,41 @@ object MkObjectCursorBuilder {
     ): MkObjectCursorBuilder[T] =
     new MkObjectCursorBuilder[T] {
       def apply(tpe: Type): ObjectCursorBuilder[T] = {
-        def fieldMap: Map[String, (List[String], T) => Result[Cursor]] = {
+        def fieldMap: Map[String, (List[String], T, Option[Cursor], Env) => Result[Cursor]] = {
           val keys: List[String] = unsafeToList[Symbol](keys0()).map(_.name)
           val elems = unsafeToList[CursorBuilder[Any]](elems0.instances)
           keys.zip(elems.zipWithIndex).map {
-            case (fieldName, (elem, idx)) => (fieldName, (p: List[String], t: T) => elem.build(p, t.productElement(idx)))
+            case (fieldName, (elem, idx)) => (fieldName, (p: List[String], t: T, c: Option[Cursor], e: Env) => elem.build(p, t.productElement(idx), c, e))
           }.toMap
         }
         new Impl[T](tpe, fieldMap)
       }
     }
 
-  class Impl[T](tpe0: Type, fieldMap0: => Map[String, (List[String], T) => Result[Cursor]]) extends ObjectCursorBuilder[T] {
+  class Impl[T](tpe0: Type, fieldMap0: => Map[String, (List[String], T, Option[Cursor], Env) => Result[Cursor]]) extends ObjectCursorBuilder[T] {
     lazy val fieldMap = fieldMap0
 
     val tpe = tpe0
 
-    def build(path: List[String], focus: T): Result[Cursor] =
-      CursorImpl(tpe, fieldMap, path, focus).rightIor
+    def build(path: List[String], focus: T, parent: Option[Cursor], env: Env): Result[Cursor] =
+      CursorImpl(path, tpe, focus, fieldMap, parent, env).rightIor
 
     def renameField(from: String, to: String): ObjectCursorBuilder[T] =
       transformFieldNames { case `from` => to ; case other => other }
     def transformFieldNames(f: String => String): ObjectCursorBuilder[T] =
       new Impl(tpe, fieldMap0.map { case (k, v) => (f(k), v) })
     def transformField[U](fieldName: String)(f: T => Result[U])(implicit cb: => CursorBuilder[U]): ObjectCursorBuilder[T] =
-      new Impl(tpe, fieldMap0.updated(fieldName, (path: List[String], focus: T) => f(focus).flatMap(f => cb.build(path, f))))
+      new Impl(tpe, fieldMap0.updated(fieldName, (path: List[String], focus: T, parent: Option[Cursor], env: Env) => f(focus).flatMap(f => cb.build(path, f, parent, env))))
   }
 
-  case class CursorImpl[T](tpe: Type, fieldMap: Map[String, (List[String], T) => Result[Cursor]], path: List[String], focus: T)
+  case class CursorImpl[T](path: List[String], tpe: Type, focus: T, fieldMap: Map[String, (List[String], T, Option[Cursor], Env) => Result[Cursor]], parent: Option[Cursor], env: Env)
     extends AbstractCursor[Product] {
+    def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+
     override def hasField(fieldName: String): Boolean = fieldMap.contains(fieldName)
 
     override def field(fieldName: String): Result[Cursor] = {
-      fieldMap.get(fieldName).toRightIor(mkOneError(s"No field '$fieldName' for type $tpe")).flatMap(f => f(fieldName :: path, focus))
+      fieldMap.get(fieldName).toRightIor(mkOneError(s"No field '$fieldName' for type $tpe")).flatMap(f => f(fieldName :: path, focus, Some(this), Env.empty))
     }
   }
 }
@@ -123,14 +126,16 @@ object MkInterfaceCursorBuilder {
 
   class Impl[T](tpe0: Type, sel: T => Int, elems: => Array[CursorBuilder[T]]) extends CursorBuilder[T] {
     val tpe = tpe0
-    def build(path: List[String], focus: T): Result[Cursor] = {
+    def build(path: List[String], focus: T, parent: Option[Cursor], env: Env): Result[Cursor] = {
       val builder = elems(sel(focus))
-      builder.build(path, focus).map(cursor => CursorImpl(tpe, builder.tpe, cursor))
+      builder.build(path, focus, parent, env).map(cursor => CursorImpl(tpe, builder.tpe, cursor, parent, env))
     }
   }
 
-  case class CursorImpl[T](tpe: Type, rtpe: Type, cursor: Cursor)
+  case class CursorImpl[T](tpe: Type, rtpe: Type, cursor: Cursor, parent: Option[Cursor], env: Env)
     extends AbstractCursor[T] {
+    def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+
     def focus: Any = cursor.focus
     def path: List[String] = cursor.path
 
@@ -149,7 +154,7 @@ object MkInterfaceCursorBuilder {
 
 trait CursorBuilder[T] { outer =>
   def tpe: Type
-  def build(path: List[String], focus: T): Result[Cursor]
+  def build(path: List[String], focus: T, parent: Option[Cursor] = None, env: Env = Env.empty): Result[Cursor]
 }
 
 object CursorBuilder {
@@ -157,107 +162,139 @@ object CursorBuilder {
 
   import ScalarType._
 
-  implicit val stringCursorBuilder: CursorBuilder[String] =
+  implicit val stringCursorBuilder: CursorBuilder[String] = {
+    case class StringCursor(path: List[String], focus: String, parent: Option[Cursor], env: Env) extends PrimitiveCursor[String] {
+      val tpe = StringType
+      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+      override def asLeaf: Result[Json] = Json.fromString(focus).rightIor
+    }
     new CursorBuilder[String] {
       val tpe = StringType
-      def build(path: List[String], focus: String): Result[Cursor] =
-        new PrimitiveCursor(focus, tpe, path) {
-          override def asLeaf: Result[Json] = Json.fromString(focus).rightIor
-        }.rightIor
+      def build(path: List[String], focus: String, parent: Option[Cursor], env: Env): Result[Cursor] =
+        StringCursor(path, focus, parent, env).rightIor
     }
+  }
 
-  implicit val intCursorBuilder: CursorBuilder[Int] =
+  implicit val intCursorBuilder: CursorBuilder[Int] = {
+    case class IntCursor(path: List[String], focus: Int, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Int] {
+      val tpe = IntType
+      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+      override def asLeaf: Result[Json] = Json.fromInt(focus).rightIor
+    }
     new CursorBuilder[Int] {
       val tpe = IntType
-      def build(path: List[String], focus: Int): Result[Cursor] =
-        new PrimitiveCursor(focus, tpe, path) {
-          override def asLeaf: Result[Json] = Json.fromInt(focus).rightIor
-        }.rightIor
+      def build(path: List[String], focus: Int, parent: Option[Cursor], env: Env): Result[Cursor] =
+        IntCursor(path, focus, parent, env).rightIor
     }
+  }
 
-  implicit val longCursorBuilder: CursorBuilder[Long] =
+  implicit val longCursorBuilder: CursorBuilder[Long] = {
+    case class LongCursor(path: List[String], focus: Long, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Long] {
+      val tpe = IntType
+      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+      override def asLeaf: Result[Json] = Json.fromLong(focus).rightIor
+    }
     new CursorBuilder[Long] {
       val tpe = IntType
-      def build(path: List[String], focus: Long): Result[Cursor] =
-        new PrimitiveCursor(focus, tpe, path) {
-          override def asLeaf: Result[Json] = Json.fromLong(focus).rightIor
-        }.rightIor
+      def build(path: List[String], focus: Long, parent: Option[Cursor], env: Env): Result[Cursor] =
+        LongCursor(path, focus, parent, env).rightIor
     }
+  }
 
-  implicit val floatCursorBuilder: CursorBuilder[Float] =
+  implicit val floatCursorBuilder: CursorBuilder[Float] = {
+    case class FloatCursor(path: List[String], focus: Float, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Float] {
+      val tpe = FloatType
+      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+      override def asLeaf: Result[Json] =
+        Json.fromFloat(focus).toRightIor(mkOneError(s"Unrepresentable float %focus"))
+    }
     new CursorBuilder[Float] {
       val tpe = FloatType
-      def build(path: List[String], focus: Float): Result[Cursor] =
-        new PrimitiveCursor(focus, tpe, path) {
-          override def asLeaf: Result[Json] =
-            Json.fromFloat(focus).toRightIor(mkOneError(s"Unrepresentable float %focus"))
-        }.rightIor
+      def build(path: List[String], focus: Float, parent: Option[Cursor], env: Env): Result[Cursor] =
+        FloatCursor(path, focus, parent, env).rightIor
     }
+  }
 
-  implicit val doubleCursorBuilder: CursorBuilder[Double] =
+  implicit val doubleCursorBuilder: CursorBuilder[Double] = {
+    case class DoubleCursor(path: List[String], focus: Double, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Double] {
+      val tpe = FloatType
+      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+      override def asLeaf: Result[Json] =
+        Json.fromDouble(focus).toRightIor(mkOneError(s"Unrepresentable double %focus"))
+    }
     new CursorBuilder[Double] {
       val tpe = FloatType
-      def build(path: List[String], focus: Double): Result[Cursor] =
-        new PrimitiveCursor(focus, tpe, path) {
-          override def asLeaf: Result[Json] =
-            Json.fromDouble(focus).toRightIor(mkOneError(s"Unrepresentable double %focus"))
-        }.rightIor
+      def build(path: List[String], focus: Double, parent: Option[Cursor], env: Env): Result[Cursor] =
+        DoubleCursor(path, focus, parent, env).rightIor
     }
+  }
 
-  implicit val booleanCursorBuilder: CursorBuilder[Boolean] =
+  implicit val booleanCursorBuilder: CursorBuilder[Boolean] = {
+    case class BooleanCursor(path: List[String], focus: Boolean, parent: Option[Cursor], env: Env) extends PrimitiveCursor[Boolean] {
+      val tpe = BooleanType
+      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+      override def asLeaf: Result[Json] = Json.fromBoolean(focus).rightIor
+    }
     new CursorBuilder[Boolean] {
       val tpe = BooleanType
-      def build(path: List[String], focus: Boolean): Result[Cursor] =
-        new PrimitiveCursor(focus, tpe, path) {
-          override def asLeaf: Result[Json] = Json.fromBoolean(focus).rightIor
-        }.rightIor
+      def build(path: List[String], focus: Boolean, parent: Option[Cursor], env: Env): Result[Cursor] =
+        BooleanCursor(path, focus, parent, env).rightIor
     }
+  }
 
-  implicit def deriveEnumerationCursorBuilder[T <: Enumeration#Value](tpe0: Type): CursorBuilder[T] =
+  implicit def deriveEnumerationCursorBuilder[T <: Enumeration#Value](tpe0: Type): CursorBuilder[T] = {
+    case class EnumerationCursor(path: List[String], focus: T, parent: Option[Cursor], env: Env) extends PrimitiveCursor[T] {
+      val tpe = tpe0
+      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+      override def asLeaf: Result[Json] = Json.fromString(focus.toString).rightIor
+    }
     new CursorBuilder[T] {
       val tpe = tpe0
-      def build(path: List[String], focus: T): Result[Cursor] =
-        new PrimitiveCursor(focus, tpe, path) {
-          override def asLeaf: Result[Json] = Json.fromString(focus.toString).rightIor
-        }.rightIor
+      def build(path: List[String], focus: T, parent: Option[Cursor], env: Env): Result[Cursor] =
+        EnumerationCursor(path, focus, parent, env).rightIor
     }
+  }
 
   implicit def enumerationCursorBuilder[T <: Enumeration#Value]: CursorBuilder[T] =
     deriveEnumerationCursorBuilder(NoType)
 
-  implicit def optionCursorBuiler[T](implicit elemBuilder: CursorBuilder[T]): CursorBuilder[Option[T]] =
+  implicit def optionCursorBuiler[T](implicit elemBuilder: CursorBuilder[T]): CursorBuilder[Option[T]] = {
+    case class OptionCursor(path: List[String], tpe: Type, focus: Option[T], parent: Option[Cursor], env: Env) extends AbstractCursor[Option[T]] {
+      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+
+      override def isNullable: Boolean = true
+      override def asNullable: Result[Option[Cursor]] = {
+        focus.traverse(elem => elemBuilder.build(path, elem, Some(this), env))
+      }
+    }
+
     new CursorBuilder[Option[T]] { outer =>
       val tpe = NullableType(elemBuilder.tpe)
-      def build(path0: List[String], focus0: Option[T]): Result[Cursor] =
-        new AbstractCursor[Option[T]] {
-          def focus = focus0
-          def tpe = outer.tpe
-          def path = path0
+      def build(path: List[String], focus: Option[T], parent: Option[Cursor], env: Env): Result[Cursor] =
+        OptionCursor(path, tpe, focus, parent, env).rightIor
+    }
+  }
 
-          override def isNullable: Boolean = true
-          override def asNullable: Result[Option[Cursor]] = {
-            focus.traverse(elem => elemBuilder.build(path, elem))
-          }
-        }.rightIor
+  implicit def listCursorBuiler[T](implicit elemBuilder: CursorBuilder[T]): CursorBuilder[List[T]] = {
+    case class ListCursor(path: List[String], tpe: Type, focus: List[T], parent: Option[Cursor], env: Env) extends AbstractCursor[List[T]] {
+      def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+
+      override def isList: Boolean = true
+      override def asList: Result[List[Cursor]] = {
+        focus.traverse(elem => elemBuilder.build(path, elem, Some(this), env))
+      }
     }
 
-  implicit def listCursorBuiler[T](implicit elemBuilder: CursorBuilder[T]): CursorBuilder[List[T]] =
     new CursorBuilder[List[T]] { outer =>
       val tpe = ListType(elemBuilder.tpe)
-      def build(path0: List[String], focus0: List[T]): Result[Cursor] =
-        new AbstractCursor[List[T]] {
-          def focus = focus0
-          def tpe = outer.tpe
-          def path = path0
-
-          override def isList: Boolean = true
-          override def asList: Result[List[Cursor]] = {
-            focus.traverse(elem => elemBuilder.build(path, elem))
-          }
-        }.rightIor
+      def build(path: List[String], focus: List[T], parent: Option[Cursor], env: Env): Result[Cursor] =
+        ListCursor(path, tpe, focus, parent, env).rightIor
     }
+  }
 
-  class LeafCursor[T](val focus: T, val tpe: Type, val path: List[String], encoder: Encoder[T]) extends AbstractCursor[T] {
+  case class LeafCursor[T](path: List[String], tpe: Type, focus: T, encoder: Encoder[T], parent: Option[Cursor], env: Env) extends AbstractCursor[T] {
+    def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
+
     override def isLeaf: Boolean = true
     override def asLeaf: Result[Json] = encoder(focus).rightIor
   }
@@ -265,8 +302,8 @@ object CursorBuilder {
   def deriveLeafCursorBuilder[T](tpe0: Type)(implicit encoder: Encoder[T]): CursorBuilder[T] =
     new CursorBuilder[T] {
       val tpe = tpe0
-      def build(path: List[String], focus: T): Result[Cursor] =
-        new LeafCursor(focus, tpe, path, encoder).rightIor
+      def build(path: List[String], focus: T, parent: Option[Cursor], env: Env): Result[Cursor] =
+        new LeafCursor(path, tpe, focus, encoder, parent, env).rightIor
     }
 
   implicit def leafCursorBuilder[T](implicit encoder: Encoder[T]): CursorBuilder[T] =
@@ -305,7 +342,8 @@ abstract class AbstractCursor[T] extends Cursor {
     mkErrorResult(s"No attribute '$attributeName' for type $tpe")
 }
 
-abstract class PrimitiveCursor[T](val focus: T, val tpe: Type, val path: List[String]) extends AbstractCursor[T] {
+abstract class PrimitiveCursor[T] extends AbstractCursor[T] {
+  val focus: T
   override def isLeaf: Boolean = true
 }
 
@@ -319,4 +357,3 @@ object ShapelessUtils {
     loop(l, Nil)
   }
 }
-

--- a/modules/skunk/src/main/scala/SkunkMappingCompanion.scala
+++ b/modules/skunk/src/main/scala/SkunkMappingCompanion.scala
@@ -12,6 +12,8 @@ import cats.Monad
 import cats.syntax.functor._
 import io.circe.Json
 
+import Cursor.Env
+
 trait SkunkMappingCompanion {
 
   def mkMapping[F[_]: Sync](pool: Resource[F, Session[F]], monitor: SkunkMonitor[F]): Mapping[F]
@@ -50,11 +52,11 @@ trait TracedSkunkMappingCompanion {
     new QueryExecutor[F, (Json, List[List[SkunkStats]])] {
       implicit val M: Monad[F] = Sync[F]
 
-      def run(query: Query, rootTpe: Type): F[(Json, List[List[SkunkStats]])] =
-        stateMapping.run(query, rootTpe).run(Nil).map(_.swap)
+      def run(query: Query, rootTpe: Type, env: Env): F[(Json, List[List[SkunkStats]])] =
+        stateMapping.run(query, rootTpe, env).run(Nil).map(_.swap)
 
-      def compileAndRun(text: String, name: Option[String] = None, untypedEnv: Option[Json] = None, useIntrospection: Boolean = true): F[(Json, List[List[SkunkStats]])] =
-        stateMapping.compileAndRun(text, name, untypedEnv, useIntrospection).run(Nil).map(_.swap)
+      def compileAndRun(text: String, name: Option[String] = None, untypedEnv: Option[Json] = None, useIntrospection: Boolean = true, env: Env = Env.empty): F[(Json, List[List[SkunkStats]])] =
+        stateMapping.compileAndRun(text, name, untypedEnv, useIntrospection, env).run(Nil).map(_.swap)
     }
   }
 }


### PR DESCRIPTION
* Added environment map, lookup, and parent cursor to cursors.
* Added `Environment` element to query algebra.
* Previous `Env` is now `Vars`.

See [here](https://github.com/gemini-hlsw/gsp-graphql/blob/106c8f238699ff40c5cfc18051c0e738b9d6e751/modules/core/src/test/scala/compiler/Environment.scala) for a full example. We can add to the environment of a cursor in a `SelectElaborator`, eg.,

```scala
case Select("sum", List(Binding("x", IntValue(x)), Binding("y", IntValue(y))), child) =>
  Environment(Env("x" -> x, "y" -> y), Select("sum", Nil, child)).rightIor
```

and then retrieve these values via a `Cursor`, eg. in a `CursorField`,

```scala
ObjectMapping(
  tpe = NestedType,
  fieldMappings = List(CursorField("sum", sum))
)

def sum(c: Cursor): Result[Int] =
  (for {
    x <- c.env[Int]("x")
    y <- c.env[Int]("y")
  } yield x+y).toRightIor(mkOneError(s"Missing argument"))
```