### PR TITLE
More fine-grained introspection controls

### DIFF
--- a/modules/core/src/test/scala/introspection/IntrospectionSpec.scala
+++ b/modules/core/src/test/scala/introspection/IntrospectionSpec.scala
@@ -10,6 +10,8 @@ import io.circe.literal.JsonStringContext
 import io.circe.optics.JsonPath.root
 
 import edu.gemini.grackle._
+import QueryCompiler.IntrospectionLevel
+import IntrospectionLevel._
 
 final class IntrospectionSuite extends CatsSuite {
   def standardTypeName(name: String): Boolean = name match {
@@ -1253,7 +1255,38 @@ final class IntrospectionSuite extends CatsSuite {
       }
     """
 
-    val res = TestMapping.compileAndRun(query, useIntrospection = false)
+    val res = TestMapping.compileAndRun(query, introspectionLevel = Disabled)
+    //println(res)
+
+    assert(res == expected)
+  }
+
+  test("introspection disabled typename allowed") {
+    val query = """
+      {
+        users {
+          __typename
+          renamed: __typename
+          name
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "users" : [
+            {
+              "__typename" : "User",
+              "renamed" : "User",
+              "name" : "Luke Skywalker"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = SmallMapping.compileAndRun(query, introspectionLevel = TypenameOnly)
     //println(res)
 
     assert(res == expected)

--- a/modules/doobie/src/main/scala/DoobieMappingCompanion.scala
+++ b/modules/doobie/src/main/scala/DoobieMappingCompanion.scala
@@ -14,6 +14,8 @@ import io.chrisdavenport.log4cats.Logger
 import io.circe.Json
 
 import Cursor.Env
+import QueryCompiler.IntrospectionLevel
+import IntrospectionLevel.Full
 
 trait DoobieMappingCompanion {
   def mkMapping[F[_]: Sync](transactor: Transactor[F], monitor: DoobieMonitor[F]): Mapping[F]
@@ -48,8 +50,8 @@ trait TracedDoobieMappingCompanion {
       def run(query: Query, rootTpe: Type, env: Env): F[(Json, List[List[DoobieStats]])] =
         stateMapping.run(query, rootTpe, env).run(Nil).map(_.swap)
 
-      def compileAndRun(text: String, name: Option[String] = None, untypedVars: Option[Json] = None, useIntrospection: Boolean = true, env: Env = Env.empty): F[(Json, List[List[DoobieStats]])] =
-        stateMapping.compileAndRun(text, name, untypedVars, useIntrospection).run(Nil).map(_.swap)
+      def compileAndRun(text: String, name: Option[String] = None, untypedVars: Option[Json] = None, introspectionLevel: IntrospectionLevel = Full, env: Env = Env.empty): F[(Json, List[List[DoobieStats]])] =
+        stateMapping.compileAndRun(text, name, untypedVars, introspectionLevel).run(Nil).map(_.swap)
     }
   }
 }

--- a/modules/skunk/src/main/scala/SkunkMappingCompanion.scala
+++ b/modules/skunk/src/main/scala/SkunkMappingCompanion.scala
@@ -13,6 +13,8 @@ import cats.syntax.functor._
 import io.circe.Json
 
 import Cursor.Env
+import QueryCompiler.IntrospectionLevel
+import IntrospectionLevel.Full
 
 trait SkunkMappingCompanion {
 
@@ -55,8 +57,8 @@ trait TracedSkunkMappingCompanion {
       def run(query: Query, rootTpe: Type, env: Env): F[(Json, List[List[SkunkStats]])] =
         stateMapping.run(query, rootTpe, env).run(Nil).map(_.swap)
 
-      def compileAndRun(text: String, name: Option[String] = None, untypedEnv: Option[Json] = None, useIntrospection: Boolean = true, env: Env = Env.empty): F[(Json, List[List[SkunkStats]])] =
-        stateMapping.compileAndRun(text, name, untypedEnv, useIntrospection, env).run(Nil).map(_.swap)
+      def compileAndRun(text: String, name: Option[String] = None, untypedEnv: Option[Json] = None, introspectionLevel: IntrospectionLevel = Full, env: Env = Env.empty): F[(Json, List[List[SkunkStats]])] =
+        stateMapping.compileAndRun(text, name, untypedEnv, introspectionLevel, env).run(Nil).map(_.swap)
     }
   }
 }


### PR DESCRIPTION
The Apollo client insists on using `__typename` in normal queries to support deserialization into its generated data types, so we need to be able to leave handling of `__typename` active even if we want to be able to disable the more intrusive forms of introspection.