### PR TITLE
Validate field arguments and input object fields

### DIFF
--- a/modules/core/src/test/scala/compiler/CompilerSpec.scala
+++ b/modules/core/src/test/scala/compiler/CompilerSpec.scala
@@ -273,7 +273,6 @@ final class CompilerSuite extends CatsSuite {
     assert(res == Ior.Left(Chain(expected)))
   }
 
-
   test("invalid: leaf subselection set not empty (2)") {
     val query = """
       query {
@@ -288,6 +287,26 @@ final class CompilerSuite extends CatsSuite {
     val expected = json"""
       {
         "message" : "Leaf field 'name' of Character must have an empty subselection set"
+      }
+    """
+
+    val res = AtomicMapping.compiler.compile(query)
+
+    assert(res == Ior.Left(Chain(expected)))
+  }
+
+  test("invalid: bogus field argument") {
+    val query = """
+      query {
+        character(id: "1000", quux: 23) {
+          name
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "message" : "Unknown argument(s) 'quux' in field character of type Query"
       }
     """
 


### PR DESCRIPTION
Prior to this commit field argument and input object fields which were present in the schema would be validated against the schema as expected. However, field arguments and input value fields which were not mentioned in the schema would be silently dropped.

These bogus arguments and fields are now reported.