### PR TITLE
Fixed prefixed mapping filter issue

### DIFF
--- a/modules/doobie/src/main/scala/DoobieMapping.scala
+++ b/modules/doobie/src/main/scala/DoobieMapping.scala
@@ -13,6 +13,7 @@ import _root_.doobie.implicits._
 import _root_.doobie.util.fragments
 import java.sql.ResultSet
 import scala.annotation.unchecked.uncheckedVariance
+import org.tpolecat.typename.TypeName
 
 abstract class DoobieMapping[F[_]: Sync](
   val transactor: Transactor[F],
@@ -31,7 +32,7 @@ abstract class DoobieMapping[F[_]: Sync](
   def doubleEncoder  = (Put[Double], false)
 
   class TableDef(name: String) {
-    def col(colName: String, codec: Meta[_], nullable: Boolean = false): ColumnRef =
+    def col[A : TypeName](colName: String, codec: Meta[A], nullable: Boolean = false): ColumnRef =
       ColumnRef(name, colName, (codec, nullable))
   }
 

--- a/modules/doobie/src/test/scala/world/WorldCompilerSpec.scala
+++ b/modules/doobie/src/test/scala/world/WorldCompilerSpec.scala
@@ -25,4 +25,6 @@ final class WorldCompilerSpec extends DatabaseSuite with SqlWorldCompilerSpec {
   def simpleRestrictedQuerySql: String =
     "SELECT country.name, country.code FROM country WHERE (country.code = ?)"
 
+  def simpleFilteredQuerySql: String =
+    "SELECT city.name, city.id FROM city WHERE (city.name ILIKE ?)"
 }

--- a/modules/skunk/src/main/scala/skunkmapping.scala
+++ b/modules/skunk/src/main/scala/skunkmapping.scala
@@ -13,6 +13,7 @@ import cats.implicits._
 import edu.gemini.grackle.sql._
 import scala.util.control.NonFatal
 import scala.annotation.unchecked.uncheckedVariance
+import org.tpolecat.typename.TypeName
 
 abstract class SkunkMapping[F[_]: Sync](
   val pool:    Resource[F, Session[F]],
@@ -33,7 +34,7 @@ abstract class SkunkMapping[F[_]: Sync](
   def intEncoder     = int4
 
   class TableDef(name: String) {
-    def col(colName: String, codec: Codec[_]): ColumnRef =
+    def col[A : TypeName](colName: String, codec: Codec[A]): ColumnRef =
       ColumnRef(name, colName, codec)
   }
 

--- a/modules/skunk/src/test/scala/world/WorldCompilerSpec.scala
+++ b/modules/skunk/src/test/scala/world/WorldCompilerSpec.scala
@@ -26,4 +26,6 @@ final class WorldCompilerSpec extends DatabaseSuite with SqlWorldCompilerSpec {
   def simpleRestrictedQuerySql: String =
     "SELECT country.name, country.code FROM country WHERE (country.code = $1)"
 
+  def simpleFilteredQuerySql: String =
+    "SELECT city.name, city.id FROM city WHERE (city.name ILIKE $1)"
 }

--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -267,7 +267,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
               val prefix = termPath.path.init
               obj.path(prefix).flatMap { parent =>
                 val name = termPath.path.last
-                termColumnForField(path.reverse_:::(termPath.path), parent, name)
+                termColumnForField(path.reverse_:::(prefix), parent, name)
               }
             }
           case _ => sys.error("impossible")
@@ -282,9 +282,9 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
 
       def putForTerm[A](x: Term[A]): Option[Encoder[A]] =
         x match {
-          case path: Path =>
+          case termPath: Path =>
             for {
-              cr <- primaryColumnForTerm(path.path, tpe, path)
+              cr <- primaryColumnForTerm(path, tpe, termPath)
             } yield toEncoder(cr.codec.codec.asInstanceOf[Codec[Any]])
 
           case (_: And)|(_: Or)|(_: Not)|(_: Eql[_])|(_: NEql[_])|(_: Lt[_])|(_: LtEql[_])|(_: Gt[_])|(_: GtEql[_])  => Some(booleanEncoder)


### PR DESCRIPTION
+ A bug in the lookup for an encoder corresponding to a field under a prefixed mapping could result in the encoder not being found and filters referring to that term not being translated to SQL where clauses.
+ Added a test for rows fetched for a filtered (rather than unique) query.
+ Also fixed a bug in `TableDef#col` where a bogus `TypeName` instance could be summoned out of thin air.