### PR TITLE
Fixed skunk handling of nullable columns in failed joins

### DIFF
--- a/modules/doobie/src/test/scala/world/WorldData.scala
+++ b/modules/doobie/src/test/scala/world/WorldData.scala
@@ -59,6 +59,7 @@ trait WorldMapping[F[_]] extends WorldPostgresSchema[F] {
     schema"""
       type Query {
         cities(namePattern: String = "%"): [City!]
+        city(id: Int): City
         country(code: String): Country
         countries(limit: Int = -1, minPopulation: Int = 0, byPopulation: Boolean = false): [Country!]
         language(language: String): Language
@@ -107,6 +108,7 @@ trait WorldMapping[F[_]] extends WorldPostgresSchema[F] {
         tpe = QueryType,
         fieldMappings = List(
           SqlRoot("cities"),
+          SqlRoot("city"),
           SqlRoot("country"),
           SqlRoot("countries"),
           SqlRoot("language"),
@@ -164,6 +166,9 @@ trait WorldMapping[F[_]] extends WorldPostgresSchema[F] {
 
       case Select("country", List(Binding("code", StringValue(code))), child) =>
         Select("country", Nil, Unique(Filter(Eql(UniquePath(List("code")), Const(code)), child))).rightIor
+
+      case Select("city", List(Binding("id", IntValue(id))), child) =>
+        Select("city", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
 
       case Select("countries", List(Binding("limit", IntValue(num)), Binding("minPopulation", IntValue(min)), Binding("byPopulation", BooleanValue(byPop))), child) =>
         def limit(query: Query): Query =

--- a/modules/skunk/src/test/scala/mapping/SqlMappingValidatorSpec.scala
+++ b/modules/skunk/src/test/scala/mapping/SqlMappingValidatorSpec.scala
@@ -22,7 +22,7 @@ final class SqlMappingValidatorSpec extends AnyFunSuite {
         tpe = schema.ref("Foo"),
         fieldMappings =
           List(
-            SqlField("bar", ColumnRef("foo", "bar", int2))
+            SqlField("bar", ColumnRef("foo", "bar", (int2, false)))
           )
       ),
       LeafMapping[String](schema.ref("Baz")),

--- a/modules/skunk/src/test/scala/world/WorldData.scala
+++ b/modules/skunk/src/test/scala/world/WorldData.scala
@@ -58,6 +58,7 @@ trait WorldMapping[F[_]] extends WorldPostgresSchema[F] {
     schema"""
       type Query {
         cities(namePattern: String = "%"): [City!]
+        city(id: Int): City
         country(code: String): Country
         countries(limit: Int = -1, minPopulation: Int = 0, byPopulation: Boolean = false): [Country!]
         language(language: String): Language
@@ -106,6 +107,7 @@ trait WorldMapping[F[_]] extends WorldPostgresSchema[F] {
         tpe = QueryType,
         fieldMappings = List(
           SqlRoot("cities"),
+          SqlRoot("city"),
           SqlRoot("country"),
           SqlRoot("countries"),
           SqlRoot("language"),
@@ -163,6 +165,9 @@ trait WorldMapping[F[_]] extends WorldPostgresSchema[F] {
 
       case Select("country", List(Binding("code", StringValue(code))), child) =>
         Select("country", Nil, Unique(Filter(Eql(UniquePath(List("code")), Const(code)), child))).rightIor
+
+      case Select("city", List(Binding("id", IntValue(id))), child) =>
+        Select("city", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
 
       case Select("countries", List(Binding("limit", IntValue(num)), Binding("minPopulation", IntValue(min)), Binding("byPopulation", BooleanValue(byPop))), child) =>
         def limit(query: Query): Query =

--- a/modules/sql/src/test/scala/SqlWorldSpec.scala
+++ b/modules/sql/src/test/scala/SqlWorldSpec.scala
@@ -1153,7 +1153,7 @@ trait SqlWorldSpec extends AnyFunSuite {
     """
 
     val res = mapping.compileAndRun(query).unsafeRunSync()
-    println(res)
+    //println(res)
 
     assertWeaklyEqual(res, expected)
   }

--- a/modules/sql/src/test/scala/SqlWorldSpec.scala
+++ b/modules/sql/src/test/scala/SqlWorldSpec.scala
@@ -1124,4 +1124,38 @@ trait SqlWorldSpec extends AnyFunSuite {
 
     assertWeaklyEqual(res, expected, strictPaths = List(List("data", "countries")))
   }
+
+  test("null in a nullable joined column") {
+    val query = """
+      query {
+        city(id: 33) {
+          name
+          country {
+            name
+            indepyear
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "city" : {
+            "name" : "Willemstad",
+            "country" : {
+              "name" : "Netherlands Antilles",
+              "indepyear" : null
+            }
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
 }


### PR DESCRIPTION
Ok so the deal is that `SkunkMapping` will interpret _any_ null in a joined column as `FailedJoin`, even if the column is nullable, because we don't have any type information at that point. So we can compute nullity and pass it in, or I can add a flag to `Codec` and friends in Skunk.