### PR TITLE
Fixed issue with nested lists

### DIFF
--- a/modules/sql/src/test/scala/GraphQLResponseTests.scala
+++ b/modules/sql/src/test/scala/GraphQLResponseTests.scala
@@ -9,6 +9,25 @@ object GraphQLResponseTests {
   def assertWeaklyEqual(x: Json, y: Json, strictPaths: List[List[String]] = Nil): Unit =
     assert(weaklyEqual(x, y, strictPaths))
 
+  def assertNoErrors(x: Json): Unit =
+    assert(noErrors(x))
+
+  def hasField(x: Json, fieldName: String): Boolean =
+    (for {
+      x0 <- x.asObject
+      _  <- x0(fieldName)
+    } yield true).getOrElse(false)
+
+  def errorsOf(x: Json): Seq[Json] =
+    (for {
+      x0          <- x.asObject
+      errorsField <- x0("errors")
+      errors      <- errorsField.asArray
+    } yield errors).getOrElse(Nil)
+
+  def noErrors(x: Json): Boolean =
+    hasField(x, "data") && !hasField(x, "errors") || errorsOf(x).isEmpty
+
   def weaklyEqual(x: Json, y: Json, strictPaths: List[List[String]] = Nil): Boolean = {
     def cmpObject(x: JsonObject, y: JsonObject, strictPaths: List[List[String]], path: List[String]): Boolean = {
       val xkeys = x.keys

--- a/modules/sql/src/test/scala/SqlWorldSpec.scala
+++ b/modules/sql/src/test/scala/SqlWorldSpec.scala
@@ -11,7 +11,7 @@ import cats.effect.unsafe.implicits.global
 import edu.gemini.grackle._
 import syntax._
 
-import GraphQLResponseTests.assertWeaklyEqual
+import GraphQLResponseTests.{assertNoErrors, assertWeaklyEqual}
 
 trait SqlWorldSpec extends AnyFunSuite {
 
@@ -1158,4 +1158,94 @@ trait SqlWorldSpec extends AnyFunSuite {
     assertWeaklyEqual(res, expected)
   }
 
+  test("multiple nested lists (1)") {
+    val query = """
+      query {
+        language(language: "Icelandic") {
+          one: countries {
+            cities {
+              name
+            }
+            languages {
+              language
+            }
+          }
+          two: countries {
+            cities {
+              name
+            }
+            languages {
+              language
+              one: countries {
+                cities {
+                  name
+                }
+                languages {
+                  language
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertNoErrors(res)
+  }
+
+  test("multiple nested lists (2)") {
+    val query = """
+      query {
+        language(language: "Icelandic") {
+          countries {
+            cities {
+              name
+            }
+            languages {
+              countries {
+                cities {
+                  name
+                }
+                languages {
+                  language
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertNoErrors(res)
+  }
+
+  test("multiple nested lists (3)") {
+    val query = """
+      query {
+        language(language: "Icelandic") {
+          countries {
+            cities {
+              name
+            }
+            languages {
+              countries {
+                name
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertNoErrors(res)
+  }
 }


### PR DESCRIPTION
Nested list structures which generated SQL unions on the left hand side of a join could cause alias confusions leading to either incorrect SQL being generated or, if the SQL was correct, incorrect indexing into the result set.

This PR fixes that and also simplified and cleans up the the `nest` operation on `SQLUnion`.