### PR TITLE
In should use the right encoder

### DIFF
--- a/modules/doobie/src/test/scala/scalars/MovieData.scala
+++ b/modules/doobie/src/test/scala/scalars/MovieData.scala
@@ -119,6 +119,7 @@ trait MovieMapping[F[_]] extends DoobieMapping[F] {
         type Query {
           movieById(id: UUID!): Movie
           moviesByGenre(genre: Genre!): [Movie!]!
+          moviesByGenres(genres: [Genre!]): [Movie!]!
           moviesReleasedBetween(from: Date!, to: Date!): [Movie!]!
           moviesLongerThan(duration: Interval!): [Movie!]!
           moviesShownLaterThan(time: Time!): [Movie!]!
@@ -172,6 +173,7 @@ trait MovieMapping[F[_]] extends DoobieMapping[F] {
           List(
             SqlRoot("movieById"),
             SqlRoot("moviesByGenre"),
+            SqlRoot("moviesByGenres"),
             SqlRoot("moviesReleasedBetween"),
             SqlRoot("moviesLongerThan"),
             SqlRoot("moviesShownLaterThan"),
@@ -247,12 +249,22 @@ trait MovieMapping[F[_]] extends DoobieMapping[F] {
       Genre.fromString(e.value.name)
   }
 
+  object GenreListValue {
+    def unapply(gs: ListValue): Option[List[Genre]] =
+      gs.elems.traverse {
+        case GenreValue(g) => Some(g)
+        case _ => None
+      }
+  }
+
   override val selectElaborator = new SelectElaborator(Map(
     QueryType -> {
       case Select("movieById", List(Binding("id", UUIDValue(id))), child) =>
         Select("movieById", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
       case Select("moviesByGenre", List(Binding("genre", GenreValue(genre))), child) =>
         Select("moviesByGenre", Nil, Filter(Eql(UniquePath(List("genre")), Const(genre)), child)).rightIor
+      case Select("moviesByGenres", List(Binding("genres", GenreListValue(genres))), child) =>
+        Select("moviesByGenres", Nil, Filter(In(UniquePath(List("genre")), genres), child)).rightIor
       case Select("moviesReleasedBetween", List(Binding("from", DateValue(from)), Binding("to", DateValue(to))), child) =>
         Select("moviesReleasedBetween", Nil,
           Filter(

--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -793,9 +793,11 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
             binaryOp(x, y)(Fragments.const(" >= "))
 
           case In(x, y) =>
-            NonEmptyList.fromList(y).flatMap { ys =>
-              binaryOp2(x)(nx => Fragments.in(nx.toFragment, ys, e))
-            }
+            for {
+              enc <- encoderForTerm(context, x)
+              ys  <- NonEmptyList.fromList(y)
+              w   <- binaryOp2(x)(nx => Fragments.in(nx.toFragment, ys, enc))
+            } yield w
 
           case AndB(x, y) =>
             binaryOp(x, y)(Fragments.const(" & "), Some(intEncoder))

--- a/modules/sql/src/test/scala/SqlMovieSpec.scala
+++ b/modules/sql/src/test/scala/SqlMovieSpec.scala
@@ -380,4 +380,44 @@ trait SqlMovieSpec extends AnyFunSuite {
     assertWeaklyEqual(res, expected)
   }
 
+  test("query with enum list argument") {
+    val query = """
+      query {
+        moviesByGenres(genres: [COMEDY, ACTION]) {
+          title
+          genre
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "moviesByGenres" : [
+            {
+              "title" : "Zazie dans le Métro",
+              "genre" : "COMEDY"
+            },
+            {
+              "title" : "Alphaville",
+              "genre" : "ACTION"
+            },
+            {
+              "title" : "Weekend",
+              "genre" : "COMEDY"
+            },
+            {
+              "title" : "Daisies",
+              "genre" : "COMEDY"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
 }


### PR DESCRIPTION
The compilation of `In` was using the wrong encoder (the encoder for the result type, ie. `Boolean`) rather than the encoder for the argument type.