### PR TITLE
Attempt to extract doobie Put.Advanced type name

### DIFF
--- a/modules/doobie/src/main/scala/DoobieMapping.scala
+++ b/modules/doobie/src/main/scala/DoobieMapping.scala
@@ -101,7 +101,6 @@ abstract class DoobieMapping[F[_]: Sync](
           case Null                  => Some("NULL")
           case Numeric               => Some("NUMERIC")
           case NVarChar              => Some("NVARCHAR")
-          case Other                 => Some("OTHER")
           case Real                  => Some("REAL")
           case Ref                   => Some("REF")
           case RefCursor             => Some("REF CURSOR")
@@ -116,6 +115,13 @@ abstract class DoobieMapping[F[_]: Sync](
           case TinyInt               => Some("TINYINT")
           case VarBinary             => Some("VARBINARY")
           case VarChar               => Some("VARCHAR")
+          case Other                 =>
+            codec._1.put match {
+              case adv: Put.Advanced[_] =>
+                Some(adv.schemaTypes.head)
+              case _ => None
+            }
+
           case _                     => None
         }
     }


### PR DESCRIPTION
Previously doobie Advanced Puts were mapped to a bogus SQL type name `"OTHER"`. Now we attempt to extract the underlying `schemaTypes` name.

This showed up in a scenario where we had a pair of lists at the same level in the structure with the elements of one having a Json field that was not present in the other. This resulted in Grackle synthesizing a column for a union as `(NULL: OTHER)` rather than
`(NULL: json)`.