### PR TITLE
Fix immediate self-joins

### DIFF
--- a/modules/doobie/src/test/scala/tree/TreeData.scala
+++ b/modules/doobie/src/test/scala/tree/TreeData.scala
@@ -1,0 +1,72 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package tree
+
+import cats.effect.Sync
+import cats.implicits._
+import doobie.util.meta.Meta
+import doobie.util.transactor.Transactor
+
+import edu.gemini.grackle._, doobie._
+import edu.gemini.grackle.syntax._
+import Query._, Path._, Predicate._, Value._
+import QueryCompiler._
+
+trait TreeMapping[F[_]] extends DoobieMapping[F] {
+
+  object bintree extends TableDef("bintree") {
+    val id = col("id", Meta[Int])
+    val leftChild = col("left_child", Meta[Int], nullable = true)
+    val rightChild = col("right_child", Meta[Int], nullable = true)
+  }
+
+  val schema =
+    schema"""
+      type Query {
+        bintree(id: Int!): BinTree
+      }
+      type BinTree {
+        id: Int!
+        left: BinTree
+        right: BinTree
+      }
+    """
+
+  val QueryType = schema.ref("Query")
+  val BinTreeType = schema.ref("BinTree")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            SqlRoot("bintree")
+          )
+      ),
+      SqlUnionMapping(
+        tpe = BinTreeType,
+        fieldMappings =
+          List(
+            SqlField("id", bintree.id, key = true),
+            SqlObject("left", Join(bintree.leftChild, bintree.id)),
+            SqlObject("right", Join(bintree.rightChild, bintree.id)),
+          )
+      )
+    )
+
+  override val selectElaborator: SelectElaborator = new SelectElaborator(Map(
+    QueryType -> {
+      case Select("bintree", List(Binding("id", IntValue(id))), child) =>
+        Select("bintree", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+
+      case other => other.rightIor
+    }
+  ))
+}
+
+object TreeMapping extends DoobieMappingCompanion {
+  def mkMapping[F[_]: Sync](transactor: Transactor[F], monitor: DoobieMonitor[F]): Mapping[F] =
+    new DoobieMapping[F](transactor, monitor) with TreeMapping[F]
+}

--- a/modules/doobie/src/test/scala/tree/TreeSpec.scala
+++ b/modules/doobie/src/test/scala/tree/TreeSpec.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package tree
+
+import utils.DatabaseSuite
+import grackle.test.SqlTreeSpec
+
+final class TreeSpec extends DatabaseSuite with SqlTreeSpec {
+  lazy val mapping = TreeMapping.fromTransactor(xa)
+}

--- a/modules/skunk/src/test/scala/tree/TreeData.scala
+++ b/modules/skunk/src/test/scala/tree/TreeData.scala
@@ -1,0 +1,72 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package tree
+
+import cats.effect.{Resource, Sync}
+import cats.implicits._
+import skunk.Session
+import skunk.codec.all._
+
+import edu.gemini.grackle._, skunk._
+import edu.gemini.grackle.syntax._
+import Query._, Path._, Predicate._, Value._
+import QueryCompiler._
+
+trait TreeMapping[F[_]] extends SkunkMapping[F] {
+
+  object bintree extends TableDef("bintree") {
+    val id = col("id", int4)
+    val leftChild = col("left_child", int4.opt)
+    val rightChild = col("right_child", int4.opt)
+  }
+
+  val schema =
+    schema"""
+      type Query {
+        bintree(id: Int!): BinTree
+      }
+      type BinTree {
+        id: Int!
+        left: BinTree
+        right: BinTree
+      }
+    """
+
+  val QueryType = schema.ref("Query")
+  val BinTreeType = schema.ref("BinTree")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            SqlRoot("bintree")
+          )
+      ),
+      SqlUnionMapping(
+        tpe = BinTreeType,
+        fieldMappings =
+          List(
+            SqlField("id", bintree.id, key = true),
+            SqlObject("left", Join(bintree.leftChild, bintree.id)),
+            SqlObject("right", Join(bintree.rightChild, bintree.id)),
+          )
+      )
+    )
+
+  override val selectElaborator: SelectElaborator = new SelectElaborator(Map(
+    QueryType -> {
+      case Select("bintree", List(Binding("id", IntValue(id))), child) =>
+        Select("bintree", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+
+      case other => other.rightIor
+    }
+  ))
+}
+
+object TreeMapping extends SkunkMappingCompanion {
+  def mkMapping[F[_]: Sync](pool: Resource[F, Session[F]], monitor: SkunkMonitor[F]): Mapping[F] =
+    new SkunkMapping[F](pool, monitor) with TreeMapping[F]
+}

--- a/modules/skunk/src/test/scala/tree/TreeSpec.scala
+++ b/modules/skunk/src/test/scala/tree/TreeSpec.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package tree
+
+import utils.DatabaseSuite
+import grackle.test.SqlTreeSpec
+
+final class TreeSpec extends DatabaseSuite with SqlTreeSpec {
+  lazy val mapping = TreeMapping.mkMapping(pool)
+}

--- a/modules/sql/src/test/resources/db/tree.sql
+++ b/modules/sql/src/test/resources/db/tree.sql
@@ -1,0 +1,15 @@
+CREATE TABLE bintree (
+  id INTEGER PRIMARY KEY,
+  left_child INTEGER,
+  right_child INTEGER
+);
+
+COPY bintree (id, left_child, right_child) FROM STDIN WITH DELIMITER '|';
+0|1|2
+1|3|4
+2|5|6
+3|\N|\N
+4|\N|\N
+5|\N|\N
+6|\N|\N
+\.

--- a/modules/sql/src/test/scala/SqlTreeSpec.scala
+++ b/modules/sql/src/test/scala/SqlTreeSpec.scala
@@ -1,0 +1,209 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package grackle.test
+
+import cats.effect.IO
+import io.circe.Json
+import org.scalatest.funsuite.AnyFunSuite
+import cats.effect.unsafe.implicits.global
+
+import edu.gemini.grackle._
+import syntax._
+
+import GraphQLResponseTests.assertWeaklyEqual
+
+trait SqlTreeSpec extends AnyFunSuite {
+  def mapping: QueryExecutor[IO, Json]
+
+  test("root query") {
+    val query = """
+      query {
+        bintree(id: 0) {
+          id
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "bintree" : {
+            "id" : 0
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("child query (1)") {
+    val query = """
+      query {
+        bintree(id: 0) {
+          id
+          left {
+            id
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "bintree" : {
+            "id" : 0,
+            "left" : {
+              "id" : 1
+            }
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("child query (2)") {
+    val query = """
+      query {
+        bintree(id: 0) {
+          id
+          left {
+            id
+          }
+          right {
+            id
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "bintree" : {
+            "id" : 0,
+            "left" : {
+              "id" : 1
+            },
+            "right" : {
+              "id" : 2
+            }
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("child query (3)") {
+    val query = """
+      query {
+        bintree(id: 0) {
+          id
+          left {
+            id
+            left {
+              id
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "bintree" : {
+            "id" : 0,
+            "left" : {
+              "id" : 1,
+              "left" : {
+                "id" : 3
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("child query (4)") {
+    val query = """
+      query {
+        bintree(id: 0) {
+          id
+          left {
+            id
+            left {
+              id
+            }
+            right {
+              id
+            }
+          }
+          right {
+            id
+            left {
+              id
+            }
+            right {
+              id
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "bintree" : {
+            "id" : 0,
+            "left" : {
+              "id" : 1,
+              "left" : {
+                "id" : 3
+              },
+              "right" : {
+                "id" : 4
+              }
+            },
+            "right" : {
+              "id" : 2,
+              "left" : {
+                "id" : 5
+              },
+              "right" : {
+                "id" : 6
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+}


### PR DESCRIPTION
It turns out that up until now no one has attempted to represent a _directly_ recursive structure in Grackle ... all recursion has been indirect via one more more intermediate types.

A bug was revealed in the attempt to do this: we need to alias the child table of a join if it has already been seen, however prior to this PR, if the parent of the join is the same as the child, then both ends would be renamed, resulting in a join condition which would typically be empty.

This PR fixes that by ensuring that we only alias the child. 