### PR TITLE
Fix aliasing of nested joins

### DIFF
--- a/modules/doobie/src/test/scala/graph/GraphData.scala
+++ b/modules/doobie/src/test/scala/graph/GraphData.scala
@@ -1,0 +1,89 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package graph
+
+import cats.effect.Sync
+import cats.implicits._
+import doobie.util.meta.Meta
+import doobie.util.transactor.Transactor
+
+import edu.gemini.grackle._, doobie._
+import edu.gemini.grackle.syntax._
+import Query._, Path._, Predicate._, Value._
+import QueryCompiler._
+
+trait GraphMapping[F[_]] extends DoobieMapping[F] {
+
+  object graphNode extends TableDef("graph_node") {
+    val id = col("id", Meta[Int])
+  }
+
+  object graphEdge extends TableDef("graph_edge") {
+    val id = col("id", Meta[Int])
+    val a = col("a", Meta[Int], nullable = true)
+    val b = col("b", Meta[Int], nullable = true)
+  }
+
+  val schema =
+    schema"""
+      type Query {
+        node(id: Int!): Node
+      }
+      type Node {
+        id: Int!
+        neighbours: [Node!]!
+      }
+      type Edge {
+        id: Int!
+        a: Node
+        b: Node
+      }
+    """
+
+  val QueryType = schema.ref("Query")
+  val NodeType = schema.ref("Node")
+  val EdgeType = schema.ref("Edge")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            SqlRoot("node")
+          )
+      ),
+      ObjectMapping(
+        tpe = NodeType,
+        fieldMappings =
+          List(
+            SqlField("id", graphNode.id, key = true),
+            SqlObject("neighbours", Join(graphNode.id, graphEdge.a), Join(graphEdge.b, graphNode.id))
+          )
+      ),
+      ObjectMapping(
+        tpe = EdgeType,
+        fieldMappings =
+          List(
+            SqlField("id", graphEdge.id, key = true),
+            SqlObject("a", Join(graphEdge.a, graphNode.id)),
+            SqlObject("b", Join(graphEdge.b, graphNode.id))
+          )
+      )
+    )
+
+  override val selectElaborator: SelectElaborator = new SelectElaborator(Map(
+    QueryType -> {
+      case Select("node", List(Binding("id", IntValue(id))), child) =>
+        Select("node", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+
+      case other => other.rightIor
+    }
+  ))
+}
+
+object GraphMapping extends DoobieMappingCompanion {
+  def mkMapping[F[_]: Sync](transactor: Transactor[F], monitor: DoobieMonitor[F]): Mapping[F] =
+    new DoobieMapping[F](transactor, monitor) with GraphMapping[F]
+}

--- a/modules/doobie/src/test/scala/graph/GraphSpec.scala
+++ b/modules/doobie/src/test/scala/graph/GraphSpec.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package graph
+
+import utils.DatabaseSuite
+import grackle.test.SqlGraphSpec
+
+final class GraphSpec extends DatabaseSuite with SqlGraphSpec {
+  lazy val mapping = GraphMapping.fromTransactor(xa)
+}

--- a/modules/doobie/src/test/scala/tree/TreeData.scala
+++ b/modules/doobie/src/test/scala/tree/TreeData.scala
@@ -45,7 +45,7 @@ trait TreeMapping[F[_]] extends DoobieMapping[F] {
             SqlRoot("bintree")
           )
       ),
-      SqlUnionMapping(
+      ObjectMapping(
         tpe = BinTreeType,
         fieldMappings =
           List(

--- a/modules/skunk/src/test/scala/graph/GraphData.scala
+++ b/modules/skunk/src/test/scala/graph/GraphData.scala
@@ -1,0 +1,89 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package graph
+
+import cats.effect.{Resource, Sync}
+import cats.implicits._
+import skunk.Session
+import skunk.codec.all._
+
+import edu.gemini.grackle._, skunk._
+import edu.gemini.grackle.syntax._
+import Query._, Path._, Predicate._, Value._
+import QueryCompiler._
+
+trait GraphMapping[F[_]] extends SkunkMapping[F] {
+
+  object graphNode extends TableDef("graph_node") {
+    val id = col("id", int4)
+  }
+
+  object graphEdge extends TableDef("graph_edge") {
+    val id = col("id", int4)
+    val a = col("a", int4.opt)
+    val b = col("b", int4.opt)
+  }
+
+  val schema =
+    schema"""
+      type Query {
+        node(id: Int!): Node
+      }
+      type Node {
+        id: Int!
+        neighbours: [Node!]!
+      }
+      type Edge {
+        id: Int!
+        a: Node
+        b: Node
+      }
+    """
+
+  val QueryType = schema.ref("Query")
+  val NodeType = schema.ref("Node")
+  val EdgeType = schema.ref("Edge")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            SqlRoot("node")
+          )
+      ),
+      ObjectMapping(
+        tpe = NodeType,
+        fieldMappings =
+          List(
+            SqlField("id", graphNode.id, key = true),
+            SqlObject("neighbours", Join(graphNode.id, graphEdge.a), Join(graphEdge.b, graphNode.id))
+          )
+      ),
+      ObjectMapping(
+        tpe = EdgeType,
+        fieldMappings =
+          List(
+            SqlField("id", graphEdge.id, key = true),
+            SqlObject("a", Join(graphEdge.a, graphNode.id)),
+            SqlObject("b", Join(graphEdge.b, graphNode.id))
+          )
+      )
+    )
+
+  override val selectElaborator: SelectElaborator = new SelectElaborator(Map(
+    QueryType -> {
+      case Select("node", List(Binding("id", IntValue(id))), child) =>
+        Select("node", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
+
+      case other => other.rightIor
+    }
+  ))
+}
+
+object GraphMapping extends SkunkMappingCompanion {
+  def mkMapping[F[_]: Sync](pool: Resource[F, Session[F]], monitor: SkunkMonitor[F]): Mapping[F] =
+    new SkunkMapping[F](pool, monitor) with GraphMapping[F]
+}

--- a/modules/skunk/src/test/scala/graph/GraphSpec.scala
+++ b/modules/skunk/src/test/scala/graph/GraphSpec.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package graph
+
+import utils.DatabaseSuite
+import grackle.test.SqlGraphSpec
+
+final class GraphSpec extends DatabaseSuite with SqlGraphSpec {
+  lazy val mapping = GraphMapping.mkMapping(pool)
+}

--- a/modules/skunk/src/test/scala/tree/TreeData.scala
+++ b/modules/skunk/src/test/scala/tree/TreeData.scala
@@ -45,7 +45,7 @@ trait TreeMapping[F[_]] extends SkunkMapping[F] {
             SqlRoot("bintree")
           )
       ),
-      SqlUnionMapping(
+      ObjectMapping(
         tpe = BinTreeType,
         fieldMappings =
           List(

--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -381,6 +381,8 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
         case Some(SqlJson(_, cr)) => List(applyColumnAliases(context.resultPath, cr))
         case Some(CursorField(_, _, _, required, _)) =>
           required.flatMap(r => columnsForLeaf(context, r))
+        case None =>
+          sys.error(s"No mapping for field '$fieldName' of type ${context.tpe}")
         case other =>
           sys.error(s"Non-leaf mapping for field '$fieldName' of type ${context.tpe}: $other")
       }

--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -4,7 +4,7 @@
 package edu.gemini.grackle
 package sql
 
-import scala.annotation.nowarn
+import scala.annotation.{nowarn, tailrec}
 
 import cats.data.NonEmptyList
 import cats.implicits._
@@ -394,15 +394,15 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
         case SqlObject(_, joins) =>
           val aliased = joins.map(j => this.applyJoinAliases(context.resultPath, j))
           for {
-            pt           <- this.parentTableForType(context)
             fieldContext <- context.forField(fieldName, resultName)
             ct           <- this.parentTableForType(fieldContext)
           } yield {
             val inner = !fieldContext.tpe.isNullable && !fieldContext.tpe.isList
-            val sjoins = SqlJoin.fromJoins(pt, ct, aliased, plural, inner)
-            val (am1, sjoins1) =
-              sjoins.foldLeft((this, List.empty[SqlJoin])) {
-                case ((am0, sjoins0), sjoin) =>
+            val sjoins = SqlJoin.fromJoins(ct, aliased, plural, inner)
+            val (am1, _, sjoins1) =
+              sjoins.foldLeft((this, Option.empty[String], List.empty[SqlJoin])) {
+                case ((am0, prevChild, sjoins0), sjoin0) =>
+                  val sjoin = prevChild.map(c => sjoin0.substParent(TableRef.fromRefName(sjoin0.parent), TableRef.fromRefName(c))).getOrElse(sjoin0)
                   sjoin.child match {
                     case tr: TableRef =>
                       val (am, join) =
@@ -410,7 +410,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
                           val aliased = am0.aliasTable(fieldContext, tr.refName)
                           (aliased._1, sjoin.substChild(tr, tr.copy(alias = Some(aliased._2))))
                         } else
-                          (am0, sjoin)
+                          (am0.seenTable(tr.refName), sjoin)
 
                       if (isAssociative(fieldContext)) {
                         // TODO: Merge this with the filter/order by/limit predicate join logic
@@ -420,14 +420,15 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
                         val joinChild = join.child.refName
                         val on = keys.map(key => (key.move(table = idTable), key.move(table = joinChild)))
                         val selfJoin = SqlJoin(idTable, join.child, on, plural, false, false)
-                        (am1, selfJoin :: join0 :: sjoins0)
+                        (am1, Some(selfJoin.child.refName), selfJoin :: join0 :: sjoins0)
                       } else {
-                        (am, join :: sjoins0)
+                        (am, Some(join.child.refName), join :: sjoins0)
                       }
                     case _: SubqueryRef =>
-                      (am0, sjoin :: sjoins0)
+                      (am0, Some(sjoin.child.refName), sjoin :: sjoins0)
                   }
               }
+
             (am1, sjoins1.reverse)
           }
         case _ => None
@@ -747,13 +748,13 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
             val wheres = sels.flatMap(_.wheres).distinct
             SqlSelect(context, table, cols, sels.head.joins, wheres, orders, limit, distinct)
           }
-          val sameJoins = joins.groupBy(_.joins.toSet).values.map(combineSameJoins).toList
+          val sameJoins = joins.groupBy(_.joins).values.map(combineSameJoins).toList
 
           val (pluralJoins, singularJoins) = sameJoins.partition(_.plural)
 
           val combined: Option[SqlSelect] = {
             val cols = (singularJoins.flatMap(_.cols) ++ noJoins.flatMap(_.cols)).distinct
-            val joins = singularJoins.flatMap(_.joins).distinct
+            val joins = singularJoins.flatMap(_.joins)
             val wheres = (singularJoins.flatMap(_.wheres) ++ noJoins.flatMap(_.wheres)).distinct
             if (cols.isEmpty) {
               assert(joins.isEmpty && wheres.isEmpty)
@@ -766,7 +767,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
             case (Some(c), Nil) => List(c)
             case (Some(c), p :: ps) =>
               val cols = (c.cols ++ p.cols).distinct
-              val joins = (c.joins ++ p.joins).distinct
+              val joins = (c.joins ++ p.joins)
               val wheres = (c.wheres ++ p.wheres).distinct
               p.copy(cols = cols, joins = joins, wheres = wheres) :: ps
           }
@@ -975,7 +976,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
     case class SqlSelect(
       context:  Context,             // the GraphQL context of the query
       table:    TableExpr,           // the table/subquery
-      cols:     List[Column],     // the requested columns
+      cols:     List[Column],        // the requested columns
       joins:    List[SqlJoin],       // joins for predicates/subobjects
       wheres:   List[Where],
       orders:   List[Order],
@@ -985,6 +986,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
       collate:  Set[Column] = Set.empty[Column]  // The set of columns requiring collation
     ) extends SqlQuery {
       assert(aliases.isEmpty || aliases.sizeCompare(cols) == 0)
+      assert(SqlJoin.checkOrdering(table.refName, joins))
 
       /** This query in the given context */
       def withContext(context: Context): SqlSelect =
@@ -1079,7 +1081,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
                 extraJoins
             }
 
-          (copy(context = parentContext, table = parentTable, cols = (cols ++ extraCols).distinct, joins = (newJoins ++ joins)), aliasedMappings)
+          (copy(context = parentContext, table = parentTable, cols = (cols ++ extraCols).distinct, joins = (newJoins ++ joins.filterNot(newJoins.contains))), aliasedMappings)
         }
       }
 
@@ -1311,14 +1313,15 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
 
     /** Representation of an SQL join */
     case class SqlJoin(
-      parent:  String,                        // name of parent table
-      child:   TableExpr,                     // child table/subquery
+      parent:  String,                  // name of parent table
+      child:   TableExpr,               // child table/subquery
       on:      List[(Column, Column)],  // join conditions
-      plural:  Boolean,                       // does the result of this join contain a list of subobjects?
+      plural:  Boolean,                 // does the result of this join contain a list of subobjects?
       lateral: Boolean,
       inner:   Boolean
     ) {
       assert(on.forall { case (p, c) => p.table == parent && c.table == child.refName })
+      assert(child.name.map(!_.contains("_alias_")).getOrElse(true))
 
       /** Replace references to `from` with `to` */
       def subst(from: TableExpr, to: TableExpr): SqlJoin = {
@@ -1333,6 +1336,12 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
           }
         val newOn = on.map { case (p, c) => (p.subst(from, to), c.subst(from, to)) }
         copy(parent = newParent, child = newChild, on = newOn)
+      }
+
+      def substParent(from: TableExpr, to: TableExpr): SqlJoin = {
+        val newParent = if(parent == from.refName) to.refName else parent
+        val newOn = on.map { case (p, c) => (p.subst(from, to), c) }
+        copy(parent = newParent, on = newOn)
       }
 
       def substChild(from: TableExpr, to: TableExpr): SqlJoin = {
@@ -1377,52 +1386,28 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
     }
 
     object SqlJoin {
-      def fromJoins(parent: TableRef, child: TableRef, joins: List[Join], plural: Boolean, inner: Boolean): List[SqlJoin] = {
-        val sjoins =
-          joins.groupBy(j => (j.parent.table, j.child.table)).map { case (_, joins0) =>
-            val first = joins0.head
-            val parent0 = first.parent.table
-            val child0 = first.child.table
-            val child1 = if (child0 == child.refName) child else TableRef(child0)
-
-            new SqlJoin(parent0, child1, joins0.map(j => (j.parent, j.child)), plural, false, inner)
-          }.toList
-
-        if (sjoins.sizeCompare(1) == 0) sjoins
-        else {
-          val allTables = sjoins.flatMap { sjoin => List(sjoin.parent, sjoin.child.refName) }.distinct
-          val descendentTables = allTables.filter(t => t != parent.refName)
-
-          def relates(x: String, ys: List[String])(sjoin: SqlJoin): Boolean =
-            (sjoin.parent == x && ys.contains(sjoin.child.refName)) || (ys.contains(sjoin.parent) && sjoin.child.refName == x)
-
-          def orderTables(tables: List[String], pending: List[String], acc: List[String]): List[String] =
-            tables match {
-              case Nil =>
-                if (!pending.isEmpty) sys.error(s"Unable to order tables: $this")
-                acc.reverse.tail
-              case hd :: tl =>
-                if (sjoins.exists(relates(hd, acc)))
-                  orderTables(tl.reverse_:::(pending), Nil, hd :: acc)
-                else
-                  orderTables(tl, hd :: pending, acc)
-            }
-
-          def orderJoins(tables: List[String], sjoins: List[SqlJoin], seen: List[String], acc: List[SqlJoin]): List[SqlJoin] =
-            tables match {
-              case Nil =>
-                if (!sjoins.isEmpty) sys.error(s"Unable to order joins: $this")
-                acc.reverse
-              case hd :: tl =>
-                val (next, rest) = sjoins.partition(relates(hd, seen))
-                orderJoins(tl, rest, hd :: tl, acc.reverse_:::(next))
-            }
-
-          val orderedTables = orderTables(descendentTables, Nil, List(parent.refName))
-          val orderedJoins = orderJoins(orderedTables, sjoins, List(parent.refName), Nil)
-
-          orderedJoins
+      def unaliasTable(table: String): String =
+        table.indexOf("_alias_") match {
+          case -1 => table
+          case n => table.take(n)
         }
+
+      def fromJoins(child: TableRef, joins: List[Join], plural: Boolean, inner: Boolean): List[SqlJoin] =
+        joins.map { j =>
+          val child0 = if (j.child.table == child.refName) child else TableRef.fromRefName(j.child.table)
+          new SqlJoin(j.parent.table, child0, List((j.parent, j.child)), plural, false, inner)
+        }
+
+      def checkOrdering(parent: String, joins: List[SqlJoin]): Boolean = {
+        @tailrec
+        def loop(joins: List[SqlJoin], seen: Set[String]): Boolean = {
+          joins match {
+            case Nil => true
+            case hd :: tl =>
+              seen.contains(hd.parent) && loop(tl, seen+hd.child.refName)
+          }
+        }
+        loop(joins, Set(parent))
       }
     }
 

--- a/modules/sql/src/test/resources/db/graph.sql
+++ b/modules/sql/src/test/resources/db/graph.sql
@@ -1,0 +1,23 @@
+CREATE TABLE graph_node (
+  id INTEGER PRIMARY KEY
+);
+
+CREATE TABLE graph_edge (
+  id INTEGER PRIMARY KEY,
+  a INTEGER,
+  b INTEGER
+);
+
+COPY graph_node (id) FROM STDIN WITH DELIMITER '|';
+1
+2
+3
+4
+\.
+
+COPY graph_edge (id, a, b) FROM STDIN WITH DELIMITER '|';
+12|1|2
+13|1|3
+24|2|4
+34|3|4
+\.

--- a/modules/sql/src/test/scala/SqlGraphSpec.scala
+++ b/modules/sql/src/test/scala/SqlGraphSpec.scala
@@ -1,0 +1,128 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package grackle.test
+
+import cats.effect.IO
+import io.circe.Json
+import org.scalatest.funsuite.AnyFunSuite
+import cats.effect.unsafe.implicits.global
+
+import edu.gemini.grackle._
+import syntax._
+
+import GraphQLResponseTests.assertWeaklyEqual
+
+trait SqlGraphSpec extends AnyFunSuite {
+  def mapping: QueryExecutor[IO, Json]
+
+  test("root query") {
+    val query = """
+      query {
+        node(id: 1) {
+          id
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "node" : {
+            "id" : 1
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("neighbour query (1)") {
+    val query = """
+      query {
+        node(id: 1) {
+          id
+          neighbours {
+            id
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "node" : {
+            "id" : 1,
+            "neighbours" : [
+              {
+                "id" : 2
+              },
+              {
+                "id" : 3
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("neighbour query (2)") {
+    val query = """
+      query {
+        node(id: 1) {
+          id
+          neighbours {
+            id
+            neighbours {
+              id
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "node" : {
+            "id" : 1,
+            "neighbours" : [
+              {
+                "id" : 2,
+                "neighbours" : [
+                  {
+                    "id" : 4
+                  }
+                ]
+              },
+              {
+                "id" : 3,
+                "neighbours" : [
+                  {
+                    "id" : 4
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+}


### PR DESCRIPTION
Correctly alias all along the path in cases where a `SubObject` is reached via a nested join.

Also a couple of minor cleanups (whitespace, accidental use of `SqlUnionMapping` instead of `ObjectMapping` and an improved error report).