### PR TITLE
Type conditions may widen as well as narrow

### DIFF
--- a/modules/circe/src/test/scala/CirceSpec.scala
+++ b/modules/circe/src/test/scala/CirceSpec.scala
@@ -175,6 +175,39 @@ final class CirceSpec extends CatsSuite {
     assert(res == expected)
   }
 
+  test("supertype fragment") {
+    val query = """
+      query {
+        root {
+          object {
+            ... on Child {
+              id
+            }
+            aField
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "root" : {
+            "object" : {
+              "id" : "obj",
+              "aField" : 27
+            }
+          }
+        }
+      }
+    """
+
+    val res = TestCirceMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
   test("introspection") {
     val query = """
       query {

--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -406,7 +406,7 @@ object QueryCompiler {
             subtpe <- schema.definition(tpnme)
           } yield {
             transform(child, vars, schema, subtpe).map { ec =>
-              if (tpe.underlyingObject.map(_ =:= subtpe).getOrElse(false)) ec else Narrow(schema.ref(tpnme), ec)
+              if (tpe.underlyingObject.map(_ <:< subtpe).getOrElse(false)) ec else Narrow(schema.ref(tpnme), ec)
             }
           }).getOrElse(mkErrorResult(s"Unknown type '$tpnme' in type condition"))
 

--- a/modules/generic/src/test/scala/derivation.scala
+++ b/modules/generic/src/test/scala/derivation.scala
@@ -472,6 +472,35 @@ final class DerivationSpec extends CatsSuite {
     assert(res == expected)
   }
 
+  test("supertype fragment query") {
+    val query = """
+      query {
+        human(id: "1000") {
+          id
+          ... on Character {
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "human" : {
+            "id" : "1000",
+            "name" : "Luke Skywalker"
+          }
+        }
+      }
+    """
+
+    val res = StarWarsMapping.compileAndRun(query)
+    //println(res)
+
+    assert(res == expected)
+  }
+
   test("count") {
     val query = """
       query {

--- a/modules/sql/src/test/scala/SqlInterfacesSpec.scala
+++ b/modules/sql/src/test/scala/SqlInterfacesSpec.scala
@@ -594,4 +594,43 @@ trait SqlInterfacesSpec extends AnyFunSuite {
 
     assertWeaklyEqual(res, expected)
   }
+
+  test("interface query with supertype fragment") {
+    val query = """
+      query {
+        films {
+          ... on Entity {
+            id
+          }
+          rating
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "films" : [
+            {
+              "id" : "1",
+              "rating" : "PG"
+            },
+            {
+              "id" : "2",
+              "rating" : "U"
+            },
+            {
+              "id" : "3",
+              "rating" : "15"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
 }


### PR DESCRIPTION
This PR fixes the incorrect assumption that a type condition (as part of a fragment, inline or otherwise) will only ever _narrow_ the expected type. Whilst it's pretty much pointless to widen in an `inline` fragment, standalone fragments might very well operate on types which are wider than the concrete types they're applied to, eg. in a case where a collection of supertype fields are collected up as a fragment and applied in multiple subtype subtrees.

For instance, given the schema,
```graphql
type Query {
  user(id: ID!): User!
  profiles: [Profile!]!
}
type User implements Profile {
  id: String!
  name: String!
  profilePic: String!
  friends: [User!]!
  mutualFriends: [User!]!
  favourite: UserOrPage
}
type Page implements Profile {
  id: String!
  title: String!
  likers: [User!]!
}
union UserOrPage = User | Page
interface Profile {
  id: String!
}
```
The following query contains a use of a fragment with a type condition (`on Profile`) which is a supertype of the static type which it is applied to (`User`),

```graphql
query withFragments {
  user(id: 1) {
    friends {
      ...profileFields
    }
  }
}

fragment profileFields on Profile {
  id
}
```

Prior to this PR, queries of the above form would either assert, or incorrectly execute as if the fragment didn't apply.