### PR TITLE
Reduce use of Lists and miscellaneous performance tweaks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ val Scala3 = "3.1.3"
 ThisBuild / scalaVersion        := Scala2
 ThisBuild / crossScalaVersions  := Seq(Scala2, Scala3)
 
-ThisBuild / tlBaseVersion    := "0.3"
+ThisBuild / tlBaseVersion    := "0.4"
 ThisBuild / organization     := "edu.gemini"
 ThisBuild / organizationName := "Association of Universities for Research in Astronomy, Inc. (AURA)"
 ThisBuild / startYear        := Some(2019)

--- a/modules/circe/src/main/scala/circemapping.scala
+++ b/modules/circe/src/main/scala/circemapping.scala
@@ -4,6 +4,8 @@
 package edu.gemini.grackle
 package circe
 
+import scala.collection.Factory
+
 import cats.Monad
 import cats.implicits._
 import fs2.Stream
@@ -78,9 +80,9 @@ abstract class CirceMapping[F[_]: Monad] extends Mapping[F] {
 
     def isList: Boolean = tpe.isList && focus.isArray
 
-    def asList: Result[List[Cursor]] = tpe match {
+    def asList[C](factory: Factory[Cursor, C]): Result[C] = tpe match {
       case ListType(elemTpe) if focus.isArray =>
-        focus.asArray.map(_.map(e => mkChild(context.asType(elemTpe), e)).toList)
+        focus.asArray.map(_.view.map(e => mkChild(context.asType(elemTpe), e)).to(factory))
           .toRightIor(mkOneError(s"Expected List type, found $tpe for focus ${focus.noSpaces}"))
       case _ =>
         mkErrorResult(s"Expected List type, found $tpe for focus ${focus.noSpaces}")

--- a/modules/core/src/main/scala/query.scala
+++ b/modules/core/src/main/scala/query.scala
@@ -139,7 +139,7 @@ object Query {
   }
 
   case class OrderSelections(selections: List[OrderSelection[_]]) {
-    def order(lc: List[Cursor]): List[Cursor] = {
+    def order(lc: Seq[Cursor]): Seq[Cursor] = {
       def cmp(x: Cursor, y: Cursor): Int = {
         @tailrec
         def loop(sels: List[OrderSelection[_]]): Int =

--- a/modules/core/src/main/scala/valuemapping.scala
+++ b/modules/core/src/main/scala/valuemapping.scala
@@ -3,6 +3,7 @@
 
 package edu.gemini.grackle
 
+import scala.collection.Factory
 import scala.reflect.ClassTag
 
 import cats.Monad
@@ -118,8 +119,8 @@ abstract class ValueMapping[F[_]: Monad] extends Mapping[F] {
       case _ => false
     }
 
-    def asList: Result[List[Cursor]] = (tpe, focus) match {
-      case (ListType(tpe), it: List[_]) => it.map(f => mkChild(context.asType(tpe), f)).rightIor
+    def asList[C](factory: Factory[Cursor, C]): Result[C] = (tpe, focus) match {
+      case (ListType(tpe), it: List[_]) => it.view.map(f => mkChild(context.asType(tpe), f)).to(factory).rightIor
       case _ => mkErrorResult(s"Expected List type, found $tpe")
     }
 

--- a/modules/generic/src/main/scala/genericmapping.scala
+++ b/modules/generic/src/main/scala/genericmapping.scala
@@ -4,6 +4,8 @@
 package edu.gemini.grackle
 package generic
 
+import scala.collection.Factory
+
 import cats.Monad
 import cats.implicits._
 import fs2.Stream
@@ -169,8 +171,8 @@ object CursorBuilder {
       def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
 
       override def isList: Boolean = true
-      override def asList: Result[List[Cursor]] = {
-        focus.traverse(elem => elemBuilder.build(context, elem, Some(this), env))
+      override def asList[C](factory: Factory[Cursor, C]): Result[C] = {
+        focus.traverse(elem => elemBuilder.build(context, elem, Some(this), env)).map(_.to(factory))
       }
     }
 
@@ -207,7 +209,7 @@ abstract class AbstractCursor[T] extends Cursor {
 
   def isList: Boolean = false
 
-  def asList: Result[List[Cursor]] =
+  def asList[C](factory: Factory[Cursor, C]): Result[C] =
     mkErrorResult(s"Expected List type, found $tpe")
 
   def isNullable: Boolean = false

--- a/modules/generic/src/test/scala/derivation.scala
+++ b/modules/generic/src/test/scala/derivation.scala
@@ -295,7 +295,7 @@ final class DerivationSpec extends CatsSuite {
         c <- CursorBuilder[Character].build(Context(CharacterType), lukeSkywalker)
         f <- c.field("appearsIn", None)
         n <- f.asNullable.flatMap(_.toRightIor(mkOneError("missing")))
-        l <- n.asList
+        l <- n.asList(List)
         s <- l.traverse(_.asLeaf)
       } yield s
     assert(appearsIn == Ior.Right(List(Json.fromString("NEWHOPE"), Json.fromString("EMPIRE"), Json.fromString("JEDI"))))
@@ -307,7 +307,7 @@ final class DerivationSpec extends CatsSuite {
         c <- CursorBuilder[Human].build(Context(HumanType), lukeSkywalker)
         f <- c.field("friends", None)
         n <- f.asNullable.flatMap(_.toRightIor(mkOneError("missing")))
-        l <- n.asList
+        l <- n.asList(List)
         m <- l.traverse(_.field("name", None))
         p <- m.traverse(_.asNullable.flatMap(_.toRightIor(mkOneError("missing"))))
         q <- p.traverse(_.asLeaf)


### PR DESCRIPTION
+ Uses of `List` replaced with `Seq`, `Iterable` or `Iterator` where possible.
+ `Cursor#asList` now takes a `Factory` to avoid committing to `List`.
+ `Context` path is more efficiently represented.
+ Several internal repeated list traversals and transforms replaced by hidden imperative loops for performance.
+ `SqlColumn` now records its result path which is used as a key for column lookup during result construction, eliminating many repeated linear traversals of the mappings.
+ Key columns and leaf encoders are memoized during result construction.

This reduces execution time of the following benchmark query by about 20%,

```graphql
query {
  cities {
    name
    country {
      name
      cities {
        name
      }
    }
  }
}
```