### PR TITLE
improve error message

### DIFF
--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -3064,7 +3064,9 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
     def isLeaf: Boolean = tpe.isLeaf
 
     def asLeaf: Result[Json] =
-      mapped.encoderForLeaf(tpe).map(enc => enc(focus).rightIor).getOrElse(mkErrorResult(s"Not a leaf: $focus"))
+      mapped.encoderForLeaf(tpe).map(enc => enc(focus).rightIor).getOrElse(mkErrorResult(
+        s"Cannot encode value $focus at ${context.path.reverse.mkString("/")} (of type of type ${context.tpe}). Did you forget a LeafMapping?".stripMargin.trim
+      ))
 
     def isList: Boolean =
       tpe match {

--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -3065,7 +3065,7 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
 
     def asLeaf: Result[Json] =
       mapped.encoderForLeaf(tpe).map(enc => enc(focus).rightIor).getOrElse(mkErrorResult(
-        s"Cannot encode value $focus at ${context.path.reverse.mkString("/")} (of type of type ${context.tpe}). Did you forget a LeafMapping?".stripMargin.trim
+        s"Cannot encode value $focus at ${context.path.reverse.mkString("/")} (of GraphQL type ${context.tpe}). Did you forget a LeafMapping?".stripMargin.trim
       ))
 
     def isList: Boolean =


### PR DESCRIPTION
Added the path and type and a suggestion that a `LeafMapping` is probably missing in the case where there's no encoder available for a result value.

Before:

```
Not a leaf: 0
```

After:

```
Cannot encode value 0 at programs/plannedTime/pi/microseconds (of GraphQL type NonNegLong). Did you forget a LeafMapping?
```