### PR TITLE
Add preunique operation to Cursor to support nested Unique

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ val Scala3 = "3.1.3"
 ThisBuild / scalaVersion        := Scala2
 ThisBuild / crossScalaVersions  := Seq(Scala2, Scala3)
 
-ThisBuild / tlBaseVersion    := "0.5"
+ThisBuild / tlBaseVersion    := "0.6"
 ThisBuild / organization     := "edu.gemini"
 ThisBuild / organizationName := "Association of Universities for Research in Astronomy, Inc. (AURA)"
 ThisBuild / startYear        := Some(2019)

--- a/modules/circe/src/main/scala/circemapping.scala
+++ b/modules/circe/src/main/scala/circemapping.scala
@@ -78,6 +78,14 @@ abstract class CirceMapping[F[_]: Monad] extends Mapping[F] {
           mkErrorResult(s"Expected Scalar type, found $tpe for focus ${focus.noSpaces}")
       }
 
+    def preunique: Result[Cursor] = {
+      val listTpe = tpe.nonNull.list
+      if(focus.isArray)
+        mkChild(context.asType(listTpe), focus).rightIor
+      else
+        mkErrorResult(s"Expected List type, found $focus for ${listTpe}")
+    }
+
     def isList: Boolean = tpe.isList && focus.isArray
 
     def asList[C](factory: Factory[Cursor, C]): Result[C] = tpe match {

--- a/modules/core/src/main/scala/cursor.scala
+++ b/modules/core/src/main/scala/cursor.scala
@@ -64,6 +64,12 @@ trait Cursor {
    */
   def asLeaf: Result[Json]
 
+  /**
+    * Yield a `Cursor` which can be used to evaluate the antecedant of a `Unique`
+    * operation.
+    */
+  def preunique: Result[Cursor]
+
   /** Is the value at this `Cursor` of a list type? */
   def isList: Boolean
 

--- a/modules/core/src/main/scala/queryinterpreter.scala
+++ b/modules/core/src/main/scala/queryinterpreter.scala
@@ -388,18 +388,9 @@ class QueryInterpreter[F[_]](mapping: Mapping[F]) {
           else stage(cursor)
 
         case (Unique(child), _) =>
-          val oc =
-            if (cursor.isNullable) cursor.asNullable
-            else Some(cursor).rightIor
-
-          oc.flatMap {
-            case Some(c) =>
-              c.asList(Iterator).flatMap { cursors =>
-                runList(child, tpe.nonNull, cursors, true, tpe.isNullable)
-              }
-            case None =>
-              ProtoJson.fromJson(Json.Null).rightIor
-          }
+          cursor.preunique.flatMap(_.asList(Iterator).flatMap { cursors =>
+            runList(child, tpe.nonNull, cursors, true, tpe.isNullable)
+          })
 
         case (_, ListType(tpe)) =>
           cursor.asList(Iterator).flatMap { cursors =>

--- a/modules/core/src/main/scala/valuemapping.scala
+++ b/modules/core/src/main/scala/valuemapping.scala
@@ -114,6 +114,15 @@ abstract class ValueMapping[F[_]: Monad] extends Mapping[F] {
           }
       }
 
+    def preunique: Result[Cursor] = {
+      val listTpe = tpe.nonNull.list
+      focus match {
+        case _: List[_] => mkChild(context.asType(listTpe), focus).rightIor
+        case _ =>
+          mkErrorResult(s"Expected List type, found $focus for ${listTpe}")
+      }
+    }
+
     def isList: Boolean = (tpe, focus) match {
       case (_: ListType, _: List[_]) => true
       case _ => false

--- a/modules/generic/src/main/scala/genericmapping.scala
+++ b/modules/generic/src/main/scala/genericmapping.scala
@@ -170,6 +170,11 @@ object CursorBuilder {
     case class ListCursor(context: Context, focus: List[T], parent: Option[Cursor], env: Env) extends AbstractCursor[List[T]] {
       def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
 
+      override def preunique: Result[Cursor] = {
+        val listTpe = tpe.nonNull.list
+        copy(context = context.asType(listTpe)).rightIor
+      }
+
       override def isList: Boolean = true
       override def asList[C](factory: Factory[Cursor, C]): Result[C] = {
         focus.traverse(elem => elemBuilder.build(context, elem, Some(this), env)).map(_.to(factory))
@@ -206,6 +211,9 @@ abstract class AbstractCursor[T] extends Cursor {
 
   def asLeaf: Result[Json] =
     mkErrorResult(s"Expected Scalar type, found $tpe for focus ${focus}")
+
+  def preunique: Result[Cursor] =
+    mkErrorResult(s"Expected List type, found $focus for ${tpe.nonNull.list}")
 
   def isList: Boolean = false
 

--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -3065,6 +3065,15 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
         s"Cannot encode value $focus at ${context.path.reverse.mkString("/")} (of GraphQL type ${context.tpe}). Did you forget a LeafMapping?".stripMargin.trim
       ))
 
+    def preunique: Result[Cursor] = {
+      val listTpe = tpe.nonNull.list
+      focus match {
+        case _: List[_] => mkChild(context.asType(listTpe), focus).rightIor
+        case _ =>
+          mkErrorResult(s"Expected List type, found $focus for ${listTpe}")
+      }
+    }
+
     def isList: Boolean =
       tpe match {
         case ListType(_) => true
@@ -3115,6 +3124,11 @@ trait SqlMapping[F[_]] extends CirceMapping[F] with SqlModule[F] { self =>
     def isLeaf: Boolean = false
     def asLeaf: Result[Json] =
       mkErrorResult(s"Not a leaf: $tpe")
+
+    def preunique: Result[Cursor] = {
+      val listTpe = tpe.nonNull.list
+      mkChild(context.asType(listTpe), focus).rightIor
+    }
 
     def isList: Boolean =
       tpe.isList

--- a/modules/sql/src/test/scala/SqlWorldMapping.scala
+++ b/modules/sql/src/test/scala/SqlWorldMapping.scala
@@ -86,6 +86,7 @@ trait SqlWorldMapping[F[_]] extends SqlTestMapping[F] {
         code2: String!
         numCities(namePattern: String): Int!
         cities: [City!]!
+        city(id: Int): City
         languages: [Language!]!
       }
     """
@@ -129,6 +130,7 @@ trait SqlWorldMapping[F[_]] extends SqlTestMapping[F] {
           SqlField("code2",          country.code2),
           SqlField("numCities",      country.numCities),
           SqlObject("cities",        Join(country.code, city.countrycode)),
+          SqlObject("city",          Join(country.code, city.countrycode)),
           SqlObject("languages",     Join(country.code, countrylanguage.countrycode))
         ),
       ),
@@ -217,6 +219,9 @@ trait SqlWorldMapping[F[_]] extends SqlTestMapping[F] {
 
       case Select("numCities", List(Binding("namePattern", StringValue(namePattern))), Empty) =>
         Count("numCities", Select("cities", Nil, Filter(Like(UniquePath(List("name")), namePattern, true), Select("name", Nil, Empty)))).rightIor
+
+      case Select("city", List(Binding("id", IntValue(id))), child) =>
+        Select("city", Nil, Unique(Filter(Eql(UniquePath(List("id")), Const(id)), child))).rightIor
     }
   ))
 }

--- a/modules/sql/src/test/scala/SqlWorldSpec.scala
+++ b/modules/sql/src/test/scala/SqlWorldSpec.scala
@@ -1710,4 +1710,58 @@ trait SqlWorldSpec extends AnyFunSuite {
 
     assertWeaklyEqual(res, expected)
   }
+
+  test("root unique of limit 1") {
+    val query = """
+      query {
+        city(id: 490) {
+          name
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "city" : {
+            "name" : "Brighton"
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("nested unique of limit 1") {
+    val query = """
+      query {
+        country(code: "GBR") {
+          city(id: 490) {
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "country" : {
+            "city" : {
+              "name" : "Brighton"
+            }
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
 }


### PR DESCRIPTION
Previously the logic for changing the expected type from `T` to `[T]` when traversing through a `Unique` node in the query algebra was only handled for root mappings. This PR adds a `preunique` operation to `Cursor` which does this and which is used by the interpreter when evaluating `Unique` nodes.