### PR TITLE
Embedding fixes

### DIFF
--- a/modules/doobie-pg/src/test/scala/DoobieSuites.scala
+++ b/modules/doobie-pg/src/test/scala/DoobieSuites.scala
@@ -37,6 +37,14 @@ final class EmbeddingSpec extends DoobieDatabaseSuite with SqlEmbeddingSpec {
   lazy val mapping = new DoobieTestMapping(xa) with SqlEmbeddingMapping[IO]
 }
 
+final class Embedding2Spec extends DoobieDatabaseSuite with SqlEmbedding2Spec {
+  lazy val mapping = new DoobieTestMapping(xa) with SqlEmbedding2Mapping[IO]
+}
+
+final class Embedding3Spec extends DoobieDatabaseSuite with SqlEmbedding3Spec {
+  lazy val mapping = new DoobieTestMapping(xa) with SqlEmbedding3Mapping[IO]
+}
+
 final class FilterOrderOffsetLimitSpec extends DoobieDatabaseSuite with SqlFilterOrderOffsetLimitSpec {
   lazy val mapping = new DoobieTestMapping(xa) with SqlFilterOrderOffsetLimitMapping[IO]
 }

--- a/modules/skunk/src/test/scala/SkunkSuites.scala
+++ b/modules/skunk/src/test/scala/SkunkSuites.scala
@@ -37,6 +37,14 @@ final class EmbeddingSpec extends SkunkDatabaseSuite with SqlEmbeddingSpec {
   lazy val mapping = new SkunkTestMapping(pool) with SqlEmbeddingMapping[IO]
 }
 
+final class Embedding2Spec extends SkunkDatabaseSuite with SqlEmbedding2Spec {
+  lazy val mapping = new SkunkTestMapping(pool) with SqlEmbedding2Mapping[IO]
+}
+
+final class Embedding3Spec extends SkunkDatabaseSuite with SqlEmbedding3Spec {
+  lazy val mapping = new SkunkTestMapping(pool) with SqlEmbedding3Mapping[IO]
+}
+
 final class FilterOrderOffsetLimitSpec extends SkunkDatabaseSuite with SqlFilterOrderOffsetLimitSpec {
   lazy val mapping = new SkunkTestMapping(pool) with SqlFilterOrderOffsetLimitMapping[IO]
 }

--- a/modules/sql/src/test/resources/db/embedding2.sql
+++ b/modules/sql/src/test/resources/db/embedding2.sql
@@ -1,0 +1,20 @@
+CREATE TABLE t_program (
+  c_program_id  VARCHAR NOT NULL PRIMARY KEY
+);
+
+CREATE TABLE t_observation (
+  c_program_id         VARCHAR    NOT NULL REFERENCES t_program(c_program_id),
+  c_observation_id     VARCHAR    NOT NULL PRIMARY KEY
+);
+
+COPY t_program (c_program_id) FROM STDIN WITH DELIMITER '|';
+foo
+bar
+\.
+
+COPY t_observation (c_program_id, c_observation_id) FROM STDIN WITH DELIMITER '|';
+foo|fo1
+foo|fo2
+bar|bo1
+bar|bo2
+\.

--- a/modules/sql/src/test/scala/SqlEmbedding2Mapping.scala
+++ b/modules/sql/src/test/scala/SqlEmbedding2Mapping.scala
@@ -1,0 +1,89 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import edu.gemini.grackle.Predicate._
+import edu.gemini.grackle.Query._
+import edu.gemini.grackle.QueryCompiler.SelectElaborator
+import edu.gemini.grackle.Value._
+import edu.gemini.grackle.Result
+import edu.gemini.grackle.syntax._
+
+trait SqlEmbedding2Mapping[F[_]] extends SqlTestMapping[F] {
+
+  object ProgramTable extends TableDef("t_program") {
+    val Id = col("c_program_id", varchar)
+  }
+
+  object ObservationTable extends TableDef("t_observation") {
+    val Pid = col("c_program_id", varchar)
+    val Id  = col("c_observation_id", varchar)
+  }
+
+  val schema = schema"""
+    type Query {
+      program(programId: String!): Program
+    }
+    type Program {
+      id: String!
+      observations: ObservationSelectResult!
+    }
+    type ObservationSelectResult {
+      matches: [Observation!]!
+    }
+    type Observation {
+      id: String!
+    }
+  """
+
+  val QueryType                   = schema.ref("Query")
+  val ProgramType                 = schema.ref("Program")
+  val ObservationSelectResultType = schema.ref("ObservationSelectResult")
+  val ObservationType             = schema.ref("Observation")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        QueryType,
+        List(
+          SqlObject("program")
+        )
+      ),
+      ObjectMapping(
+        ProgramType,
+        List(
+          SqlField("id", ProgramTable.Id, key = true),
+          SqlObject("observations")
+        )
+      ),
+      ObjectMapping(
+        ObservationSelectResultType,
+        List(
+          SqlField("id", ProgramTable.Id, key = true, hidden = true),
+          SqlObject("matches", Join(ProgramTable.Id, ObservationTable.Pid)),
+        )
+      ),
+      ObjectMapping(
+        ObservationType,
+        List(
+          SqlField("id", ObservationTable.Id, key = true),
+        )
+      )
+    )
+
+  override val selectElaborator = new SelectElaborator(Map(
+    QueryType -> {
+      case Select("program", List(Binding("programId", StringValue(id))), child) =>
+        Result(Select("program", Nil, Unique(Filter(Eql(ProgramType / "id", Const(id)), child))))
+    },
+    ObservationSelectResultType -> {
+      case Select("matches", Nil, q) =>
+        Result(
+          Select("matches", Nil,
+            OrderBy(OrderSelections(List(OrderSelection[String](ObservationType / "id", true, true))), q)
+          )
+        )
+    }
+  ))
+}

--- a/modules/sql/src/test/scala/SqlEmbedding2Spec.scala
+++ b/modules/sql/src/test/scala/SqlEmbedding2Spec.scala
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
+import io.circe.Json
+import org.scalatest.funsuite.AnyFunSuite
+
+import grackle.test.GraphQLResponseTests.assertWeaklyEqual
+
+trait SqlEmbedding2Spec extends AnyFunSuite {
+  def mapping: QueryExecutor[IO, Json]
+
+  test("paging") {
+    val query = """
+      query {
+        program(programId: "foo") {
+          id
+          observations {
+            matches {
+              id
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "program" : {
+            "id" : "foo",
+            "observations" : {
+              "matches" : [
+                {
+                  "id" : "fo1"
+                },
+                {
+                  "id" : "fo2"
+                }
+              ]
+            }
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+}

--- a/modules/sql/src/test/scala/SqlEmbedding3Mapping.scala
+++ b/modules/sql/src/test/scala/SqlEmbedding3Mapping.scala
@@ -1,0 +1,58 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import edu.gemini.grackle.syntax._
+
+trait SqlEmbedding3Mapping[F[_]] extends SqlTestMapping[F] {
+
+  object Bogus extends RootDef {
+    val Id = col("<bogus>", varchar)
+  }
+
+  object ObservationTable extends TableDef("t_observation") {
+    val Pid = col("c_program_id", varchar)
+    val Id  = col("c_observation_id", varchar)
+  }
+
+  val schema = schema"""
+    type Query {
+      observations: ObservationSelectResult!
+    }
+    type ObservationSelectResult {
+      matches: [Observation!]!
+    }
+    type Observation {
+      id: String!
+    }
+  """
+
+  val QueryType                   = schema.ref("Query")
+  val ObservationSelectResultType = schema.ref("ObservationSelectResult")
+  val ObservationType             = schema.ref("Observation")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        QueryType,
+        List(
+          SqlObject("observations")
+        )
+      ),
+      ObjectMapping(
+        ObservationSelectResultType,
+        List(
+          SqlField("<key>", Bogus.Id, hidden = true),
+          SqlObject("matches"),
+        )
+      ),
+      ObjectMapping(
+        ObservationType,
+        List(
+          SqlField("id", ObservationTable.Id, key = true),
+        )
+      )
+    )
+
+}

--- a/modules/sql/src/test/scala/SqlEmbedding3Spec.scala
+++ b/modules/sql/src/test/scala/SqlEmbedding3Spec.scala
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
+import io.circe.Json
+import org.scalatest.funsuite.AnyFunSuite
+
+import grackle.test.GraphQLResponseTests.assertWeaklyEqual
+
+trait SqlEmbedding3Spec extends AnyFunSuite {
+  def mapping: QueryExecutor[IO, Json]
+
+  test("paging") {
+    val query = """
+      query {
+        observations {
+          matches {
+            id
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "observations" : {
+            "matches" : [
+              {
+                "id" : "fo1"
+              },
+              {
+                "id" : "bo2"
+              },
+              {
+                "id" : "bo1"
+              },
+              {
+                "id" : "fo2"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+}


### PR DESCRIPTION
When subobjects are embedded in an enclosing `SELECT` rather than via a join we have to ensure that all the corresponding context paths align. This has been done by wrapping the nested columns with `EmbeddedColumn` which preserves the embedded path of the underlying column whilst simultaneously matching the path of the enclosing select.

However a number of cases where this needed to be done (references in `WHERE` and `ORDER BY` clauses) were missed and also the generation of columns for parent constraints didn't take embedding into account.