### PR TITLE
Aliasing Bug

### DIFF
--- a/modules/skunk/src/test/scala/SkunkSuites.scala
+++ b/modules/skunk/src/test/scala/SkunkSuites.scala
@@ -14,6 +14,7 @@ import edu.gemini.grackle.sql.SqlStatsMonitor
 
 import edu.gemini.grackle.sql.test._
 import edu.gemini.grackle.Mapping
+import skunk.AppliedFragment
 
 final class ArrayJoinSpec extends SkunkDatabaseSuite with SqlArrayJoinSpec {
   lazy val mapping = new SkunkTestMapping(pool) with SqlArrayJoinMapping[IO]
@@ -152,4 +153,11 @@ final class WorldCompilerSpec extends SkunkDatabaseSuite with SqlWorldCompilerSp
 
   def simpleFilteredQuerySql: String =
     "SELECT city.id, city.name FROM city WHERE (city.name ILIKE $1)"
+}
+
+final class RobSpec extends SkunkDatabaseSuite with SqlRobSpec {
+  lazy val mapping = new SkunkTestMapping(pool) with SqlRobMapping[IO] {
+    override def fetch(fragment: AppliedFragment, codecs: List[(Boolean, (skunk.Codec[_], Boolean))]): IO[Vector[Array[Any]]] =
+      IO.println(fragment.fragment.sql) >> super.fetch(fragment, codecs)
+  }
 }

--- a/modules/sql/src/test/resources/db/rob.sql
+++ b/modules/sql/src/test/resources/db/rob.sql
@@ -1,0 +1,10 @@
+
+
+create table t_program (
+  c_program_id  varchar not null primary key
+);
+
+create table t_observation (
+  c_program_id         varchar    not null    references t_program(c_program_id),
+  c_observation_id     varchar    not null primary key 
+)

--- a/modules/sql/src/test/scala/SqlPaging2Mapping.scala
+++ b/modules/sql/src/test/scala/SqlPaging2Mapping.scala
@@ -18,6 +18,7 @@ import Value.IntValue
 // This implmentation will only ever fetch up to the requested number
 // of items, and will include an SQL COUNT if the query includes `hasMore`.
 trait SqlPaging2Mapping[F[_]] extends SqlTestMapping[F] {
+  
   object root extends RootDef {
     val numCountries = col("num_countries", int8)
   }

--- a/modules/sql/src/test/scala/SqlRobMapping.scala
+++ b/modules/sql/src/test/scala/SqlRobMapping.scala
@@ -3,85 +3,73 @@
 
 package edu.gemini.grackle.sql.test
 
-import cats.syntax.all._
-import edu.gemini.grackle.Cursor
-import edu.gemini.grackle.Cursor.Env
-import edu.gemini.grackle.Cursor.ListTransformCursor
+import edu.gemini.grackle.Predicate._
 import edu.gemini.grackle.Query
 import edu.gemini.grackle.Query._
+import edu.gemini.grackle.QueryCompiler.SelectElaborator
 import edu.gemini.grackle.Result
 import edu.gemini.grackle.syntax._
-import edu.gemini.grackle.QueryCompiler.SelectElaborator
 import edu.gemini.grackle.Value._
-import edu.gemini.grackle.Predicate._
 
 trait SqlRobMapping[F[_]] extends SqlTestMapping[F] {
 
   object ProgramTable extends TableDef("t_program") {
-    val Id      = col("c_program_id", varchar)
+    val Id = col("c_program_id", varchar)
   }
 
   object ObservationTable extends TableDef("t_observation") {
-    val ProgramId = col("c_program_id", varchar)
-    val Id = col("c_observation_id", varchar)
+    val Pid = col("c_program_id", varchar)
+    val Id  = col("c_observation_id", varchar)
   }
 
-  val schema =
-    schema"""
-      type Query {
-        program(programId: String!): Program
-      }
-      type Program {
-        id: String!
-        observations(limit: Int): ObservationSelectResult!
-      }
-      type ObservationSelectResult {
-        matches: [Observation!]!
-        hasMore: Boolean!
-      }
-      type Observation {
-        id: String!
-      }
-    """
+  val schema = schema"""
+    type Query {
+      program(programId: String!): Program
+    }
+    type Program {
+      id: String!
+      observations: ObservationSelectResult!
+    }
+    type ObservationSelectResult {
+      matches: [Observation!]!
+    }
+    type Observation {
+      id: String!
+    }
+  """
 
-  val QueryType = schema.ref("Query")
-  val ProgramType = schema.ref("Program")
-  val ObsevationSelectResultType = schema.ref("ObservationSelectResult")
-  val ObservationType = schema.ref("Observation")
+  val QueryType                   = schema.ref("Query")
+  val ProgramType                 = schema.ref("Program")
+  val ObservationSelectResultType = schema.ref("ObservationSelectResult")
+  val ObservationType             = schema.ref("Observation")
 
   val typeMappings =
     List(
       ObjectMapping(
-        tpe = QueryType,
-        fieldMappings =
-          List(
-            SqlObject("program"),
-          )
+        QueryType, 
+        List(
+          SqlObject("program")
+        )
       ),
       ObjectMapping(
-        tpe = ProgramType,
-        fieldMappings =
-          List(
-            SqlField("id", ProgramTable.Id, key = true),
-            SqlObject("observations")
-          ),
+        ProgramType,
+        List(
+          SqlField("id", ProgramTable.Id, key = true),
+          SqlObject("observations")
+        )
       ),
       ObjectMapping(
-        tpe = ObsevationSelectResultType,
-        fieldMappings =
-          List(
-            SqlField("<key>", ProgramTable.Id, key = true, hidden = true),
-            SqlObject("matches", Join(ProgramTable.Id, ObservationTable.ProgramId)),
-            CursorField("hasMore", hasMore),
-          )
+        ObservationSelectResultType,
+        List(
+          SqlField("<key>", ProgramTable.Id, key = true, hidden = true),
+          SqlObject("matches", Join(ProgramTable.Id, ObservationTable.Pid)),
+        )
       ),
       ObjectMapping(
-        tpe = ObservationType,
-        fieldMappings =
-          List(
-            SqlField("id", ObservationTable.Id, key = true),
-            SqlField("<program-id>", ObservationTable.ProgramId, hidden = true),
-          )
+        ObservationType,
+        List(
+          SqlField("id", ObservationTable.Id, key = true),
+        )
       )
     )
 
@@ -91,81 +79,19 @@ trait SqlRobMapping[F[_]] extends SqlTestMapping[F] {
         Result(Select("program", Nil, Unique(Filter(Eql(ProgramType / "id", Const(id)), child))))
     },
     ProgramType -> {
-      case Select("observations", List(Binding("limit", IntValue(lim))), child) => {
-        selectResult("observations", child, lim) { q =>
-          FilterOrderByOffsetLimit(
-            pred   = None,
-            oss    = Some(List(OrderSelection[Int](ObservationType / "id", true, true))),
-            offset = None,
-            limit  = Some(lim + 1),
-            child  = q
-          )
+      case Select("observations", Nil, child) =>
+        Query.mapFields(child) {
+          case Select("matches", Nil, q) =>
+            Result(
+              Select("matches", Nil,
+                OrderBy(OrderSelections(List(OrderSelection[Int](ObservationType / "id", true, true))), q)
+              )
+            )
+          case other => Result(other)
+        } map { child =>
+          Select("observations", Nil, child)
         }
       }
-    },
   ))
-
-  // keys for things we expect to find in the environment
-  val LimitKey = "selectResultLimit"
-  val AliasKey = "selectResultAlias"
-
-  def hasMore(c: Cursor): Result[Boolean] =
-    for {
-      limit   <- c.envR[Int](LimitKey)
-      alias   <- c.envR[Option[String]](AliasKey)
-      matches <- c.field("matches", alias)
-      size    <- matches.listSize
-    } yield limit < 0 || size > limit
-
-  /** A cursor transformation that takes `n` elements from a list (if it's a list). */
-  object Take {
-    def apply(n: Int)(c: Cursor): Result[Cursor] =
-      (c.listSize, c.asList(Seq)).mapN { (size, elems) =>
-        if (size <= n) c
-        else ListTransformCursor(c, size - 1, elems.init)
-      }
-  }
- 
-  implicit class QueryOps(self: Query.type) {
-    def mapSomeFields(query: Query)(f: PartialFunction[Query, Result[Query]]): Result[Query] = 
-      self.mapFields(query)(q => f.applyOrElse(q, Result.apply[Query]))
-  }
-
-  /**
-   * Transform a top-level `Select(field, ..., child)` that yields a SelectResult with a specified
-   * `limit` into the proper form. The "matches" subselect's child is passed to `transform`, which
-   * is how you add filter, ordering, limit (MUST BE `limit + 1`!) and so on as if it were a
-   * top-level query without the SelectResult structure. See `TargetMapping` for instance, for an 
-   * example. Note that this will fail if there is no "items" subquery. Supporting such queries
-   * would complicate things and isn't really necessary.
-   */
-  def selectResult(field: String, child: Query, limit: Int)(transform: Query => Query): Result[Query] = {
-
-    // Find the "items" node under the main query and add all our filtering
-    // and whatnot down in there, wrapping with a transform that removes the last row from the
-    // final results.
-    def transformMatches(q: Query): Result[Query] =
-      Query.mapSomeFields(q) {
-        case Select("matches", Nil, child) =>
-          Result(Select("matches", Nil, Query.TransformCursor(Take(limit), transform(child))))
-      }
-
-    // If we're selecting "matches" then continue by transforming the child query, otherwise
-    // punt because there's really no point in doing such a selection.
-    if (!Query.hasField(child, "matches")) Result.failure("Field `matches` must be selected.") // meh
-    else
-      transformMatches(child).map { child =>
-        Select(field, Nil,
-          Environment(
-            Env(
-              LimitKey -> limit,
-              AliasKey -> Query.fieldAlias(child, "matches"),
-            ),
-            child
-          )
-        )
-      }
-
-  }
 
 }

--- a/modules/sql/src/test/scala/SqlRobMapping.scala
+++ b/modules/sql/src/test/scala/SqlRobMapping.scala
@@ -1,0 +1,171 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import cats.syntax.all._
+import edu.gemini.grackle.Cursor
+import edu.gemini.grackle.Cursor.Env
+import edu.gemini.grackle.Cursor.ListTransformCursor
+import edu.gemini.grackle.Query
+import edu.gemini.grackle.Query._
+import edu.gemini.grackle.Result
+import edu.gemini.grackle.syntax._
+import edu.gemini.grackle.QueryCompiler.SelectElaborator
+import edu.gemini.grackle.Value._
+import edu.gemini.grackle.Predicate._
+
+trait SqlRobMapping[F[_]] extends SqlTestMapping[F] {
+
+  object ProgramTable extends TableDef("t_program") {
+    val Id      = col("c_program_id", varchar)
+  }
+
+  object ObservationTable extends TableDef("t_observation") {
+    val ProgramId = col("c_program_id", varchar)
+    val Id = col("c_observation_id", varchar)
+  }
+
+  val schema =
+    schema"""
+      type Query {
+        program(programId: String!): Program
+      }
+      type Program {
+        id: String!
+        observations(limit: Int): ObservationSelectResult!
+      }
+      type ObservationSelectResult {
+        matches: [Observation!]!
+        hasMore: Boolean!
+      }
+      type Observation {
+        id: String!
+      }
+    """
+
+  val QueryType = schema.ref("Query")
+  val ProgramType = schema.ref("Program")
+  val ObsevationSelectResultType = schema.ref("ObservationSelectResult")
+  val ObservationType = schema.ref("Observation")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            SqlObject("program"),
+          )
+      ),
+      ObjectMapping(
+        tpe = ProgramType,
+        fieldMappings =
+          List(
+            SqlField("id", ProgramTable.Id, key = true),
+            SqlObject("observations")
+          ),
+      ),
+      ObjectMapping(
+        tpe = ObsevationSelectResultType,
+        fieldMappings =
+          List(
+            SqlField("<key>", ProgramTable.Id, key = true, hidden = true),
+            SqlObject("matches", Join(ProgramTable.Id, ObservationTable.ProgramId)),
+            CursorField("hasMore", hasMore),
+          )
+      ),
+      ObjectMapping(
+        tpe = ObservationType,
+        fieldMappings =
+          List(
+            SqlField("id", ObservationTable.Id, key = true),
+            SqlField("<program-id>", ObservationTable.ProgramId, hidden = true),
+          )
+      )
+    )
+
+  override val selectElaborator = new SelectElaborator(Map(
+    QueryType -> {
+      case Select("program", List(Binding("programId", StringValue(id))), child) =>
+        Result(Select("program", Nil, Unique(Filter(Eql(ProgramType / "id", Const(id)), child))))
+    },
+    ProgramType -> {
+      case Select("observations", List(Binding("limit", IntValue(lim))), child) => {
+        selectResult("observations", child, lim) { q =>
+          FilterOrderByOffsetLimit(
+            pred   = None,
+            oss    = Some(List(OrderSelection[Int](ObservationType / "id", true, true))),
+            offset = None,
+            limit  = Some(lim + 1),
+            child  = q
+          )
+        }
+      }
+    },
+  ))
+
+  // keys for things we expect to find in the environment
+  val LimitKey = "selectResultLimit"
+  val AliasKey = "selectResultAlias"
+
+  def hasMore(c: Cursor): Result[Boolean] =
+    for {
+      limit   <- c.envR[Int](LimitKey)
+      alias   <- c.envR[Option[String]](AliasKey)
+      matches <- c.field("matches", alias)
+      size    <- matches.listSize
+    } yield limit < 0 || size > limit
+
+  /** A cursor transformation that takes `n` elements from a list (if it's a list). */
+  object Take {
+    def apply(n: Int)(c: Cursor): Result[Cursor] =
+      (c.listSize, c.asList(Seq)).mapN { (size, elems) =>
+        if (size <= n) c
+        else ListTransformCursor(c, size - 1, elems.init)
+      }
+  }
+ 
+  implicit class QueryOps(self: Query.type) {
+    def mapSomeFields(query: Query)(f: PartialFunction[Query, Result[Query]]): Result[Query] = 
+      self.mapFields(query)(q => f.applyOrElse(q, Result.apply[Query]))
+  }
+
+  /**
+   * Transform a top-level `Select(field, ..., child)` that yields a SelectResult with a specified
+   * `limit` into the proper form. The "matches" subselect's child is passed to `transform`, which
+   * is how you add filter, ordering, limit (MUST BE `limit + 1`!) and so on as if it were a
+   * top-level query without the SelectResult structure. See `TargetMapping` for instance, for an 
+   * example. Note that this will fail if there is no "items" subquery. Supporting such queries
+   * would complicate things and isn't really necessary.
+   */
+  def selectResult(field: String, child: Query, limit: Int)(transform: Query => Query): Result[Query] = {
+
+    // Find the "items" node under the main query and add all our filtering
+    // and whatnot down in there, wrapping with a transform that removes the last row from the
+    // final results.
+    def transformMatches(q: Query): Result[Query] =
+      Query.mapSomeFields(q) {
+        case Select("matches", Nil, child) =>
+          Result(Select("matches", Nil, Query.TransformCursor(Take(limit), transform(child))))
+      }
+
+    // If we're selecting "matches" then continue by transforming the child query, otherwise
+    // punt because there's really no point in doing such a selection.
+    if (!Query.hasField(child, "matches")) Result.failure("Field `matches` must be selected.") // meh
+    else
+      transformMatches(child).map { child =>
+        Select(field, Nil,
+          Environment(
+            Env(
+              LimitKey -> limit,
+              AliasKey -> Query.fieldAlias(child, "matches"),
+            ),
+            child
+          )
+        )
+      }
+
+  }
+
+}

--- a/modules/sql/src/test/scala/SqlRobSpec.scala
+++ b/modules/sql/src/test/scala/SqlRobSpec.scala
@@ -4,62 +4,28 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import edu.gemini.grackle.QueryExecutor
 import io.circe.Json
 import org.scalatest.funsuite.AnyFunSuite
-import cats.effect.unsafe.implicits.global
-
-import edu.gemini.grackle._
-// import syntax._
-
-// import grackle.test.GraphQLResponseTests.assertWeaklyEqual
 
 trait SqlRobSpec extends AnyFunSuite {
   def mapping: QueryExecutor[IO, Json]
-
   test("paging") {
-    val query = """
-      query {
-        program(programId: "$foo") {
-          id
-          observations(limit: 3) {
-            matches {
-              id
+    mapping.compileAndRun(
+      """
+        query {
+          program(programId: "foo") {
+            id
+            observations {
+              matches {
+                id
+              }
             }
           }
         }
-      }
-    """
-
-    // val expected = json"""
-    //   {
-    //     "data" : {
-    //       "countries" : {
-    //         "hasMore" : true,
-    //         "items" : [
-    //           {
-    //             "code" : "ABW",
-    //             "name" : "Aruba"
-    //           },
-    //           {
-    //             "code" : "AFG",
-    //             "name" : "Afghanistan"
-    //           },
-    //           {
-    //             "code" : "AGO",
-    //             "name" : "Angola"
-    //           }
-    //         ]
-    //       }
-    //     }
-    //   }
-    // """
-
-    val res = mapping.compileAndRun(query).unsafeRunSync()
-    println(res)
-
-    true
-
-    // assertWeaklyEqual(res, expected)
+      """
+    ).unsafeRunSync()
   }
 
 }

--- a/modules/sql/src/test/scala/SqlRobSpec.scala
+++ b/modules/sql/src/test/scala/SqlRobSpec.scala
@@ -1,0 +1,65 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import cats.effect.IO
+import io.circe.Json
+import org.scalatest.funsuite.AnyFunSuite
+import cats.effect.unsafe.implicits.global
+
+import edu.gemini.grackle._
+// import syntax._
+
+// import grackle.test.GraphQLResponseTests.assertWeaklyEqual
+
+trait SqlRobSpec extends AnyFunSuite {
+  def mapping: QueryExecutor[IO, Json]
+
+  test("paging") {
+    val query = """
+      query {
+        program(programId: "$foo") {
+          id
+          observations(limit: 3) {
+            matches {
+              id
+            }
+          }
+        }
+      }
+    """
+
+    // val expected = json"""
+    //   {
+    //     "data" : {
+    //       "countries" : {
+    //         "hasMore" : true,
+    //         "items" : [
+    //           {
+    //             "code" : "ABW",
+    //             "name" : "Aruba"
+    //           },
+    //           {
+    //             "code" : "AFG",
+    //             "name" : "Afghanistan"
+    //           },
+    //           {
+    //             "code" : "AGO",
+    //             "name" : "Angola"
+    //           }
+    //         ]
+    //       }
+    //     }
+    //   }
+    // """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    println(res)
+
+    true
+
+    // assertWeaklyEqual(res, expected)
+  }
+
+}


### PR DESCRIPTION
Here is a testcase that causes Grackle to produce invalid SQL due to an issue with column aliasing. It's not the exact problem I was seeing in my code but hopefully it has the same root cause. It's in the style of `SqlPaging2Mapping` but does away with the `hasNext` bit, which isn't relevant to the error.

The query in the test ends up generating the following:

```sql
SELECT
  t_observation_nested.c_observation_id,
  t_observation_nested.c_program_id,
  t_program.c_program_id AS c_program_id_alias_0,
  t_program.c_program_id AS c_program_id_alias_1
FROM
  t_program
  LEFT JOIN LATERAL (
    SELECT
      t_observation.c_program_id,
      (t_observation.c_observation_id COLLATE "C")
    FROM
      t_observation
    WHERE
      (
        (
          t_program.c_program_id_alias_0 = t_observation.c_program_id 
                    -------------------- 🔥 this isn't a column
        )
      )
    ORDER BY
      (t_observation.c_observation_id COLLATE "C") NULLS LAST
  ) AS t_observation_nested ON (
    t_observation_nested.c_program_id = t_program.c_program_id
  )
WHERE
  ((t_program.c_program_id = $ 1))
```

Note that the parent and child tables both use the name `c_program_id`, which forces the aliasing and may be the unusual circumstance that's exposing the issue.