### PR TITLE
CirceField Issue

### DIFF
--- a/modules/sql/src/test/scala/SqlMixedMapping.scala
+++ b/modules/sql/src/test/scala/SqlMixedMapping.scala
@@ -34,6 +34,7 @@ trait SqlMixedMapping[F[_]] extends SqlTestMapping[F] with ValueMappingLike[F] {
         type Movie {
           id: UUID!
           title: String!
+          bar2: Bar
         }
         type Foo {
           value: Int!
@@ -69,6 +70,7 @@ trait SqlMixedMapping[F[_]] extends SqlTestMapping[F] with ValueMappingLike[F] {
           List(
             SqlField("id", movies.id, key = true),
             SqlField("title", movies.title),
+            CirceField("bar2", json"""{ "message": "Hello movie world" }""")
           )
       ),
       ValueObjectMapping[Foo](

--- a/modules/sql/src/test/scala/SqlMixedSpec.scala
+++ b/modules/sql/src/test/scala/SqlMixedSpec.scala
@@ -127,4 +127,35 @@ trait SqlMixedSpec extends AnyFunSuite {
 
     assertWeaklyEqual(res, expected)
   }
+
+  test("mixed query 2") {
+    val query = """
+      query {
+        movie(id: "6a7837fc-b463-4d32-b628-0f4b3065cb21") {
+          title
+          bar2 {
+            message
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "movie" : {
+            "title" : "Celine et Julie Vont en Bateau",
+            "bar2" : {
+               "message": "Hello movie world"
+            }
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    println(res.spaces2)
+
+    assertWeaklyEqual(res, expected)
+  }
 }


### PR DESCRIPTION
A test case, similar to an issue I'm having elsewhere, where a `CirceField` which works at a higher level (in `Query`) seemingly fails when embedded (in `Movie`).

```
[info] MixedSpec:
[info] - DB query
[info] - value query
[info] - circe query
[info] - mixed query
[info] - mixed query 2 *** FAILED ***
[info]   java.lang.RuntimeException: No mapping for field 'message' of type Bar?
[info]   at scala.sys.package$.error(package.scala:27)
[info]   at edu.gemini.grackle.sql.SqlMappingLike.columnsForLeaf(SqlMapping.scala:811)
[info]   at edu.gemini.grackle.sql.SqlMappingLike.columnsForLeaf$(SqlMapping.scala:802)
[info]   at edu.gemini.grackle.skunk.SkunkMapping.columnsForLeaf(SkunkMapping.scala:21)
[info]   at edu.gemini.grackle.sql.SqlMappingLike$MappedQuery$.loop$10(SqlMapping.scala:2782)
[info]   at edu.gemini.grackle.sql.SqlMappingLike$MappedQuery$.loop$10(SqlMapping.scala:2801)
[info]   at edu.gemini.grackle.sql.SqlMappingLike$MappedQuery$.$anonfun$apply$5(SqlMapping.scala:2677)
[info]   at scala.collection.LinearSeqOps.foldLeft(LinearSeq.scala:169)
[info]   at scala.collection.LinearSeqOps.foldLeft$(LinearSeq.scala:165)
[info]   at scala.collection.immutable.List.foldLeft(List.scala:79)
```