### PR TITLE
Added support for composite keys

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ val Scala3 = "3.1.3"
 ThisBuild / scalaVersion        := Scala2
 ThisBuild / crossScalaVersions  := Seq(Scala2, Scala3)
 
-ThisBuild / tlBaseVersion    := "0.8"
+ThisBuild / tlBaseVersion    := "0.9"
 ThisBuild / organization     := "edu.gemini"
 ThisBuild / organizationName := "Association of Universities for Research in Astronomy, Inc. (AURA)"
 ThisBuild / startYear        := Some(2019)

--- a/modules/doobie-pg/src/test/scala/DoobieSuites.scala
+++ b/modules/doobie-pg/src/test/scala/DoobieSuites.scala
@@ -29,6 +29,10 @@ final class ComposedWorldSpec extends DoobieDatabaseSuite with SqlComposedWorldS
   lazy val mapping = new SqlComposedMapping(new DoobieTestMapping(xa) with SqlWorldMapping[IO], CurrencyMapping[IO])
 }
 
+final class CompositeKeySpec extends DoobieDatabaseSuite with SqlCompositeKeySpec {
+  lazy val mapping = new DoobieTestMapping(xa) with SqlCompositeKeyMapping[IO]
+}
+
 final class CursorJsonSpec extends DoobieDatabaseSuite with SqlCursorJsonSpec {
   lazy val mapping = new DoobieTestMapping(xa) with SqlCursorJsonMapping[IO]
 }

--- a/modules/skunk/src/test/scala/SkunkSuites.scala
+++ b/modules/skunk/src/test/scala/SkunkSuites.scala
@@ -29,6 +29,10 @@ final class ComposedWorldSpec extends SkunkDatabaseSuite with SqlComposedWorldSp
   lazy val mapping = new SqlComposedMapping(new SkunkTestMapping(pool) with SqlWorldMapping[IO], CurrencyMapping[IO])
 }
 
+final class CompositeKeySpec extends SkunkDatabaseSuite with SqlCompositeKeySpec {
+  lazy val mapping = new SkunkTestMapping(pool) with SqlCompositeKeyMapping[IO]
+}
+
 final class CursorJsonSpec extends SkunkDatabaseSuite with SqlCursorJsonSpec {
   lazy val mapping = new SkunkTestMapping(pool) with SqlCursorJsonMapping[IO]
 }

--- a/modules/sql/src/test/resources/db/composite-keys.sql
+++ b/modules/sql/src/test/resources/db/composite-keys.sql
@@ -1,0 +1,26 @@
+CREATE TABLE composite_key_parent (
+  key_1 INTEGER NOT NULL,
+  key_2 VARCHAR NOT NULL,
+  PRIMARY KEY (key_1, key_2)
+);
+
+CREATE TABLE composite_key_child (
+  id INTEGER PRIMARY KEY,
+  parent_1 INTEGER NOT NULL,
+  parent_2 VARCHAR NOT NULL,
+  FOREIGN KEY (parent_1, parent_2) REFERENCES composite_key_parent (key_1, key_2)
+);
+
+COPY composite_key_parent (key_1, key_2) FROM STDIN WITH DELIMITER '|';
+1|foo
+1|bar
+2|foo
+2|bar
+\.
+
+COPY composite_key_child (id, parent_1, parent_2) FROM STDIN WITH DELIMITER '|';
+1|1|foo
+2|1|bar
+3|2|foo
+4|2|bar
+\.

--- a/modules/sql/src/test/scala/SqlCompositeKeyMapping.scala
+++ b/modules/sql/src/test/scala/SqlCompositeKeyMapping.scala
@@ -1,0 +1,70 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import edu.gemini.grackle.syntax._
+
+trait SqlCompositeKeyMapping[F[_]] extends SqlTestMapping[F] {
+
+  object compositeKeyParent extends TableDef("composite_key_parent") {
+    val key1 = col("key_1", int4)
+    val key2 = col("key_2", varchar)
+  }
+
+  object compositeKeyChild extends TableDef("composite_key_child") {
+    val id = col("id", int4)
+    val parent1 = col("parent_1", int4)
+    val parent2 = col("parent_2", varchar)
+  }
+
+  val schema =
+    schema"""
+      type Query {
+        parents: [Parent!]!
+      }
+      type Parent {
+        key1: Int!
+        key2: String!
+        children: [Child!]!
+      }
+      type Child {
+        id: Int!
+        parent1: Int!
+        parent2: String!
+      }
+    """
+
+  val QueryType = schema.ref("Query")
+  val ParentType = schema.ref("Parent")
+  val ChildType = schema.ref("Child")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            SqlObject("parents")
+          )
+      ),
+      ObjectMapping(
+        tpe = ParentType,
+        fieldMappings =
+          List(
+            SqlField("key1", compositeKeyParent.key1, key = true),
+            SqlField("key2", compositeKeyParent.key2, key = true),
+            SqlObject("children", Join(List((compositeKeyParent.key1, compositeKeyChild.parent1), (compositeKeyParent.key2, compositeKeyChild.parent2))))
+          )
+      ),
+      ObjectMapping(
+        tpe = ChildType,
+        fieldMappings =
+          List(
+            SqlField("id", compositeKeyChild.id, key = true),
+            SqlField("parent1", compositeKeyChild.parent1),
+            SqlField("parent2", compositeKeyChild.parent2),
+          )
+      )
+    )
+}

--- a/modules/sql/src/test/scala/SqlCompositeKeySpec.scala
+++ b/modules/sql/src/test/scala/SqlCompositeKeySpec.scala
@@ -1,0 +1,92 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import cats.effect.IO
+import io.circe.Json
+import org.scalatest.funsuite.AnyFunSuite
+import cats.effect.unsafe.implicits.global
+
+import edu.gemini.grackle._
+import syntax._
+
+import grackle.test.GraphQLResponseTests.assertWeaklyEqual
+
+trait SqlCompositeKeySpec extends AnyFunSuite {
+  def mapping: QueryExecutor[IO, Json]
+
+  test("root query") {
+    val query = """
+      query {
+        parents {
+          key1
+          key2
+          children {
+            id
+            parent1
+            parent2
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "parents" : [
+            {
+              "key1" : 2,
+              "key2" : "bar",
+              "children" : [
+                {
+                  "id" : 4,
+                  "parent1" : 2,
+                  "parent2" : "bar"
+                }
+              ]
+            },
+            {
+              "key1" : 2,
+              "key2" : "foo",
+              "children" : [
+                {
+                  "id" : 3,
+                  "parent1" : 2,
+                  "parent2" : "foo"
+                }
+              ]
+            },
+            {
+              "key1" : 1,
+              "key2" : "bar",
+              "children" : [
+                {
+                  "id" : 2,
+                  "parent1" : 1,
+                  "parent2" : "bar"
+                }
+              ]
+            },
+            {
+              "key1" : 1,
+              "key2" : "foo",
+              "children" : [
+                {
+                  "id" : 1,
+                  "parent1" : 1,
+                  "parent2" : "foo"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+}


### PR DESCRIPTION
Mappings can now specify multiple parent/child join conditions for a single `Join`.