### PR TITLE
Fixed cursor construction for RootEffects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ val Scala3 = "3.1.3"
 ThisBuild / scalaVersion        := Scala2
 ThisBuild / crossScalaVersions  := Seq(Scala2, Scala3)
 
-ThisBuild / tlBaseVersion    := "0.9"
+ThisBuild / tlBaseVersion    := "0.10"
 ThisBuild / organization     := "edu.gemini"
 ThisBuild / organizationName := "Association of Universities for Research in Astronomy, Inc. (AURA)"
 ThisBuild / startYear        := Some(2019)

--- a/modules/circe/src/test/scala/CirceEffectSpec.scala
+++ b/modules/circe/src/test/scala/CirceEffectSpec.scala
@@ -7,11 +7,161 @@ package circetests
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.tests.CatsSuite
+import fs2.concurrent.SignallingRef
+import io.circe.Json
+
 import edu.gemini.grackle.syntax._
 
 final class CirceEffectSpec extends CatsSuite {
+  test("circe effect (nested)") {
+    val query = """
+      query {
+        foo {
+          s,
+          n
+        }
+      }
+    """
 
-  test("circe effect") {
+    val expected = json"""
+      {
+        "data" : {
+          "foo" : {
+            "s" : "hi",
+            "n" : 42
+          }
+        }
+      }
+    """
+
+    val prg: IO[(Json, Int)] =
+      for {
+        ref  <- SignallingRef[IO, Int](0)
+        map  =  new TestCirceEffectMapping(ref)
+        res  <- map.compileAndRun(query)
+        eff  <- ref.get
+      } yield (res, eff)
+
+    val (res, eff) = prg.unsafeRunSync()
+    //println(res)
+    //println(eff)
+
+    assert(res == expected)
+    assert(eff == 1)
+  }
+
+  test("circe effect (nested, aliased)") {
+    val query = """
+      query {
+        quux:foo {
+          s,
+          n
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "quux" : {
+            "s" : "hi",
+            "n" : 42
+          }
+        }
+      }
+    """
+
+    val prg: IO[(Json, Int)] =
+      for {
+        ref  <- SignallingRef[IO, Int](0)
+        map  =  new TestCirceEffectMapping(ref)
+        res  <- map.compileAndRun(query)
+        eff  <- ref.get
+      } yield (res, eff)
+
+    val (res, eff) = prg.unsafeRunSync()
+    //println(res)
+    //println(eff)
+
+    assert(res == expected)
+    assert(eff == 1)
+  }
+
+  test("circe effect (rooted)") {
+    val query = """
+      query {
+        qux {
+          s,
+          n
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "qux" : {
+            "s" : "hi",
+            "n" : 42
+          }
+        }
+      }
+    """
+
+    val prg: IO[(Json, Int)] =
+      for {
+        ref  <- SignallingRef[IO, Int](0)
+        map  =  new TestCirceEffectMapping(ref)
+        res  <- map.compileAndRun(query)
+        eff  <- ref.get
+      } yield (res, eff)
+
+    val (res, eff) = prg.unsafeRunSync()
+    //println(res)
+    //println(eff)
+
+    assert(res == expected)
+    assert(eff == 1)
+  }
+
+  test("circe effect (rooted, aliased)") {
+    val query = """
+      query {
+        quux:qux {
+          s,
+          n
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "quux" : {
+            "s" : "hi",
+            "n" : 42
+          }
+        }
+      }
+    """
+
+    val prg: IO[(Json, Int)] =
+      for {
+        ref  <- SignallingRef[IO, Int](0)
+        map  =  new TestCirceEffectMapping(ref)
+        res  <- map.compileAndRun(query)
+        eff  <- ref.get
+      } yield (res, eff)
+
+    val (res, eff) = prg.unsafeRunSync()
+    //println(res)
+    //println(eff)
+
+    assert(res == expected)
+    assert(eff == 1)
+  }
+
+  test("circe effect (multiple)") {
     val query = """
       query {
         foo {
@@ -48,10 +198,19 @@ final class CirceEffectSpec extends CatsSuite {
       }
     """
 
-    val res = new TestCirceEffectMapping[IO].compileAndRun(query).unsafeRunSync()
+    val prg: IO[(Json, Int)] =
+      for {
+        ref  <- SignallingRef[IO, Int](0)
+        map  =  new TestCirceEffectMapping(ref)
+        res  <- map.compileAndRun(query)
+        eff  <- ref.get
+      } yield (res, eff)
+
+    val (res, eff) = prg.unsafeRunSync()
     //println(res)
+    //println(eff)
 
     assert(res == expected)
+    assert(eff == 3)
   }
-  
 }

--- a/modules/core/src/main/scala/predicate.scala
+++ b/modules/core/src/main/scala/predicate.scala
@@ -46,21 +46,22 @@ trait TermLow {
 }
 
 /** A path starting from some root type. */
-case class Path private (root: Type, path: List[String]) {
+case class Path(rootTpe: Type, path: List[String] = Nil) {
+
+  def isRoot = path.isEmpty
 
   def asTerm[A]: Term[A] =
     if (isList) PathTerm.ListPath(path)
     else PathTerm.UniquePath(path)
 
-  lazy val isList: Boolean = root.pathIsList(path)
-  lazy val tpe: Option[Type] = root.path(path)
+  lazy val isList: Boolean = rootTpe.pathIsList(path)
+  lazy val tpe: Option[Type] = rootTpe.path(path)
 
   def prepend(prefix: List[String]): Path =
     copy(path = prefix ++ path)
 
   def /(elem: String): Path =
     copy(path = path :+ elem)
-
 }
 
 object Path {

--- a/modules/core/src/main/scala/queryinterpreter.scala
+++ b/modules/core/src/main/scala/queryinterpreter.scala
@@ -58,8 +58,8 @@ class QueryInterpreter[F[_]](mapping: Mapping[F]) {
     val mergedResults: Stream[F,Result[ProtoJson]] =
       if(mapping.schema.subscriptionType.map(_ =:= rootTpe).getOrElse(false)) {
         (effectfulQueries, pureQueries) match {
-          case (List(EffectfulQuery(query, RootEffect(_, effect))), Nil) =>
-            effect(query, rootTpe, env.addFromQuery(query)).map(_.flatMap {
+          case (List(EffectfulQuery(query, RootEffect(fieldName, effect))), Nil) =>
+            effect(query, rootTpe / fieldName, env.addFromQuery(query)).map(_.flatMap {
               case (q, c) => runValue(q, rootTpe, c)
             })
           case _ =>
@@ -96,8 +96,8 @@ class QueryInterpreter[F[_]](mapping: Mapping[F]) {
           if(effectfulQueries.isEmpty) Stream.empty
           else {
             effectfulQueries.foldMap {
-              case EffectfulQuery(query, RootEffect(_, effect)) =>
-                effect(query, rootTpe, env.addFromQuery(query)).map(_.flatMap {
+              case EffectfulQuery(query, RootEffect(fieldName, effect)) =>
+                effect(query, rootTpe / fieldName, env.addFromQuery(query)).map(_.flatMap {
                   case (q, c) => runValue(q, rootTpe, c)
                 })
             }

--- a/modules/core/src/test/scala/effects/ValueEffectData.scala
+++ b/modules/core/src/test/scala/effects/ValueEffectData.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package effects
+
+import cats.effect.Sync
+import cats.implicits._
+import fs2.concurrent.SignallingRef
+
+import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
+
+class ValueEffectMapping[F[_]: Sync](ref: SignallingRef[F, Int]) extends ValueMapping[F] {
+  val schema =
+    schema"""
+      type Query {
+        foo: Struct!
+      }
+      type Struct {
+        n: Int!
+        s: String!
+      }
+    """
+
+  val QueryType = schema.ref("Query")
+  val StructType = schema.ref("Struct")
+
+  case class Struct(n: Int, s: String)
+
+  val typeMappings = List(
+    ObjectMapping(
+      tpe = QueryType,
+      fieldMappings =
+        List(
+          // Compute a ValueCursor
+          RootEffect.computeCursor("foo")((_, p, e) =>
+            ref.update(_+1).as(
+              Result(valueCursor(p, e, Struct(42, "hi")))
+            )
+          )
+        )
+    ),
+    ValueObjectMapping[Struct](
+      tpe = StructType,
+      fieldMappings =
+        List(
+          ValueField("n", _.n),
+          ValueField("s", _.s),
+        )
+    )
+  )
+}

--- a/modules/core/src/test/scala/effects/ValueEffectSpec.scala
+++ b/modules/core/src/test/scala/effects/ValueEffectSpec.scala
@@ -1,0 +1,88 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package effects
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.tests.CatsSuite
+import fs2.concurrent.SignallingRef
+import io.circe.Json
+
+import edu.gemini.grackle.syntax._
+
+final class ValueEffectSpec extends CatsSuite {
+  test("value effect") {
+    val query = """
+      query {
+        foo {
+          s,
+          n
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "foo" : {
+            "s" : "hi",
+            "n" : 42
+          }
+        }
+      }
+    """
+
+    val prg: IO[(Json, Int)] =
+      for {
+        ref  <- SignallingRef[IO, Int](0)
+        map  =  new ValueEffectMapping(ref)
+        res  <- map.compileAndRun(query)
+        eff  <- ref.get
+      } yield (res, eff)
+
+    val (res, eff) = prg.unsafeRunSync()
+    //println(res)
+    //println(eff)
+
+    assert(res == expected)
+    assert(eff == 1)
+  }
+
+  test("value effect, aliased") {
+    val query = """
+      query {
+        quux:foo {
+          s,
+          n
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "quux" : {
+            "s" : "hi",
+            "n" : 42
+          }
+        }
+      }
+    """
+
+    val prg: IO[(Json, Int)] =
+      for {
+        ref  <- SignallingRef[IO, Int](0)
+        map  =  new ValueEffectMapping(ref)
+        res  <- map.compileAndRun(query)
+        eff  <- ref.get
+      } yield (res, eff)
+
+    val (res, eff) = prg.unsafeRunSync()
+    //println(res)
+    //println(eff)
+
+    assert(res == expected)
+    assert(eff == 1)
+  }
+}

--- a/modules/core/src/test/scala/subscription/SubscriptionSpec.scala
+++ b/modules/core/src/test/scala/subscription/SubscriptionSpec.scala
@@ -39,19 +39,19 @@ final class SubscriptionSpec extends CatsSuite {
       val typeMappings: List[TypeMapping] =
         List(
           ObjectMapping(QueryType, List(
-            RootEffect.computeCursor("get")((_, tpe, env) => ref.get.map(n => Result(valueCursor(tpe, env, n))))
+            RootEffect.computeCursor("get")((_, path, env) => ref.get.map(n => Result(valueCursor(path, env, n))))
           )),
           ObjectMapping(MutationType, List(
-            RootEffect.computeCursor("put")( (_, tpe, env) =>
+            RootEffect.computeCursor("put")( (_, path, env) =>
               env.get[Int]("n") match {
                 case None    => Result.failure(s"Implementation error: `n: Int` not found in $env").pure[IO]
-                case Some(n) => ref.set(n).map(_ => Result(valueCursor(tpe, env, n)))
+                case Some(n) => ref.set(n).map(_ => Result(valueCursor(path, env, n)))
               }
             )
           )),
           ObjectMapping(SubscriptionType, List(
-            RootEffect.computeCursorStream("watch")((_, tpe, env) =>
-              ref.discrete.map(n => Result(valueCursor(tpe, env, n))))
+            RootEffect.computeCursorStream("watch")((_, path, env) =>
+              ref.discrete.map(n => Result(valueCursor(path, env, n))))
           ))
         )
 
@@ -189,5 +189,4 @@ final class SubscriptionSpec extends CatsSuite {
     ))
 
   }
-
 }

--- a/modules/generic/src/main/scala/genericmapping.scala
+++ b/modules/generic/src/main/scala/genericmapping.scala
@@ -11,14 +11,17 @@ import cats.implicits._
 import io.circe.{Encoder, Json}
 import org.tpolecat.sourcepos.SourcePos
 
-import Cursor.{AbstractCursor, Context, Env}
+import Cursor.{AbstractCursor, Context, DeferredCursor, Env}
 import QueryInterpreter.mkOneError
 
 abstract class GenericMapping[F[_]](implicit val M: Monad[F]) extends Mapping[F] with GenericMappingLike[F]
 
 trait GenericMappingLike[F[_]] extends ScalaVersionSpecificGenericMappingLike[F] {
-  def genericCursor[T](tpe: Type, env: Env, t: T)(implicit cb: => CursorBuilder[T]): Result[Cursor] =
-    cb.build(Context(tpe), t, None, env)
+  def genericCursor[T](path: Path, env: Env, t: T)(implicit cb: => CursorBuilder[T]): Result[Cursor] =
+    if(path.isRoot)
+      cb.build(Context(path.rootTpe), t, None, env)
+    else
+      DeferredCursor(path, (context, parent) => cb.build(context, t, Some(parent), env)).rightIor
 
   override def mkCursorForField(parent: Cursor, fieldName: String, resultName: Option[String]): Result[Cursor] = {
     val context = parent.context

--- a/modules/generic/src/test/scala/effects.scala
+++ b/modules/generic/src/test/scala/effects.scala
@@ -1,0 +1,129 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle
+package generic
+
+import cats.effect.{IO, Sync}
+import cats.effect.unsafe.implicits.global
+import cats.implicits._
+import cats.tests.CatsSuite
+import fs2.concurrent.SignallingRef
+import io.circe.Json
+
+import edu.gemini.grackle.syntax._
+
+class GenericEffectMapping[F[_]: Sync](ref: SignallingRef[F, Int]) extends GenericMapping[F] {
+  import semiauto._
+
+  val schema =
+    schema"""
+      type Query {
+        foo: Struct!
+      }
+      type Struct {
+        n: Int!
+        s: String!
+      }
+    """
+
+  val QueryType = schema.ref("Query")
+  val StructType = schema.ref("Struct")
+
+  case class Struct(n: Int, s: String)
+  object Struct {
+    implicit val cursorBuilder: CursorBuilder[Struct] =
+      deriveObjectCursorBuilder[Struct](StructType)
+  }
+
+  val typeMappings = List(
+    ObjectMapping(
+      tpe = QueryType,
+      fieldMappings =
+        List(
+          // Compute a ValueCursor
+          RootEffect.computeCursor("foo")((_, p, e) =>
+            ref.update(_+1).as(
+              genericCursor(p, e, Struct(42, "hi"))
+            )
+          )
+        )
+    )
+  )
+}
+
+final class GenericEffectSpec extends CatsSuite {
+  test("generic effect") {
+    val query = """
+      query {
+        foo {
+          s,
+          n
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "foo" : {
+            "s" : "hi",
+            "n" : 42
+          }
+        }
+      }
+    """
+
+    val prg: IO[(Json, Int)] =
+      for {
+        ref  <- SignallingRef[IO, Int](0)
+        map  =  new GenericEffectMapping(ref)
+        res  <- map.compileAndRun(query)
+        eff  <- ref.get
+      } yield (res, eff)
+
+    val (res, eff) = prg.unsafeRunSync()
+    //println(res)
+    //println(eff)
+
+    assert(res == expected)
+    assert(eff == 1)
+  }
+
+  test("generic effect, aliased") {
+    val query = """
+      query {
+        quux:foo {
+          s,
+          n
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "quux" : {
+            "s" : "hi",
+            "n" : 42
+          }
+        }
+      }
+    """
+
+    val prg: IO[(Json, Int)] =
+      for {
+        ref  <- SignallingRef[IO, Int](0)
+        map  =  new GenericEffectMapping(ref)
+        res  <- map.compileAndRun(query)
+        eff  <- ref.get
+      } yield (res, eff)
+
+    val (res, eff) = prg.unsafeRunSync()
+    //println(res)
+    //println(eff)
+
+    assert(res == expected)
+    assert(eff == 1)
+  }
+}


### PR DESCRIPTION
The only user-visible change is that the functions `RootEffects` are constructed with now take a `Path` rather than a root `Type`. Typically this path should be passed directly through to the relevant cursor construction call as was previously the case with the type, so, in many cases, user code which was previously correct will continue to compile and function as expected.

Fixes https://github.com/gemini-hlsw/gsp-graphql/pull/310.