### PR TITLE
Fixes/refactorings of root effects to better support effect batching

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ val Scala3 = "3.2.2"
 ThisBuild / scalaVersion        := Scala2
 ThisBuild / crossScalaVersions  := Seq(Scala2, Scala3)
 
-ThisBuild / tlBaseVersion    := "0.10"
+ThisBuild / tlBaseVersion    := "0.11"
 ThisBuild / organization     := "edu.gemini"
 ThisBuild / organizationName := "Association of Universities for Research in Astronomy, Inc. (AURA)"
 ThisBuild / startYear        := Some(2019)

--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -716,6 +716,20 @@ object Value {
 
   case object AbsentValue extends Value
 
+  object StringListValue {
+    def apply(ss: List[String]): Value =
+      ListValue(ss.map(StringValue(_)))
+
+    def unapply(value: Value): Option[List[String]] =
+      value match {
+        case ListValue(l) => l.traverse {
+          case StringValue(s) => Some(s)
+          case _ => None
+        }
+        case _ => None
+      }
+  }
+
   def checkValue(iv: InputValue, value: Option[Value]): Result[Value] =
     (iv.tpe.dealias, value) match {
       case (_, None) if iv.defaultValue.isDefined =>

--- a/modules/core/src/test/scala/subscription/SubscriptionSpec.scala
+++ b/modules/core/src/test/scala/subscription/SubscriptionSpec.scala
@@ -50,7 +50,7 @@ final class SubscriptionSpec extends CatsSuite {
             )
           )),
           ObjectMapping(SubscriptionType, List(
-            RootEffect.computeCursorStream("watch")((_, path, env) =>
+            RootStream.computeCursor("watch")((_, path, env) =>
               ref.discrete.map(n => Result(valueCursor(path, env, n))))
           ))
         )

--- a/modules/doobie-pg/src/test/scala/DoobieSuites.scala
+++ b/modules/doobie-pg/src/test/scala/DoobieSuites.scala
@@ -26,7 +26,10 @@ final class CoalesceSpec extends DoobieDatabaseSuite with SqlCoalesceSpec {
 }
 
 final class ComposedWorldSpec extends DoobieDatabaseSuite with SqlComposedWorldSpec {
-  lazy val mapping = new SqlComposedMapping(new DoobieTestMapping(xa) with SqlWorldMapping[IO], CurrencyMapping[IO])
+  def mapping: IO[(CurrencyMapping[IO], QueryExecutor[IO, Json])] =
+    for {
+      currencyMapping <- CurrencyMapping[IO]
+    } yield (currencyMapping, new SqlComposedMapping(new DoobieTestMapping(xa) with SqlWorldMapping[IO], currencyMapping))
 }
 
 final class CompositeKeySpec extends DoobieDatabaseSuite with SqlCompositeKeySpec {

--- a/modules/skunk/src/test/scala/SkunkSuites.scala
+++ b/modules/skunk/src/test/scala/SkunkSuites.scala
@@ -26,7 +26,10 @@ final class CoalesceSpec extends SkunkDatabaseSuite with SqlCoalesceSpec {
 }
 
 final class ComposedWorldSpec extends SkunkDatabaseSuite with SqlComposedWorldSpec {
-  lazy val mapping = new SqlComposedMapping(new SkunkTestMapping(pool) with SqlWorldMapping[IO], CurrencyMapping[IO])
+  def mapping: IO[(CurrencyMapping[IO], QueryExecutor[IO, Json])] =
+    for {
+      currencyMapping <- CurrencyMapping[IO]
+    } yield (currencyMapping, new SqlComposedMapping(new SkunkTestMapping(pool) with SqlWorldMapping[IO], currencyMapping))
 }
 
 final class CompositeKeySpec extends SkunkDatabaseSuite with SqlCompositeKeySpec {

--- a/modules/skunk/src/test/scala/subscription/SubscriptionMapping.scala
+++ b/modules/skunk/src/test/scala/subscription/SubscriptionMapping.scala
@@ -84,7 +84,7 @@ trait SubscriptionMapping[F[_]] extends SkunkMapping[F] {
       ObjectMapping(
         tpe = SubscriptionType,
         fieldMappings = List(
-          RootEffect.computeQueryStream("channel")((query, _, _) =>
+          RootStream.computeQuery("channel")((query, _, _) =>
             for {
               s  <- fs2.Stream.resource(pool)
               id <- s.channel(id"city_channel").listen(256).map(_.value.toInt)

--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -703,13 +703,13 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
     rootFieldMapping(context, query) match {
       //case Some(_: SqlFieldMapping) => true // Scala 3 thinks this is unreachable
       case Some(fm) if fm.isInstanceOf[SqlFieldMapping] => true
-      case Some(re: RootEffect) =>
+      case Some(re: EffectMapping) =>
         val fieldContext = context.forFieldOrAttribute(re.fieldName, None)
         objectMapping(fieldContext).map { om =>
           om.fieldMappings.exists {
             //case _: SqlFieldMapping => true // Scala 3 thinks this is unreachable
-      case fm if fm.isInstanceOf[SqlFieldMapping] => true
-      case _ => false
+            case fm if fm.isInstanceOf[SqlFieldMapping] => true
+            case _ => false
           }
         }.getOrElse(false)
       case _ => false
@@ -745,7 +745,7 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
           }
         )
 
-      case (Some(_: SqlObject)|Some(_: RootEffect), sc: SqlCursor) =>
+      case (Some(_: SqlObject)|Some(_: EffectMapping), sc: SqlCursor) =>
         sc.asTable.map { table =>
           val focussed = sc.mapped.narrow(fieldContext, table)
           sc.mkChild(context = fieldContext, focus = focussed)

--- a/modules/sql/src/test/scala/SqlComposedWorldSpec.scala
+++ b/modules/sql/src/test/scala/SqlComposedWorldSpec.scala
@@ -14,7 +14,36 @@ import syntax._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqual
 
 trait SqlComposedWorldSpec extends AnyFunSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: IO[(CurrencyMapping[IO], QueryExecutor[IO, Json])]
+
+  test("simple effectful query") {
+    val query = """
+      query {
+        currencies(countryCodes: ["GBR"]) {
+          code
+          exchangeRate
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "currencies" : [
+            {
+              "code" : "GBP",
+              "exchangeRate" : 1.25
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.flatMap(_._1.compileAndRun(query)).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
 
   test("simple composed query") {
     val query = """
@@ -45,7 +74,7 @@ trait SqlComposedWorldSpec extends AnyFunSuite {
       }
     """
 
-    val res = mapping.compileAndRun(query).unsafeRunSync()
+    val res = mapping.flatMap(_._2.compileAndRun(query)).unsafeRunSync()
     //println(res)
 
     assertWeaklyEqual(res, expected)
@@ -100,10 +129,125 @@ trait SqlComposedWorldSpec extends AnyFunSuite {
       }
     """
 
-    val res = mapping.compileAndRun(query).unsafeRunSync()
+    val (res, n0, n1) =
+      (for {
+        cm  <- mapping
+        c   =  cm._1
+        m   =  cm._2
+        n0  <- cm._1.count
+        res <- m.compileAndRun(query)
+        n1  <- cm._1.count
+      } yield (res, n0, n1)).unsafeRunSync()
+
     //println(res)
 
+    assert(n0 == 0 && n1 == 1)
+
     assertWeaklyEqual(res, expected)
+  }
+
+  test("simple query with mutation") {
+    val query = """
+      query {
+        cities(namePattern: "Ame%") {
+          name
+          country {
+            name
+            currencies {
+              code
+              exchangeRate
+            }
+          }
+        }
+      }
+    """
+
+    val expected0 = json"""
+      {
+        "data": {
+          "cities" : [
+            {
+              "name" : "Amersfoort",
+              "country" : {
+                "name" : "Netherlands",
+                "currencies" : [
+                  {
+                    "code" : "EUR",
+                    "exchangeRate" : 1.12
+                  }
+                ]
+              }
+            },
+            {
+              "name" : "Americana",
+              "country" : {
+                "name" : "Brazil",
+                "currencies" : [
+                  {
+                    "code" : "BRL",
+                    "exchangeRate" : 0.25
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    """
+
+    val expected1 = json"""
+      {
+        "data": {
+          "cities" : [
+            {
+              "name" : "Amersfoort",
+              "country" : {
+                "name" : "Netherlands",
+                "currencies" : [
+                  {
+                    "code" : "EUR",
+                    "exchangeRate" : 1.13
+                  }
+                ]
+              }
+            },
+            {
+              "name" : "Americana",
+              "country" : {
+                "name" : "Brazil",
+                "currencies" : [
+                  {
+                    "code" : "BRL",
+                    "exchangeRate" : 0.25
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    """
+
+    val (res0, res1, n0, n1, n2) =
+      (for {
+        cm   <- mapping
+        c    =  cm._1
+        m    =  cm._2
+        n0   <- cm._1.count
+        res0 <- m.compileAndRun(query)
+        n1   <- cm._1.count
+        _    <- c.update("EUR", 1.13)
+        res1 <- m.compileAndRun(query)
+        n2   <- cm._1.count
+      } yield (res0, res1, n0, n1, n2)).unsafeRunSync()
+
+    //println(res0)
+    //println(res1)
+
+    assert(n0 == 0 && n1 == 1 && n2 == 2)
+
+    assertWeaklyEqual(res0, expected0)
+    assertWeaklyEqual(res1, expected1)
   }
 
   test("composed query with introspection") {
@@ -139,7 +283,7 @@ trait SqlComposedWorldSpec extends AnyFunSuite {
       }
     """
 
-    val res = mapping.compileAndRun(query).unsafeRunSync()
+    val res = mapping.flatMap(_._2.compileAndRun(query)).unsafeRunSync()
     //println(res)
 
     assertWeaklyEqual(res, expected)


### PR DESCRIPTION
+ Added `combineQueries` to `Mapping`.
+ Split `RootEffect` into an abstract `EffectMapping` type with `RootEffect` and `RootStream` subtypes. `RootEffect` represents a single shot effect whereas `RootStream` represents a stream for subscriptions.
+ Split root interpreter logic into subscription/`Stream` and non-subscription/non-`Stream` branches.
+ Moved some internal `QueryInterpreter` methods from yielding `Stream[F, T]` to yield `F[T]`.
+ Reworked `SqlComposedWorldMapping/Spec` to better illustrate effectful composition and batching.