### PR TITLE
Order terms were not contextualized in one case

### DIFF
--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -2330,10 +2330,12 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
             val nonNullKeys = predCols.map(col => IsNull(col.toTerm, false))
 
             val pred1 = pred0.map(p => contextualiseWhereTerms(context, baseRef, p))
+            val distOss0 = oss.map(os => contextualiseOrderTerms(context, baseRef, os))
 
             val distOrders =
               keyCols.map(col => OrderSelection(col.derive(baseRef).toTerm, true, true)) ++
-              oss.filterNot(os => keyCols.contains(columnForSqlTerm(context, os.term).getOrElse(sys.error(s"No column for term ${os.term}"))))
+              distOss0.filterNot(os => keyCols.contains(columnForSqlTerm(context, os.term).getOrElse(sys.error(s"No column for term ${os.term}"))))
+
             val distOrderCols = orderCols.diff(keyCols).map(_.derive(baseRef))
 
             val predQuery0 = SqlSelect(

--- a/modules/sql/src/test/scala/SqlWorldSpec.scala
+++ b/modules/sql/src/test/scala/SqlWorldSpec.scala
@@ -1893,4 +1893,50 @@ trait SqlWorldSpec extends AnyFunSuite {
 
     assertWeaklyEqual(res, expected)
   }
+
+  test("query with top-level ordering, limit and subobjects") {
+    val query = """
+      query {
+        countries(limit: 3, byPopulation: true) {
+          name
+          population
+          cities {
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "countries" : [
+            {
+              "name" : "Bouvet Island",
+              "population" : 0,
+              "cities" : [
+              ]
+            },
+            {
+              "name" : "Antarctica",
+              "population" : 0,
+              "cities" : [
+              ]
+            },
+            {
+              "name" : "French Southern territories",
+              "population" : 0,
+              "cities" : [
+              ]
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected, strictPaths = List(List("data", "countries")))
+  }
 }


### PR DESCRIPTION
Fix for a bug revealed by #343.