### PR TITLE
Added support for non-root effects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,6 +125,7 @@ lazy val sql = project
     name := "gsp-graphql-sql",
     libraryDependencies ++= Seq(
       "org.typelevel"     %% "log4cats-slf4j"         % log4catsVersion,
+      "io.circe"          %% "circe-generic"          % circeVersion % "test",
       "ch.qos.logback"    %  "logback-classic"        % logbackVersion % "test",
       "com.dimafeng"      %% "testcontainers-scala-scalatest"  % testContainersVersion % "test",
       "com.dimafeng"      %% "testcontainers-scala-postgresql" % testContainersVersion % "test",

--- a/docs/src/main/paradox/tutorial/in-memory-model.md
+++ b/docs/src/main/paradox/tutorial/in-memory-model.md
@@ -210,9 +210,9 @@ sealed trait Query {
   case class Group(queries: List[Query]) extends Query
   case class Unique(child: Query) extends Query
   case class Filter(pred: Predicate, child: Query) extends Query
-  case class Component[F[_]](mapping: Mapping[F], join: (Cursor, Query) => Result[Query], child: Query) extends Query
+  case class Component[F[_]](mapping: Mapping[F], join: (Query, Cursor) => Result[Query], child: Query) extends Query
+  case class Effect[F[_]](handler: EffectHandler[F], child: Query) extends Query
   case class Introspect(schema: Schema, child: Query) extends Query
-  case class Defer(join: (Cursor, Query) => Result[Query], child: Query, rootTpe: Type) extends Query
   case class Environment(env: Env, child: Query) extends Query
   case class Wrap(name: String, child: Query) extends Query
   case class Rename(name: String, child: Query) extends Query

--- a/modules/core/src/main/scala/query.scala
+++ b/modules/core/src/main/scala/query.scala
@@ -213,7 +213,13 @@ object Query {
 
   case class UntypedVarDef(name: String, tpe: Ast.Type, default: Option[Value])
 
-  /** Extractor for nested Rename/Select patterns in the query algebra */
+  /**
+   * Extractor for nested Rename/Select patterns in the query algebra
+   *
+   * PossiblyRenamedSelect is an extractor/constructor for a Select node
+   * possibly wrapped in a Rename node so that they can be handled together
+   * conveniently.
+   */
   object PossiblyRenamedSelect {
     def apply(sel: Select, resultName: String): Query = sel match {
       case Select(`resultName`, _, _) => sel

--- a/modules/core/src/test/scala/composed/ComposedData.scala
+++ b/modules/core/src/test/scala/composed/ComposedData.scala
@@ -190,7 +190,7 @@ object ComposedMapping extends ComposedMapping[Id] {
       )
     )
 
-  def countryCurrencyJoin(c: Cursor, q: Query): Result[Query] =
+  def countryCurrencyJoin(q: Query, c: Cursor): Result[Query] =
     (c.focus, q) match {
       case (c: CountryData.Country, Select("currency", _, child)) =>
         Select("fx", Nil, Unique(Filter(Eql(CurrencyType / "code", Const(c.currencyCode)), child))).rightIor

--- a/modules/core/src/test/scala/composed/ComposedListSpec.scala
+++ b/modules/core/src/test/scala/composed/ComposedListSpec.scala
@@ -173,7 +173,7 @@ object ComposedListMapping extends ComposedMapping[Id] {
     }
   ))
 
-  def collectionItemJoin(c: Cursor, q: Query): Result[Query] =
+  def collectionItemJoin(q: Query, c: Cursor): Result[Query] =
     (c.focus, q) match {
       case (c: CollectionData.Collection, Select("items", _, child)) =>
         Group(c.itemIds.map(id => Select("itemById", Nil, Unique(Filter(Eql(ItemType / "id", Const(id)), child))))).rightIor

--- a/modules/doobie-pg/src/test/scala/DoobieSuites.scala
+++ b/modules/doobie-pg/src/test/scala/DoobieSuites.scala
@@ -125,6 +125,19 @@ final class MutationSpec extends DoobieDatabaseSuite with SqlMutationSpec {
     }
 }
 
+final class NestedEffectsSpec extends DoobieDatabaseSuite with SqlNestedEffectsSpec {
+  def mapping: IO[(CurrencyService[IO], QueryExecutor[IO, Json])] =
+    for {
+      currencyService0 <- CurrencyService[IO]
+    } yield {
+      val mapping =
+        new DoobieTestMapping(xa) with SqlNestedEffectsMapping[IO] {
+          lazy val currencyService = currencyService0
+        }
+      (currencyService0, mapping)
+    }
+}
+
 final class Paging1Spec extends DoobieDatabaseSuite with SqlPaging1Spec {
   lazy val mapping = new DoobieTestMapping(xa) with SqlPaging1Mapping[IO]
 }

--- a/modules/skunk/src/test/scala/SkunkSuites.scala
+++ b/modules/skunk/src/test/scala/SkunkSuites.scala
@@ -128,6 +128,19 @@ final class MutationSpec extends SkunkDatabaseSuite with SqlMutationSpec {
     }
 }
 
+final class NestedEffectsSpec extends SkunkDatabaseSuite with SqlNestedEffectsSpec {
+  def mapping: IO[(CurrencyService[IO], QueryExecutor[IO, Json])] =
+    for {
+      currencyService0 <- CurrencyService[IO]
+    } yield {
+      val mapping =
+        new SkunkTestMapping(pool) with SqlNestedEffectsMapping[IO] {
+          lazy val currencyService = currencyService0
+        }
+      (currencyService0, mapping)
+    }
+}
+
 final class Paging1Spec extends SkunkDatabaseSuite with SqlPaging1Spec {
   lazy val mapping = new SkunkTestMapping(pool) with SqlPaging1Mapping[IO]
 }

--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -8,7 +8,7 @@ import scala.annotation.tailrec
 import scala.collection.Factory
 
 import cats.Monad
-import cats.data.{Chain, Ior, NonEmptyChain, NonEmptyList, State}
+import cats.data.{NonEmptyList, State}
 import cats.implicits._
 import io.circe.Json
 import org.tpolecat.sourcepos.SourcePos
@@ -635,14 +635,14 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
         case u: UntypedNarrow => u.copy(child = loop(u.child, context))
         case n@Narrow(subtpe, _) => n.copy(child = loop(n.child, context.asType(subtpe)))
         case s: Skip => s.copy(child = loop(s.child, context))
-        case other@(_: Component[_] | _: Defer | Empty | _: Introspect | _: Select | Skipped) => other
+        case other@(_: Component[_] | _: Effect[_] | Empty | _: Introspect | _: Select | Skipped) => other
       }
 
     loop(query, context)
   }
 
   // Overrides definition in Mapping
-  override def defaultRootCursor(query: Query, tpe: Type, env: Env): F[Result[(Query, Cursor)]] = {
+  override def defaultRootCursor(query: Query, tpe: Type, parentCursor: Option[Cursor]): F[Result[(Query, Cursor)]] = {
     val context = Context(tpe)
 
     val rootQueries = ungroup(query)
@@ -659,19 +659,9 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
           _     <- monitor.queryMapped(query, mapped.fragment, table.numRows, table.numCols)
         } yield {
           val stripped: Query = stripCompiled(query, context)
-          val cursor: SqlCursor = SqlCursor(context, table, mapped, None, env)
+          val cursor: SqlCursor = SqlCursor(context, table, mapped, parentCursor, Env.empty)
           (stripped, cursor)
         }
-      }
-
-    def combineAll(results: List[Result[(Query, SqlCursor)]]): (Chain[Problem], List[Query], List[SqlCursor]) =
-      results.foldLeft((Chain.empty[Problem], List.empty[Query], List.empty[SqlCursor])) {
-        case ((ps, qs, cs), elem) =>
-          elem match {
-            case Ior.Left(ps0) => (ps0.toChain ++ ps, qs, cs)
-            case Ior.Right((q, c)) => (ps, q :: qs, c :: cs)
-            case Ior.Both(ps0, (q, c)) => (ps0.toChain ++ ps, q :: qs, c :: cs)
-          }
       }
 
     val (sqlRoots, otherRoots) = rootQueries.partition(isLocallyMapped(context, _))
@@ -682,13 +672,12 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
       })
     else {
       sqlRoots.traverse(mkCursor).map { qcs =>
-        val (problems, queries, cursors) = combineAll(qcs)
-
-        val mergedQuery = mergeQueries(queries ++ otherRoots)
-        val cursor = MultiRootCursor(cursors)
-        NonEmptyChain.fromChain(problems).map(problems0 =>
-          Ior.Both(problems0, (mergedQuery, cursor))
-        ).getOrElse(Result((mergedQuery, cursor)))
+        qcs.sequence.map(_.unzip match {
+          case (queries, cursors) =>
+            val mergedQuery = mergeQueries(queries ++ otherRoots)
+            val cursor = MultiRootCursor(cursors)
+            (mergedQuery, cursor)
+        })
       }
     }
   }
@@ -3045,7 +3034,7 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
           case TransformCursor(_, child) =>
             loop(child, context, parentConstraints, exposeJoins)
 
-          case Empty | Skipped | Query.Component(_, _, _) | (_: Defer) | (_: UntypedNarrow) | (_: Skip) | (_: Select) =>
+          case Empty | Skipped | Query.Component(_, _, _) | Query.Effect(_, _) | (_: UntypedNarrow) | (_: Skip) | (_: Select) =>
             None
         }
       }

--- a/modules/sql/src/main/scala/SqlMapping.scala
+++ b/modules/sql/src/main/scala/SqlMapping.scala
@@ -641,6 +641,9 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
     loop(query, context)
   }
 
+  def sqlCursor(query: Query, env: Env): F[Result[Cursor]] =
+    defaultRootCursor(query, schema.queryType, Some(RootCursor(Context(schema.queryType), None, env))).map(_.map(_._2))
+
   // Overrides definition in Mapping
   override def defaultRootCursor(query: Query, tpe: Type, parentCursor: Option[Cursor]): F[Result[(Query, Cursor)]] = {
     val context = Context(tpe)

--- a/modules/sql/src/test/scala/SqlNestedEffectsMapping.scala
+++ b/modules/sql/src/test/scala/SqlNestedEffectsMapping.scala
@@ -1,0 +1,248 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import cats.effect.{Ref, Sync}
+import cats.implicits._
+import io.circe.{Encoder, Json}
+import io.circe.syntax._
+import io.circe.generic.semiauto.deriveEncoder
+
+import edu.gemini.grackle._
+import sql.Like
+import syntax._
+import Query._, Predicate._, Value._
+import QueryCompiler._
+
+class CurrencyService[F[_] : Sync](dataRef: Ref[F, CurrencyData], countRef: Ref[F, Int]) {
+  implicit val currencyEncoder: Encoder[Currency] = deriveEncoder
+
+  def get(countryCodes: List[String]): F[Json] =
+    for {
+      _    <- countRef.update(_+1)
+      data <- dataRef.get
+    } yield {
+      val currencies = data.currencies.values.filter(cur => countryCodes.contains(cur.countryCode))
+      Json.fromValues(currencies.map(_.asJson))
+    }
+
+  def update(code: String, exchangeRate: Double): F[Unit] =
+    dataRef.update(data => data.update(code, exchangeRate).getOrElse(data))
+
+  def count: F[Int] = countRef.get
+}
+
+object CurrencyService {
+  def apply[F[_] : Sync]: F[CurrencyService[F]] = {
+    val BRL = Currency("BRL", 0.25, "BRA")
+    val EUR = Currency("EUR", 1.12, "NLD")
+    val GBP = Currency("GBP", 1.25, "GBR")
+
+    val data = CurrencyData(List(BRL, EUR, GBP).map(c => (c.code, c)).toMap)
+
+    for {
+      dataRef  <- Ref[F].of(data)
+      countRef <- Ref[F].of(0)
+    } yield new CurrencyService[F](dataRef, countRef)
+  }
+}
+
+trait SqlNestedEffectsMapping[F[_]] extends SqlTestMapping[F] {
+  def currencyService: CurrencyService[F]
+
+  object root extends RootDef {
+    val numCountries = col("num_countries", int8)
+  }
+
+  object country extends TableDef("country") {
+    val code           = col("code", bpchar(3))
+    val name           = col("name", text)
+    val continent      = col("continent", text)
+    val region         = col("region", text)
+    val surfacearea    = col("surfacearea", float4)
+    val indepyear      = col("indepyear", nullable(int2))
+    val population     = col("population", int4)
+    val lifeexpectancy = col("lifeexpectancy", nullable(float4))
+    val gnp            = col("gnp", nullable(numeric(10, 2)))
+    val gnpold         = col("gnpold", nullable(numeric(10, 2)))
+    val localname      = col("localname", text)
+    val governmentform = col("governmentform", text)
+    val headofstate    = col("headofstate", nullable(text))
+    val capitalId      = col("capital", nullable(int4))
+    val numCities      = col("num_cities", int8)
+    val code2          = col("code2", bpchar(2))
+  }
+
+  object city extends TableDef("city") {
+    val id          = col("id", int4)
+    val countrycode = col("countrycode", bpchar(3))
+    val name        = col("name", text)
+    val district    = col("district", text)
+    val population  = col("population", int4)
+  }
+
+  object countrylanguage extends TableDef("countrylanguage") {
+    val countrycode = col("countrycode", bpchar(3))
+    val language = col("language", text)
+    val isOfficial = col("isOfficial", bool)
+    val percentage = col("percentage", float4)
+  }
+
+  val schema =
+    schema"""
+      type Query {
+        cities(namePattern: String = "%"): [City!]
+        country(code: String): Country
+      }
+      type City {
+        name: String!
+        country: Country!
+        district: String!
+        population: Int!
+      }
+      type Language {
+        language: String!
+        isOfficial: Boolean!
+        percentage: Float!
+        countries: [Country!]!
+      }
+      type Country {
+        name: String!
+        continent: String!
+        region: String!
+        surfacearea: Float!
+        indepyear: Int
+        population: Int!
+        lifeexpectancy: Float
+        gnp: Float
+        gnpold: Float
+        localname: String!
+        governmentform: String!
+        headofstate: String
+        capitalId: Int
+        code2: String!
+        cities: [City!]!
+        languages: [Language!]!
+        currencies: [Currency!]!
+      }
+      type Currency {
+        code: String!
+        exchangeRate: Float!
+        countryCode: String!
+      }
+    """
+
+  val QueryType    = schema.ref("Query")
+  val CountryType  = schema.ref("Country")
+  val CityType     = schema.ref("City")
+  val LanguageType = schema.ref("Language")
+  val CurrencyType = schema.ref("Currency")
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings = List(
+          SqlObject("cities"),
+          SqlObject("country")
+        )
+      ),
+      ObjectMapping(
+        tpe = CountryType,
+        fieldMappings = List(
+          SqlField("code",            country.code, key = true, hidden = true),
+          SqlField("name",            country.name),
+          SqlField("continent",       country.continent),
+          SqlField("region",          country.region),
+          SqlField("surfacearea",     country.surfacearea),
+          SqlField("indepyear",       country.indepyear),
+          SqlField("population",      country.population),
+          SqlField("lifeexpectancy",  country.lifeexpectancy),
+          SqlField("gnp",             country.gnp),
+          SqlField("gnpold",          country.gnpold),
+          SqlField("localname",       country.localname),
+          SqlField("governmentform",  country.governmentform),
+          SqlField("headofstate",     country.headofstate),
+          SqlField("capitalId",       country.capitalId),
+          SqlField("code2",           country.code2),
+          SqlObject("cities",         Join(country.code, city.countrycode)),
+          SqlObject("languages",      Join(country.code, countrylanguage.countrycode)),
+          EffectMapping("currencies", CurrencyQueryHandler)
+        ),
+      ),
+      ObjectMapping(
+        tpe = CityType,
+        fieldMappings = List(
+          SqlField("id", city.id, key = true, hidden = true),
+          SqlField("countrycode", city.countrycode, hidden = true),
+          SqlField("name", city.name),
+          SqlField("district", city.district),
+          SqlField("population", city.population),
+          SqlObject("country", Join(city.countrycode, country.code)),
+        )
+      ),
+      ObjectMapping(
+        tpe = LanguageType,
+        fieldMappings = List(
+          SqlField("language", countrylanguage.language, key = true, associative = true),
+          SqlField("isOfficial", countrylanguage.isOfficial),
+          SqlField("percentage", countrylanguage.percentage),
+          SqlField("countrycode", countrylanguage.countrycode, hidden = true),
+          SqlObject("countries", Join(countrylanguage.countrycode, country.code))
+        )
+      )
+    )
+
+  object CurrencyQueryHandler extends EffectHandler[F] {
+    def runEffects(queries: List[(Query, Cursor)]): F[Result[List[(Query, Cursor)]]] = {
+      val countryCodes = queries.map(_._2.fieldAs[String]("code").toOption)
+      val distinctCodes = queries.flatMap(_._2.fieldAs[String]("code").toList).distinct
+
+      val children = queries.flatMap {
+        case (PossiblyRenamedSelect(Select(name, _, child), alias), parentCursor) =>
+          parentCursor.context.forField(name, alias).toList.map(ctx => (ctx, child, parentCursor))
+        case _ => Nil
+      }
+
+      def unpackResults(res: Json): List[Json] =
+        (for {
+          arr <- res.asArray
+        } yield
+          countryCodes.map {
+            case Some(countryCode) =>
+              Json.fromValues(arr.find { elem =>
+                (for {
+                  obj  <- elem.asObject
+                  fld  <- obj("countryCode")
+                  code <- fld.asString
+                } yield countryCode == code).getOrElse(false)
+              })
+            case _ => Json.Null
+        }).getOrElse(Nil)
+
+      for {
+        res <- currencyService.get(distinctCodes)
+      } yield {
+        unpackResults(res).zip(children).map {
+          case (res, (ctx, child, parentCursor)) =>
+            val cursor = CirceCursor(ctx, res, Some(parentCursor), parentCursor.env)
+            (child, cursor)
+        }
+      }.rightIor
+    }
+  }
+
+  override val selectElaborator = new SelectElaborator(Map(
+    QueryType -> {
+      case Select("country", List(Binding("code", StringValue(code))), child) =>
+        Select("country", Nil, Unique(Filter(Eql(CountryType / "code", Const(code)), child))).rightIor
+
+      case Select("cities", List(Binding("namePattern", StringValue(namePattern))), child) =>
+        if (namePattern == "%")
+          Select("cities", Nil, child).rightIor
+        else
+          Select("cities", Nil, Filter(Like(CityType / "name", namePattern, true), child)).rightIor
+    }
+  ))
+}

--- a/modules/sql/src/test/scala/SqlNestedEffectsSpec.scala
+++ b/modules/sql/src/test/scala/SqlNestedEffectsSpec.scala
@@ -1,0 +1,284 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle.sql.test
+
+import cats.effect.IO
+import io.circe.Json
+import org.scalatest.funsuite.AnyFunSuite
+import cats.effect.unsafe.implicits.global
+
+import edu.gemini.grackle._
+import syntax._
+
+import grackle.test.GraphQLResponseTests.assertWeaklyEqual
+
+trait SqlNestedEffectsSpec extends AnyFunSuite {
+  def mapping: IO[(CurrencyService[IO], QueryExecutor[IO, Json])]
+
+  test("simple effectful service call") {
+    val expected = json"""
+      [
+        {
+          "code" : "EUR",
+          "exchangeRate" : 1.12,
+          "countryCode" : "NLD"
+        },
+        {
+          "code" : "GBP",
+          "exchangeRate" : 1.25,
+          "countryCode" : "GBR"
+        }
+      ]
+    """
+
+    val res = mapping.flatMap(_._1.get(List("GBR", "NLD"))).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("simple composed query") {
+    val query = """
+      query {
+        country(code: "GBR") {
+          name
+          currencies {
+            code
+            exchangeRate
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "country" : {
+            "name" : "United Kingdom",
+            "currencies": [
+              {
+                "code": "GBP",
+                "exchangeRate": 1.25
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.flatMap(_._2.compileAndRun(query)).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("simple multiple nested query") {
+    val query = """
+      query {
+        cities(namePattern: "Ame%") {
+          name
+          country {
+            name
+            currencies {
+              code
+              exchangeRate
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data": {
+          "cities" : [
+            {
+              "name" : "Amersfoort",
+              "country" : {
+                "name" : "Netherlands",
+                "currencies" : [
+                  {
+                    "code" : "EUR",
+                    "exchangeRate" : 1.12
+                  }
+                ]
+              }
+            },
+            {
+              "name" : "Americana",
+              "country" : {
+                "name" : "Brazil",
+                "currencies" : [
+                  {
+                    "code" : "BRL",
+                    "exchangeRate" : 0.25
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    """
+
+    val (res, n0, n1) =
+      (for {
+        cm  <- mapping
+        c   =  cm._1
+        m   =  cm._2
+        n0  <- cm._1.count
+        res <- m.compileAndRun(query)
+        n1  <- cm._1.count
+      } yield (res, n0, n1)).unsafeRunSync()
+
+    //println(res)
+
+    assert(n0 == 0 && n1 == 1)
+
+    assertWeaklyEqual(res, expected)
+  }
+
+  test("simple query with mutation") {
+    val query = """
+      query {
+        cities(namePattern: "Ame%") {
+          name
+          country {
+            name
+            currencies {
+              code
+              exchangeRate
+            }
+          }
+        }
+      }
+    """
+
+    val expected0 = json"""
+      {
+        "data": {
+          "cities" : [
+            {
+              "name" : "Amersfoort",
+              "country" : {
+                "name" : "Netherlands",
+                "currencies" : [
+                  {
+                    "code" : "EUR",
+                    "exchangeRate" : 1.12
+                  }
+                ]
+              }
+            },
+            {
+              "name" : "Americana",
+              "country" : {
+                "name" : "Brazil",
+                "currencies" : [
+                  {
+                    "code" : "BRL",
+                    "exchangeRate" : 0.25
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    """
+
+    val expected1 = json"""
+      {
+        "data": {
+          "cities" : [
+            {
+              "name" : "Amersfoort",
+              "country" : {
+                "name" : "Netherlands",
+                "currencies" : [
+                  {
+                    "code" : "EUR",
+                    "exchangeRate" : 1.13
+                  }
+                ]
+              }
+            },
+            {
+              "name" : "Americana",
+              "country" : {
+                "name" : "Brazil",
+                "currencies" : [
+                  {
+                    "code" : "BRL",
+                    "exchangeRate" : 0.25
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    """
+
+    val (res0, res1, n0, n1, n2) =
+      (for {
+        cm   <- mapping
+        c    =  cm._1
+        m    =  cm._2
+        n0   <- cm._1.count
+        res0 <- m.compileAndRun(query)
+        n1   <- cm._1.count
+        _    <- c.update("EUR", 1.13)
+        res1 <- m.compileAndRun(query)
+        n2   <- cm._1.count
+      } yield (res0, res1, n0, n1, n2)).unsafeRunSync()
+
+    //println(res0)
+    //println(res1)
+
+    assert(n0 == 0 && n1 == 1 && n2 == 2)
+
+    assertWeaklyEqual(res0, expected0)
+    assertWeaklyEqual(res1, expected1)
+  }
+
+  test("composed query with introspection") {
+    val query = """
+      query {
+        country(code: "GBR") {
+          __typename
+          name
+          currencies {
+            __typename
+            code
+            exchangeRate
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "country" : {
+            "__typename" : "Country",
+            "name" : "United Kingdom",
+            "currencies" : [
+              {
+                "__typename" : "Currency",
+                "code" : "GBP",
+                "exchangeRate" : 1.25
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.flatMap(_._2.compileAndRun(query)).unsafeRunSync()
+    //println(res)
+
+    assertWeaklyEqual(res, expected)
+  }
+}


### PR DESCRIPTION
+ Added `EffectField` with one-shot and batched variants.
+ Added `EffectHandler` type and `Effect` node to the query algebra.
+ Added `EffectElaborator` phase which maps selections of effect-mapped fields into `Effect` nodes.
+ Generalized `StagedJson` to `EffectJson`, handling both components and batched effects.
+ Simplified effect/stage grouping/batching logic.
+ Renamed and simplified `Mapping#combineQueries` to `combineAndRun`. This also replaces `QueryInterpreter#runRootValues` which has been removed.
+ Several root APIs (eg. `defaultRootCursor`) which were previously parameterized with a `Type` and/or an `Env` are now parameterized with an optional parent `Cursor`. This allows for more uniform inheritance of runtime attributes between components.
+ Removed redundant `Defer` node from the query algebra.
+ Reordered the arguments to the component join for consistency.