### PR TITLE
Added support for EffectField dependencies and hiding

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ val Scala3 = "3.2.2"
 ThisBuild / scalaVersion        := Scala2
 ThisBuild / crossScalaVersions  := Seq(Scala2, Scala3)
 
-ThisBuild / tlBaseVersion    := "0.12"
+ThisBuild / tlBaseVersion    := "0.13"
 ThisBuild / organization     := "edu.gemini"
 ThisBuild / organizationName := "Association of Universities for Research in Astronomy, Inc. (AURA)"
 ThisBuild / startYear        := Some(2019)

--- a/modules/sql/src/test/scala/SqlNestedEffectsSpec.scala
+++ b/modules/sql/src/test/scala/SqlNestedEffectsSpec.scala
@@ -22,17 +22,17 @@ trait SqlNestedEffectsSpec extends AnyFunSuite {
         {
           "code" : "EUR",
           "exchangeRate" : 1.12,
-          "countryCode" : "NLD"
+          "countryCode" : "NL"
         },
         {
           "code" : "GBP",
           "exchangeRate" : 1.25,
-          "countryCode" : "GBR"
+          "countryCode" : "GB"
         }
       ]
     """
 
-    val res = mapping.flatMap(_._1.get(List("GBR", "NLD"))).unsafeRunSync()
+    val res = mapping.flatMap(_._1.get(List("GB", "NL"))).unsafeRunSync()
     //println(res)
 
     assertWeaklyEqual(res, expected)


### PR DESCRIPTION
An `EffectField` can now specify a list of sibling fields which are required for running the effect.

An `EffectField` can now also be specified as hidden.

Fixes #396.