### PR TITLE
More informative error when implementing non-interface

### DIFF
--- a/modules/core/src/main/scala/ast.scala
+++ b/modules/core/src/main/scala/ast.scala
@@ -107,7 +107,11 @@ object Ast {
     tpe:           Type.Named
   )
 
-  sealed trait TypeDefinition extends TypeSystemDefinition with Product with Serializable
+  sealed trait TypeDefinition extends TypeSystemDefinition with Product with Serializable {
+    def name: Name
+    def description: Option[String]
+    def directives: List[Directive]
+  }
 
   case class ScalarTypeDefinition(
     name: Name,

--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -1083,7 +1083,11 @@ object SchemaValidator {
       implements.flatMap { ifaceName =>
         interfaces.find(_.name == ifaceName.astName) match {
           case Some(interface) => checkImplementation(name, fields, interface)
-          case None => List(Problem(s"Interface ${ifaceName.astName.value} implemented by ${name.value} is not defined"))
+          case None =>
+            definitions.find(_.name == ifaceName.astName) match {
+              case None => List(Problem(s"Interface ${ifaceName.astName.value} implemented by ${name.value} is not defined"))
+              case _    => List(Problem(s"Non-interface type ${ifaceName.astName.value} declared as implemented by ${name.value}"))
+            }
         }
       }
     }


### PR DESCRIPTION
Now reports that a non-interface type has been implemented rather than reporting that the named interface type does not exist.