### PR TITLE
Removed most dependencies on SLF4J

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -132,7 +132,6 @@ lazy val sql = project
   .settings(
     name := "gsp-graphql-sql",
     libraryDependencies ++= Seq(
-      "org.typelevel"     %% "log4cats-slf4j"         % log4catsVersion,
       "io.circe"          %% "circe-generic"          % circeVersion % "test",
       "ch.qos.logback"    %  "logback-classic"        % logbackVersion % "test",
       "com.dimafeng"      %% "testcontainers-scala-scalatest"  % testContainersVersion % "test",
@@ -151,8 +150,9 @@ lazy val doobie = project
     Test / fork := true,
     Test / parallelExecution := false,
     libraryDependencies ++= Seq(
-      "org.tpolecat" %% "doobie-core"           % doobieVersion,
-      "org.tpolecat" %% "doobie-postgres-circe" % doobieVersion,
+      "org.tpolecat"  %% "doobie-core"           % doobieVersion,
+      "org.tpolecat"  %% "doobie-postgres-circe" % doobieVersion,
+      "org.typelevel" %% "log4cats-core"         % log4catsVersion
     )
   )
 

--- a/demo/src/main/scala/demo/starwars/StarWarsMapping.scala
+++ b/demo/src/main/scala/demo/starwars/StarWarsMapping.scala
@@ -152,7 +152,7 @@ trait StarWarsData[F[_]] extends GenericMapping[F] { self: StarWarsMapping[F] =>
 
   // #model_values
   // The character database ...
-  val characters: List[Character] = List(
+  lazy val characters: List[Character] = List(
     Human(
       id = "1000",
       name = Some("Luke Skywalker"),

--- a/modules/doobie-pg/src/test/scala/DoobieDatabaseSuite.scala
+++ b/modules/doobie-pg/src/test/scala/DoobieDatabaseSuite.scala
@@ -11,19 +11,13 @@ import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
 import doobie.{Get, Meta, Put, Transactor}
 import io.circe.Json
-import org.typelevel.log4cats.Logger
-import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import edu.gemini.grackle.doobie.postgres.{DoobieMapping, DoobieMonitor}
 
 import edu.gemini.grackle.sql.test._
 
 trait DoobieDatabaseSuite extends SqlDatabaseSuite {
-
-  implicit val log: Logger[IO] = Slf4jLogger.getLogger[IO]
-
   // lazy vals because the container is not initialised until the test is run
-
   lazy val xa = {
     import container.{ driverClassName, jdbcUrl, username, password }
 


### PR DESCRIPTION
It turns out we don't need an SLF4J dependency anywhere except the demo project. Even there it's satisfied transiently via http4s and doobie-hikari, but for hygiene's sake it's still listed explicitly.