### PR TITLE
Reworked schema validation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ val Scala3 = "3.3.0"
 ThisBuild / scalaVersion        := Scala2
 ThisBuild / crossScalaVersions  := Seq(Scala2, Scala3)
 
-ThisBuild / tlBaseVersion    := "0.13"
+ThisBuild / tlBaseVersion    := "0.14"
 ThisBuild / organization     := "edu.gemini"
 ThisBuild / organizationName := "Association of Universities for Research in Astronomy, Inc. (AURA)"
 ThisBuild / startYear        := Some(2019)

--- a/modules/core/src/main/scala/result.scala
+++ b/modules/core/src/main/scala/result.scala
@@ -194,6 +194,12 @@ object Result extends ResultInstances {
   def fromEither[A](ea: Either[String, A])(implicit ev: DummyImplicit): Result[A] =
     fromEither(ea.leftMap(Problem(_)))
 
+  def fromProblems(problems: Seq[Problem]): Result[Unit] =
+    NonEmptyChain.fromSeq(problems).map(Result.Failure(_)).getOrElse(Result.unit)
+
+  def fromProblems(problems: Chain[Problem]): Result[Unit] =
+    NonEmptyChain.fromChain(problems).map(Result.Failure(_)).getOrElse(Result.unit)
+
   def catchNonFatal[T](body: => T): Result[T] =
     try {
       success(body)

--- a/modules/core/src/test/scala/sdl/SDLSuite.scala
+++ b/modules/core/src/test/scala/sdl/SDLSuite.scala
@@ -6,6 +6,7 @@ package sdl
 import munit.CatsEffectSuite
 
 import edu.gemini.grackle.{ Ast, GraphQLParser, SchemaParser }
+import edu.gemini.grackle.syntax._
 import Ast._, OperationType._, Type.{ List => _, _ }
 
 final class SDLSuite extends CatsEffectSuite {
@@ -30,9 +31,9 @@ final class SDLSuite extends CatsEffectSuite {
         )
       )
 
-    val res = GraphQLParser.Document.parseAll(schema).toOption
+    val res = GraphQLParser.Document.parseAll(schema)
 
-    assertEquals(res, Some(expected))
+    assertEquals(res, Right(expected))
   }
 
   test("parse scalar type definition") {
@@ -50,9 +51,9 @@ final class SDLSuite extends CatsEffectSuite {
         ScalarTypeDefinition(Name("Time"), Some("A scalar type"), List(Directive(Name("deprecated"), Nil)))
       )
 
-    val res = GraphQLParser.Document.parseAll(schema).toOption
+    val res = GraphQLParser.Document.parseAll(schema)
 
-    assertEquals(res, Some(expected))
+    assertEquals(res, Right(expected))
   }
 
   test("parse object type definition") {
@@ -82,9 +83,9 @@ final class SDLSuite extends CatsEffectSuite {
         )
       )
 
-    val res = GraphQLParser.Document.parseAll(schema).toOption
+    val res = GraphQLParser.Document.parseAll(schema)
 
-    assertEquals(res, Some(expected))
+    assertEquals(res, Right(expected))
   }
 
   test("parse interface type definition") {
@@ -114,9 +115,9 @@ final class SDLSuite extends CatsEffectSuite {
         )
       )
 
-    val res = GraphQLParser.Document.parseAll(schema).toOption
+    val res = GraphQLParser.Document.parseAll(schema)
 
-    assertEquals(res, Some(expected))
+    assertEquals(res, Right(expected))
   }
 
   test("parse union type definition") {
@@ -135,9 +136,9 @@ final class SDLSuite extends CatsEffectSuite {
         )
       )
 
-    val res = GraphQLParser.Document.parseAll(schema).toOption
+    val res = GraphQLParser.Document.parseAll(schema)
 
-    assertEquals(res, Some(expected))
+    assertEquals(res, Right(expected))
   }
 
   test("parse enum type definition") {
@@ -163,9 +164,9 @@ final class SDLSuite extends CatsEffectSuite {
         )
       )
 
-    val res = GraphQLParser.Document.parseAll(schema).toOption
+    val res = GraphQLParser.Document.parseAll(schema)
 
-    assertEquals(res, Some(expected))
+    assertEquals(res, Right(expected))
   }
 
   test("parse input object type definition") {
@@ -188,9 +189,9 @@ final class SDLSuite extends CatsEffectSuite {
         )
       )
 
-    val res = GraphQLParser.Document.parseAll(schema).toOption
+    val res = GraphQLParser.Document.parseAll(schema)
 
-    assertEquals(res, Some(expected))
+    assertEquals(res, Right(expected))
   }
 
   test("parse directive definition") {
@@ -219,9 +220,9 @@ final class SDLSuite extends CatsEffectSuite {
         )
       )
 
-    val res = GraphQLParser.Document.parseAll(schema).toOption
+    val res = GraphQLParser.Document.parseAll(schema)
 
-    assertEquals(res, Some(expected))
+    assertEquals(res, Right(expected))
   }
 
   test("deserialize schema (1)") {
@@ -246,7 +247,7 @@ final class SDLSuite extends CatsEffectSuite {
     val res = SchemaParser.parseText(schema)
     val ser = res.map(_.toString)
 
-    assertEquals(ser.toOption.get, schema)
+    assertEquals(ser, schema.success)
   }
 
   test("deserialize schema (2)") {
@@ -273,6 +274,7 @@ final class SDLSuite extends CatsEffectSuite {
        |type Human implements Character {
        |  id: String!
        |  name: String
+       |  fullname: String @deprecated(reason: "use 'name' instead")
        |  friends: [Character!]
        |  appearsIn: [Episode!]
        |  homePlanet: String
@@ -280,6 +282,7 @@ final class SDLSuite extends CatsEffectSuite {
        |type Droid implements Character {
        |  id: String!
        |  name: String
+       |  fullname: String @deprecated(reason: "use 'name' instead")
        |  friends: [Character!]
        |  appearsIn: [Episode!]
        |  primaryFunction: String
@@ -288,7 +291,7 @@ final class SDLSuite extends CatsEffectSuite {
     val res = SchemaParser.parseText(schema)
     val ser = res.map(_.toString)
 
-    assertEquals(ser.toOption.get, schema)
+    assertEquals(ser, schema.success)
   }
 
   test("deserialize schema (3)") {
@@ -311,6 +314,6 @@ final class SDLSuite extends CatsEffectSuite {
     val res = SchemaParser.parseText(schema)
     val ser = res.map(_.toString)
 
-    assertEquals(ser.toOption.get, schema)
+    assertEquals(ser, schema.success)
   }
 }


### PR DESCRIPTION
+ Schema validation errors are now reported as failures rather than as warnings.
+ Schema validation is now primarily defined in terms of schema types rather than AST type definitions
+ All type references (field arguments and results, and implemented interfaces for both object and interface types, and union members for unions) are now checked.
+ Covariant subtyping between interfaces and implementations is now fully supported.
+ Subtype relation on Type now correctly handles non null and list type wrappers and transitive subtyping between interfaces.
+ Error messages have been made more consistent.

Fixes #68.