### PR TITLE
Directives support, elaborator rework and query algebra simplification

### DIFF
--- a/demo/src/main/scala/demo/world/WorldMapping.scala
+++ b/demo/src/main/scala/demo/world/WorldMapping.scala
@@ -171,70 +171,73 @@ trait WorldMapping[F[_]] extends DoobieMapping[F] {
     )
 
   // #elaborator
-  override val selectElaborator = new SelectElaborator(Map(
+  override val selectElaborator = SelectElaborator {
+    case (QueryType, "country", List(Binding("code", StringValue(code)))) =>
+      Elab.transformChild(child => Unique(Filter(Eql(CountryType / "code", Const(code)), child)))
 
-    QueryType -> {
+    case (QueryType, "city", List(Binding("id", IntValue(id)))) =>
+      Elab.transformChild(child => Unique(Filter(Eql(CityType / "id", Const(id)), child)))
 
-      case Select("country", List(Binding("code", StringValue(code))), child) =>
-        Select("country", Nil, Unique(Filter(Eql(CountryType / "code", Const(code)), child))).success
+    case (
+           QueryType, "countries",
+           List(
+             Binding("limit", IntValue(num)),
+             Binding("offset", IntValue(off)),
+             Binding("minPopulation", IntValue(min)),
+             Binding("byPopulation", BooleanValue(byPop))
+           )
+         ) =>
+      def limit(query: Query): Query =
+        if (num < 1) query
+        else Limit(num, query)
 
-      case Select("city", List(Binding("id", IntValue(id))), child) =>
-        Select("city", Nil, Unique(Filter(Eql(CityType / "id", Const(id)), child))).success
+      def offset(query: Query): Query =
+        if (off < 1) query
+        else Offset(off, query)
 
-      case Select("countries", List(Binding("limit", IntValue(num)), Binding("offset", IntValue(off)), Binding("minPopulation", IntValue(min)), Binding("byPopulation", BooleanValue(byPop))), child) =>
-        def limit(query: Query): Query =
-          if (num < 1) query
-          else Limit(num, query)
+      def order(query: Query): Query = {
+        if (byPop)
+          OrderBy(OrderSelections(List(OrderSelection[Int](CountryType / "population"))), query)
+        else if (num > 0 || off > 0)
+          OrderBy(OrderSelections(List(OrderSelection[String](CountryType / "code"))), query)
+        else query
+      }
 
-        def offset(query: Query): Query =
-          if (off < 1) query
-          else Offset(off, query)
+      def filter(query: Query): Query =
+        if (min == 0) query
+        else Filter(GtEql(CountryType / "population", Const(min)), query)
 
-        def order(query: Query): Query = {
-          if (byPop)
-            OrderBy(OrderSelections(List(OrderSelection[Int](CountryType / "population"))), query)
-          else if (num > 0 || off > 0)
-            OrderBy(OrderSelections(List(OrderSelection[String](CountryType / "code"))), query)
-          else query
-        }
+      Elab.transformChild(child => limit(offset(order(filter(child)))))
 
-        def filter(query: Query): Query =
-          if (min == 0) query
-          else Filter(GtEql(CountryType / "population", Const(min)), query)
+    case (QueryType, "cities", List(Binding("namePattern", StringValue(namePattern)))) =>
+      if (namePattern == "%")
+        Elab.unit
+      else
+        Elab.transformChild(child => Filter(Like(CityType / "name", namePattern, true), child))
 
-        Select("countries", Nil, limit(offset(order(filter(child))))).success
+    case (QueryType, "language", List(Binding("language", StringValue(language)))) =>
+      Elab.transformChild(child => Unique(Filter(Eql(LanguageType / "language", Const(language)), child)))
 
-      case Select("cities", List(Binding("namePattern", StringValue(namePattern))), child) =>
-        if (namePattern == "%")
-          Select("cities", Nil, child).success
-        else
-          Select("cities", Nil, Filter(Like(CityType / "name", namePattern, true), child)).success
+    case (QueryType, "search", List(Binding("minPopulation", IntValue(min)), Binding("indepSince", IntValue(year)))) =>
+      Elab.transformChild(child =>
+        Filter(
+          And(
+            Not(Lt(CountryType / "population", Const(min))),
+            Not(Lt(CountryType / "indepyear", Const(Option(year))))
+          ),
+          child
+        )
+      )
 
-      case Select("language", List(Binding("language", StringValue(language))), child) =>
-        Select("language", Nil, Unique(Filter(Eql(LanguageType / "language", Const(language)), child))).success
+    case (QueryType, "search2", List(Binding("indep", BooleanValue(indep)), Binding("limit", IntValue(num)))) =>
+      Elab.transformChild(child => Limit(num, Filter(IsNull[Int](CountryType / "indepyear", isNull = !indep), child)))
 
-      case Select("search", List(Binding("minPopulation", IntValue(min)), Binding("indepSince", IntValue(year))), child) =>
-        Select("search", Nil,
-          Filter(
-            And(
-              Not(Lt(CountryType / "population", Const(min))),
-              Not(Lt(CountryType / "indepyear", Const(Option(year))))
-            ),
-            child
-          )
-        ).success
+    case (CountryType, "numCities", List(Binding("namePattern", AbsentValue))) =>
+      Elab.transformChild(_ => Count(Select("cities", Select("name"))))
 
-      case Select("search2", List(Binding("indep", BooleanValue(indep)), Binding("limit", IntValue(num))), child) =>
-        Select("search2", Nil, Limit(num, Filter(IsNull[Int](CountryType / "indepyear", isNull = !indep), child))).success
-    },
-    CountryType -> {
-      case Select("numCities", List(Binding("namePattern", AbsentValue)), Empty) =>
-        Count("numCities", Select("cities", Nil, Select("name", Nil, Empty))).success
-
-      case Select("numCities", List(Binding("namePattern", StringValue(namePattern))), Empty) =>
-        Count("numCities", Select("cities", Nil, Filter(Like(CityType / "name", namePattern, true), Select("name", Nil, Empty)))).success
-    }
-  ))
+    case (CountryType, "numCities", List(Binding("namePattern", StringValue(namePattern)))) =>
+      Elab.transformChild(_ => Count(Select("cities", Filter(Like(CityType / "name", namePattern, true), Select("name")))))
+  }
   // #elaborator
 }
 

--- a/docs/src/main/paradox/tutorial/db-backed-model.md
+++ b/docs/src/main/paradox/tutorial/db-backed-model.md
@@ -1,8 +1,7 @@
 # DB Backed Model
 
-In this tutorial we are going to implement GraphQL API of countries and cities of the world using Grackle backed by
-a database model, i.e. provide mapping for Grackle to read data from PostgreSQL and return it as result of
-GraphQL queries.
+In this tutorial we are going to implement a GraphQL API for countries and cities of the world using Grackle backed by
+a database, ie. provide a mapping for Grackle to read data from PostgreSQL and return it as result of GraphQL queries.
 
 ## Running the demo
 
@@ -75,43 +74,45 @@ Grackle represents schemas as a Scala value of type `Schema` which can be constr
 
 ## Database mapping
 
-The API is backed by mapping to database tables. Grackle contains ready to use integration
-with [doobie](https://tpolecat.github.io/doobie/) for accessing SQL database via JDBC
-and with [Skunk](https://tpolecat.github.io/skunk/) for accessing PostgreSQL via its native API. In this example
-we will use doobie.
+The API is backed by mapping to database tables. Grackle contains ready to use integration with
+[doobie](https://tpolecat.github.io/doobie/) for accessing SQL database via JDBC and with
+[Skunk](https://tpolecat.github.io/skunk/) for accessing PostgreSQL via its native API. In this example we will use
+doobie.
 
 Let's start with defining what tables and columns are available in the database model,
 
 @@snip [WorldMapping.scala](/demo/src/main/scala/demo/world/WorldMapping.scala) { #db_tables }
 
-For each column we need to provide its name and doobie codec. We should also mark if value is nullable.
+For each column we need to provide its name and doobie codec of type `Meta`. We should also mark if the value is
+nullable.
 
-We define each query as SQL query, as below,
+We define the top-level GraphQL fields as `SqlObject` mappings,
 
 @@snip [WorldMapping.scala](/demo/src/main/scala/demo/world/WorldMapping.scala) { #root }
 
-Now, we need to map each type from GraphQL schema using available columns from database,
+Now, we need to map each type from the GraphQL schema using columns from the database,
 
 @@snip [WorldMapping.scala](/demo/src/main/scala/demo/world/WorldMapping.scala) { #type_mappings }
 
-Each GraphQL must contain key. It can contain fields from one table, but it can also contain nested types which
-are translated to SQL joins using provided conditions. `Join(country.code, city.countrycode)` means joining country
-and city tables  where `code` in the country table is the same as `countrycode` in the city table.
+Each GraphQL type mapping must contain a key. It can contain fields from one table, but it can also contain nested
+types which are translated to SQL joins using the provided conditions. `Join(country.code, city.countrycode)` means
+joining country and city tables  where `code` in the country table is the same as `countrycode` in the city table.
 
 ## The query compiler and elaborator
 
-Similar as in [in-memory model]((in-memory-model.html#the-query-compiler-and-elaborator)), we need to define elaborator
-to transform query algebra terms into the form that can be then used as source of SQL queries,
+Similarly to the [in-memory model]((in-memory-model.html#the-query-compiler-and-elaborator)), we need to define an
+elaborator to transform query algebra terms into a form that can be then used to translate query algebra terms to SQL
+queries,
 
 @@snip [WorldMapping.scala](/demo/src/main/scala/demo/world/WorldMapping.scala) { #elaborator }
 
 ## Putting it all together
 
-To expose GraphQL API with http4s we will use `GraphQLService` and `DemoServer`
-from [in-memory example](in-memory-model.html#the-service).
+To expose GraphQL API with http4s we will use the `GraphQLService` and `DemoServer`
+from the [in-memory example](in-memory-model.html#the-service).
 
-We will use [testcontainers](https://github.com/testcontainers/testcontainers-scala) to run PostgreSQL database
-in the background. The final main method, which starts PostgreSQL database in docker container, creates database
+We use [testcontainers](https://github.com/testcontainers/testcontainers-scala) to run a PostgreSQL database
+in the background. The final main method, which starts a dockerized PostgreSQL database, creates the database
 schema, writes initial data and exposes GraphQL API for in-memory and db-backend models is below,
 
 @@snip [main.scala](/demo/src/main/scala/demo/Main.scala) { #main }

--- a/docs/src/main/paradox/tutorial/in-memory-model.md
+++ b/docs/src/main/paradox/tutorial/in-memory-model.md
@@ -205,28 +205,24 @@ simplifies or expands the term to bring it into a form which can be executed dir
 Grackle's query algebra consists of the following elements,
 
 ```scala
-sealed trait Query {
-  case class Select(name: String, args: List[Binding], child: Query = Empty) extends Query
-  case class Group(queries: List[Query]) extends Query
-  case class Unique(child: Query) extends Query
-  case class Filter(pred: Predicate, child: Query) extends Query
-  case class Component[F[_]](mapping: Mapping[F], join: (Query, Cursor) => Result[Query], child: Query) extends Query
-  case class Effect[F[_]](handler: EffectHandler[F], child: Query) extends Query
-  case class Introspect(schema: Schema, child: Query) extends Query
-  case class Environment(env: Env, child: Query) extends Query
-  case class Wrap(name: String, child: Query) extends Query
-  case class Rename(name: String, child: Query) extends Query
-  case class UntypedNarrow(tpnme: String, child: Query) extends Query
-  case class Narrow(subtpe: TypeRef, child: Query) extends Query
-  case class Skip(sense: Boolean, cond: Value, child: Query) extends Query
-  case class Limit(num: Int, child: Query) extends Query
-  case class Offset(num: Int, child: Query) extends Query
-  case class OrderBy(selections: OrderSelections, child: Query) extends Query
-  case class Count(name: String, child: Query) extends Query
-  case class TransformCursor(f: Cursor => Result[Cursor], child: Query) extends Query
-  case object Skipped extends Query
-  case object Empty extends Query
-}
+case class UntypedSelect(name: String, alias: Option[String], args: List[Binding], dirs: List[Directive], child: Query)
+case class Select(name: String, alias: Option[String], child: Query)
+case class Group(queries: List[Query])
+case class Unique(child: Query)
+case class Filter(pred: Predicate, child: Query)
+case class Component[F[_]](mapping: Mapping[F], join: (Query, Cursor) => Result[Query], child: Query)
+case class Effect[F[_]](handler: EffectHandler[F], child: Query)
+case class Introspect(schema: Schema, child: Query)
+case class Environment(env: Env, child: Query)
+case class UntypedFragmentSpread(name: String, directives: List[Directive])
+case class UntypedInlineFragment(tpnme: Option[String], directives: List[Directive], child: Query)
+case class Narrow(subtpe: TypeRef, child: Query)
+case class Limit(num: Int, child: Query)
+case class Offset(num: Int, child: Query)
+case class OrderBy(selections: OrderSelections, child: Query)
+case class Count(child: Query)
+case class TransformCursor(f: Cursor => Result[Cursor], child: Query)
+case object Empty
 ```
 
 A simple query like this,
@@ -242,8 +238,8 @@ query {
 is first translated into a term in the query algebra of the form,
 
 ```scala
-Select("character", List(IntBinding("id", 1000)),
-  Select("name", Nil)
+UntypedSelect("character", None, List(IntBinding("id", 1000)), Nil,
+  UntypedSelect("name", None, Nil, Nil, Empty)
 )
 ```
 
@@ -260,23 +256,23 @@ the model) is specific to this model, so we have to provide that semantic via so
 Extracting out the case for the `character` selector,
 
 ```scala
-case Select(f@("character"), List(Binding("id", IDValue(id))), child) =>
-  Select(f, Nil, Unique(Filter(Eql(CharacterType / "id", Const(id)), child))).success
-
+case (QueryType, "character", List(Binding("id", IDValue(id)))) =>
+  Elab.transformChild(child => Unique(Filter(Eql(CharacterType / "id", Const(id)), child)))
 ```
 
-we can see that this transforms the previous term as follows,
+the previous term is transformed as follows as follows,
 
 ```scala
-Select("character", Nil,
-  Unique(Eql(CharacterType / "id"), Const("1000")), Select("name", Nil))
+Select("character", None,
+  Unique(Eql(CharacterType / "id"), Const("1000")), Select("name", None, Empty))
 )
 ```
 
-Here the argument to the `character` selector has been translated into a predicate which refines the root data of the
-model to the single element which satisfies it via `Unique`. The remainder of the query (`Select("name", Nil)`) is
-then within the scope of that constraint. We have eliminated something with model-specific semantics (`character(id:
-1000)`) in favour of something universal which can be interpreted directly against the model.
+Here the original `UntypedSelect` terms have been converted to typed `Select` terms with the argument to the
+`character` selector translated into a predicate which refines the root data of the model to the single element which
+satisfies it via `Unique`. The remainder of the query (`Select("name", None, Nil)`) is then within the scope of that
+constraint. We have eliminated something with model-specific semantics (`character(id: 1000)`) in favour of something
+universal which can be interpreted directly against the model.
 
 ## The query interpreter and cursor
 
@@ -293,7 +289,7 @@ For the Star Wars model the root definitions are of the following form,
 
 @@snip [StarWarsData.scala](/demo/src/main/scala/demo/starwars/StarWarsMapping.scala) { #root }
 
-The first argument of the `GenericRoot` constructor correspond to the top-level selection of the query (see the
+The first argument of the `GenericField` constructor corresponds to the top-level selection of the query (see the
 schema above) and the second argument is the initial model value for which a `Cursor` will be derived.  When the query
 is executed, navigation will start with that `Cursor` and the corresponding GraphQL type.
 
@@ -333,6 +329,15 @@ object Main extends IOApp {
     val starWarsGraphQLRoutes = GraphQLService.routes[IO](
       "starwars",
       GraphQLService.fromGenericIdMapping(StarWarsMapping)
+    )
+    DemoServer.stream[IO](starWarsGraphQLRoutes).compile.drain
+  }
+}
+object Main extends IOApp {
+  def run(args: List[String]): IO[ExitCode] = {
+    val starWarsGraphQLRoutes = GraphQLService.routes[IO](
+      "starwars",
+      GraphQLService.fromMapping(new StarWarsMapping[IO] with StarWarsData[IO])
     )
     DemoServer.stream[IO](starWarsGraphQLRoutes).compile.drain
   }

--- a/modules/circe/src/test/scala/CirceData.scala
+++ b/modules/circe/src/test/scala/CirceData.scala
@@ -113,10 +113,8 @@ object TestCirceMapping extends CirceMapping[IO] {
     } yield i+1).value
   }
 
-  override val selectElaborator = new SelectElaborator(Map(
-    RootType -> {
-      case Select("numChildren", Nil, Empty) =>
-        Count("numChildren", Select("children", Nil, Empty)).success
-    }
-  ))
+  override val selectElaborator = SelectElaborator {
+    case (RootType, "numChildren", Nil) =>
+      Elab.transformChild(_ => Count(Select("children")))
+  }
 }

--- a/modules/circe/src/test/scala/CirceEffectData.scala
+++ b/modules/circe/src/test/scala/CirceEffectData.scala
@@ -44,7 +44,7 @@ class TestCirceEffectMapping[F[_]: Sync](ref: SignallingRef[F, Int]) extends Cir
         List(
 
           // Compute a CirceCursor
-          RootEffect.computeCursor("foo")((_, p, e) =>
+          RootEffect.computeCursor("foo")((p, e) =>
             ref.update(_+1).as(
               Result(circeCursor(p, e,
                 Json.obj(
@@ -56,7 +56,7 @@ class TestCirceEffectMapping[F[_]: Sync](ref: SignallingRef[F, Int]) extends Cir
           ),
 
           // Compute a Json, let the implementation handle the cursor
-          RootEffect.computeJson("bar")((_, _, _) =>
+          RootEffect.computeJson("bar")((_, _) =>
             ref.update(_+1).as(
               Result(Json.obj(
                 "n" -> Json.fromInt(42),
@@ -66,14 +66,14 @@ class TestCirceEffectMapping[F[_]: Sync](ref: SignallingRef[F, Int]) extends Cir
           ),
 
           // Compute an encodable value, let the implementation handle json and the cursor
-          RootEffect.computeEncodable("baz")((_, _, _) =>
+          RootEffect.computeEncodable("baz")((_, _) =>
             ref.update(_+1).as(
               Result(Struct(44, "hee"))
             )
           ),
 
           // Compute a CirceCursor focussed on the root
-          RootEffect.computeCursor("qux")((_, p, e) =>
+          RootEffect.computeCursor("qux")((p, e) =>
             ref.update(_+1).as(
               Result(circeCursor(Path(p.rootTpe), e,
                 Json.obj(

--- a/modules/circe/src/test/scala/CirceSuite.scala
+++ b/modules/circe/src/test/scala/CirceSuite.scala
@@ -294,7 +294,7 @@ final class CirceSuite extends CatsEffectSuite {
       {
         "errors" : [
           {
-            "message" : "Unknown field 'hidden' in select"
+            "message" : "No field 'hidden' for type Root"
           }
         ]
       }

--- a/modules/core/src/main/scala/ast.scala
+++ b/modules/core/src/main/scala/ast.scala
@@ -12,11 +12,11 @@ object Ast {
   sealed trait ExecutableDefinition extends Definition
   sealed trait TypeSystemDefinition extends Definition
 
-  sealed trait OperationType
+  sealed abstract class OperationType(val name: String)
   object OperationType {
-    case object Query        extends OperationType
-    case object Mutation     extends OperationType
-    case object Subscription extends OperationType
+    case object Query        extends OperationType("query")
+    case object Mutation     extends OperationType("mutation")
+    case object Subscription extends OperationType("subscription")
   }
 
   sealed trait OperationDefinition extends ExecutableDefinition
@@ -75,7 +75,8 @@ object Ast {
     name:         Name,
     tpe:          Type,
     defaultValue: Option[Value],
-  )
+    directives:   List[Directive]
+   )
 
   sealed trait Value
   object Value {
@@ -104,7 +105,8 @@ object Ast {
 
   case class RootOperationTypeDefinition(
     operationType: OperationType,
-    tpe:           Type.Named
+    tpe:           Type.Named,
+    directives: List[Directive]
   )
 
   sealed trait TypeDefinition extends TypeSystemDefinition with Product with Serializable {

--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -902,7 +902,7 @@ object QueryCompiler {
           } yield
             emapping.get((ref, fieldName)) match {
               case Some(handler) =>
-                Effect(handler, s.copy(child = ec))
+                Select(fieldName, resultName, Effect(handler, s.copy(child = ec)))
               case None =>
                 s.copy(child = ec)
             }

--- a/modules/core/src/main/scala/introspection.scala
+++ b/modules/core/src/main/scala/introspection.scala
@@ -122,10 +122,38 @@ object Introspection {
   val __EnumValueType =  schema.ref("__EnumValue")
   val __DirectiveType =  schema.ref("__Directive")
   val __TypeKindType =  schema.ref("__TypeKind")
+  val __DirectiveLocationType =  schema.ref("__DirectiveLocation")
 
   object TypeKind extends Enumeration {
     val SCALAR, OBJECT, INTERFACE, UNION, ENUM, INPUT_OBJECT, LIST, NON_NULL = Value
     implicit val typeKindEncoder: Encoder[Value] = Encoder[String].contramap(_.toString)
+  }
+
+  implicit val directiveLocationEncoder: Encoder[Ast.DirectiveLocation] = {
+    import Ast.DirectiveLocation._
+
+    Encoder[String].contramap {
+      case QUERY                  => "QUERY"
+      case MUTATION               => "MUTATION"
+      case SUBSCRIPTION           => "SUBSCRIPTION"
+      case FIELD                  => "FIELD"
+      case FRAGMENT_DEFINITION    => "FRAGMENT_DEFINITION"
+      case FRAGMENT_SPREAD        => "FRAGMENT_SPREAD"
+      case INLINE_FRAGMENT        => "INLINE_FRAGMENT"
+      case VARIABLE_DEFINITION    => "VARIABLE_DEFINITION"
+
+      case SCHEMA                 => "SCHEMA"
+      case SCALAR                 => "SCALAR"
+      case OBJECT                 => "OBJECT"
+      case FIELD_DEFINITION       => "FIELD_DEFINITION"
+      case ARGUMENT_DEFINITION    => "ARGUMENT_DEFINITION"
+      case INTERFACE              => "INTERFACE"
+      case UNION                  => "UNION"
+      case ENUM                   => "ENUM"
+      case ENUM_VALUE             => "ENUM_VALUE"
+      case INPUT_OBJECT           => "INPUT_OBJECT"
+      case INPUT_FIELD_DEFINITION => "INPUT_FIELD_DEFINITION"
+    }
   }
 
   case class NonNullType(tpe: Type)
@@ -243,7 +271,7 @@ object Introspection {
               ValueField("defaultValue", _.defaultValue.map(SchemaRenderer.renderValue))
             )
         ),
-        ValueObjectMapping[EnumValue](
+        ValueObjectMapping[EnumValueDefinition](
           tpe = __EnumValueType,
           fieldMappings =
             List(
@@ -253,7 +281,7 @@ object Introspection {
               ValueField("deprecationReason", _.deprecationReason)
             )
         ),
-        ValueObjectMapping[Directive](
+        ValueObjectMapping[DirectiveDef](
           tpe = __DirectiveType,
           fieldMappings =
             List(
@@ -264,7 +292,8 @@ object Introspection {
               ValueField("isRepeatable", _.isRepeatable)
             )
         ),
-        LeafMapping[TypeKind.Value](__TypeKindType)
+        LeafMapping[TypeKind.Value](__TypeKindType),
+        LeafMapping[Ast.DirectiveLocation](__DirectiveLocationType)
     )
   }
 }

--- a/modules/core/src/main/scala/mappingvalidator.scala
+++ b/modules/core/src/main/scala/mappingvalidator.scala
@@ -173,7 +173,7 @@ trait MappingValidator {
 
   protected def validateLeafMapping(lm: LeafMapping[_]): Chain[Failure] =
     lm.tpe.dealias match {
-      case ScalarType(_, _)|(_: EnumType)|(_: ListType) =>
+      case (_: ScalarType)|(_: EnumType)|(_: ListType) =>
         Chain.empty // these are valid on construction. Nothing to do.
       case _ => Chain(InapplicableGraphQLType(lm, "Leaf Type"))
     }

--- a/modules/core/src/main/scala/minimizer.scala
+++ b/modules/core/src/main/scala/minimizer.scala
@@ -1,0 +1,128 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package edu.gemini.grackle
+
+import cats.implicits._
+
+object QueryMinimizer {
+  import Ast._
+
+  def minimizeText(text: String): Either[String, String] = {
+    for {
+      doc <- GraphQLParser.Document.parseAll(text).leftMap(_.expected.toList.mkString(","))
+    } yield minimizeDocument(doc)
+  }
+
+  def minimizeDocument(doc: Document): String = {
+    import OperationDefinition._
+    import OperationType._
+    import Selection._
+    import Value._
+
+    def renderDefinition(defn: Definition): String =
+      defn match {
+        case e: ExecutableDefinition => renderExecutableDefinition(e)
+        case _ => ""
+      }
+
+    def renderExecutableDefinition(ex: ExecutableDefinition): String =
+      ex match {
+        case op: OperationDefinition => renderOperationDefinition(op)
+        case frag: FragmentDefinition => renderFragmentDefinition(frag)
+      }
+
+    def renderOperationDefinition(op: OperationDefinition): String =
+      op match {
+        case qs: QueryShorthand => renderSelectionSet(qs.selectionSet)
+        case op: Operation => renderOperation(op)
+      }
+
+    def renderOperation(op: Operation): String =
+      renderOperationType(op.operationType) +
+      op.name.map(nme => s" ${nme.value}").getOrElse("") +
+      renderVariableDefns(op.variables)+
+      renderDirectives(op.directives)+
+      renderSelectionSet(op.selectionSet)
+
+    def renderOperationType(op: OperationType): String =
+      op match {
+        case Query => "query"
+        case Mutation => "mutation"
+        case Subscription => "subscription"
+      }
+
+    def renderDirectives(dirs: List[Directive]): String =
+      dirs.map { case Directive(name, args) => s"@${name.value}${renderArguments(args)}" }.mkString("")
+
+    def renderVariableDefns(vars: List[VariableDefinition]): String =
+      vars match {
+        case Nil => ""
+        case _ =>
+          vars.map {
+            case VariableDefinition(name, tpe, default, dirs) =>
+              s"$$${name.value}:${tpe.name}${default.map(v => s"=${renderValue(v)}").getOrElse("")}${renderDirectives(dirs)}"
+          }.mkString("(", ",", ")")
+      }
+
+    def renderSelectionSet(sels: List[Selection]): String =
+      sels match {
+        case Nil => ""
+        case _ => sels.map(renderSelection).mkString("{", ",", "}")
+      }
+
+    def renderSelection(sel: Selection): String =
+      sel match {
+        case f: Field => renderField(f)
+        case s: FragmentSpread => renderFragmentSpread(s)
+        case i: InlineFragment => renderInlineFragment(i)
+      }
+
+    def renderField(f: Field) = {
+      f.alias.map(a => s"${a.value}:").getOrElse("")+
+      f.name.value+
+      renderArguments(f.arguments)+
+      renderDirectives(f.directives)+
+      renderSelectionSet(f.selectionSet)
+    }
+
+    def renderArguments(args: List[(Name, Value)]): String =
+      args match {
+        case Nil => ""
+        case _ => args.map { case (n, v) => s"${n.value}:${renderValue(v)}" }.mkString("(", ",", ")")
+      }
+
+    def renderInputObject(args: List[(Name, Value)]): String =
+      args match {
+        case Nil => ""
+        case _ => args.map { case (n, v) => s"${n.value}:${renderValue(v)}" }.mkString("{", ",", "}")
+      }
+
+    def renderTypeCondition(tpe: Type): String =
+      s"on ${tpe.name}"
+
+    def renderFragmentDefinition(frag: FragmentDefinition): String =
+      s"fragment ${frag.name.value} ${renderTypeCondition(frag.typeCondition)}${renderDirectives(frag.directives)}${renderSelectionSet(frag.selectionSet)}"
+
+    def renderFragmentSpread(spread: FragmentSpread): String =
+      s"...${spread.name.value}${renderDirectives(spread.directives)}"
+
+    def renderInlineFragment(frag: InlineFragment): String =
+      s"...${frag.typeCondition.map(renderTypeCondition).getOrElse("")}${renderDirectives(frag.directives)}${renderSelectionSet(frag.selectionSet)}"
+
+    def renderValue(v: Value): String =
+      v match {
+        case Variable(name) => s"$$${name.value}"
+        case IntValue(value) => value.toString
+        case FloatValue(value) => value.toString
+        case StringValue(value) => s""""$value""""
+        case BooleanValue(value) => value.toString
+        case NullValue => "null"
+        case EnumValue(name) => name.value
+        case ListValue(values) => values.map(renderValue).mkString("[", ",", "]")
+        case ObjectValue(fields) => renderInputObject(fields)
+      }
+
+    doc.map(renderDefinition).mkString(",")
+  }
+}

--- a/modules/core/src/main/scala/operation.scala
+++ b/modules/core/src/main/scala/operation.scala
@@ -7,20 +7,40 @@ import syntax._
 import Query._
 
 sealed trait UntypedOperation {
+  val name: Option[String]
   val query: Query
   val variables: UntypedVarDefs
+  val directives: List[Directive]
   def rootTpe(schema: Schema): Result[NamedType] =
     this match {
-      case UntypedOperation.UntypedQuery(_, _)        => schema.queryType.success
-      case UntypedOperation.UntypedMutation(_, _)     => schema.mutationType.toResult("No mutation type defined in this schema.")
-      case UntypedOperation.UntypedSubscription(_, _) => schema.subscriptionType.toResult("No subscription type defined in this schema.")
+      case _: UntypedOperation.UntypedQuery        => schema.queryType.success
+      case _: UntypedOperation.UntypedMutation     => schema.mutationType.toResult("No mutation type defined in this schema.")
+      case _: UntypedOperation.UntypedSubscription => schema.subscriptionType.toResult("No subscription type defined in this schema.")
     }
 }
 object UntypedOperation {
-  case class UntypedQuery(query: Query,  variables: UntypedVarDefs) extends UntypedOperation
-  case class UntypedMutation(query: Query,  variables: UntypedVarDefs) extends UntypedOperation
-  case class UntypedSubscription(query: Query,  variables: UntypedVarDefs) extends UntypedOperation
+  case class UntypedQuery(
+    name: Option[String],
+    query: Query,
+    variables: UntypedVarDefs,
+    directives: List[Directive]
+  ) extends UntypedOperation
+  case class UntypedMutation(
+    name: Option[String],
+    query: Query,
+    variables: UntypedVarDefs,
+    directives: List[Directive]
+  ) extends UntypedOperation
+  case class UntypedSubscription(
+    name: Option[String],
+    query: Query,
+    variables: UntypedVarDefs,
+    directives: List[Directive]
+  ) extends UntypedOperation
 }
 
-case class Operation(query: Query, rootTpe: NamedType)
-
+case class Operation(
+  query: Query,
+  rootTpe: NamedType,
+  directives: List[Directive]
+)

--- a/modules/core/src/main/scala/problem.scala
+++ b/modules/core/src/main/scala/problem.scala
@@ -14,7 +14,6 @@ final case class Problem(
   path: List[String] = Nil,
   extension: Option[JsonObject] = None,
 ) {
-
   override def toString = {
 
     lazy val pathText: String =

--- a/modules/core/src/main/scala/query.scala
+++ b/modules/core/src/main/scala/query.scala
@@ -93,7 +93,7 @@ object Query {
   }
 
   trait EffectHandler[F[_]] {
-    def runEffects(queries: List[(Query, Cursor)]): F[Result[List[(Query, Cursor)]]]
+    def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]]
   }
 
   /** Evaluates an introspection query relative to `schema` */
@@ -260,6 +260,11 @@ object Query {
       }
     loop(q)
   }
+
+  def childContext(c: Context, query: Query): Result[Context] =
+    rootName(query).toResultOrError(s"Query has the wrong shape").flatMap {
+      case (fieldName, resultName) => c.forField(fieldName, resultName)
+    }
 
   /**
     * Renames the root of `target` to match `source` if possible.

--- a/modules/core/src/main/scala/query.scala
+++ b/modules/core/src/main/scala/query.scala
@@ -9,7 +9,6 @@ import cats.implicits._
 import cats.kernel.Order
 
 import syntax._
-import Cursor.Env
 import Query._
 
 /** GraphQL query Algebra */
@@ -27,14 +26,37 @@ sealed trait Query {
 }
 
 object Query {
-  /** Select field `name` given arguments `args` and continue with `child` */
-  case class Select(name: String, args: List[Binding], child: Query = Empty) extends Query {
-    def eliminateArgs(elim: Query => Query): Query = copy(args = Nil, child = elim(child))
+  /** Select field `name` possibly aliased, and continue with `child` */
+  case class Select(name: String, alias: Option[String], child: Query) extends Query {
+    def resultName: String = alias.getOrElse(name)
 
     def render = {
+      val rname = s"${alias.map(a => s"$a:").getOrElse("")}$name"
+      val rchild = if(child == Empty) "" else s" { ${child.render} }"
+      s"$rname$rchild"
+    }
+  }
+
+  object Select {
+    def apply(name: String): Select =
+      new Select(name, None, Empty)
+
+    def apply(name: String, alias: Option[String]): Select =
+      new Select(name, alias, Empty)
+
+    def apply(name: String, child: Query): Select =
+      new Select(name, None, child)
+  }
+
+  /** Precursor of a `Select` node, containing uncompiled field arguments and directives. */
+  case class UntypedSelect(name: String, alias: Option[String], args: List[Binding], directives: List[Directive], child: Query) extends Query {
+    def resultName: String = alias.getOrElse(name)
+
+    def render = {
+      val rname = s"${alias.map(a => s"$a:").getOrElse("")}$name"
       val rargs = if(args.isEmpty) "" else s"(${args.map(_.render).mkString(", ")})"
       val rchild = if(child == Empty) "" else s" { ${child.render} }"
-      s"$name$rargs$rchild"
+      s"$rname$rargs$rchild"
     }
   }
 
@@ -84,31 +106,22 @@ object Query {
     def render = s"<environment: $env ${child.render}>"
   }
 
-  /**
-   * Wraps the result of `child` as a field named `name` of an enclosing object.
-   */
-  case class Wrap(name: String, child: Query) extends Query {
-    def render = {
-      val rchild = if(child == Empty) "" else s" { ${child.render} }"
-      s"[$name]$rchild"
-    }
-  }
-
-  /**
-   * Rename the topmost field of `sel` to `name`.
-   */
-  case class Rename(name: String, child: Query) extends Query {
-    def render = s"<rename: $name ${child.render}>"
-  }
-
-  /**
-   * Untyped precursor of `Narrow`.
+  /** Representation of a fragment spread prior to comilation.
    *
-   * Trees of this type will be replaced by a corresponding `Narrow` by
-   * `SelectElaborator`.
+   * During compilation this node will be replaced by its definition, guarded by a `Narrow`
+   * corresponding to the type condition of the fragment.
    */
-  case class UntypedNarrow(tpnme: String, child: Query) extends Query {
-    def render = s"<narrow: $tpnme ${child.render}>"
+  case class UntypedFragmentSpread(name: String, directives: List[Directive]) extends Query {
+    def render = s"<fragment: $name>"
+  }
+
+  /** Representation of an inline fragment prior to comilation.
+   *
+   * During compilation this node will be replaced by its child, guarded by a `Narrow`
+   * corresponding to the type condition of the fragment, if any.
+   */
+  case class UntypedInlineFragment(tpnme: Option[String], directives: List[Directive], child: Query) extends Query {
+    def render = s"<fragment: ${tpnme.map(tc => s"on $tc ").getOrElse("")} ${child.render}>"
   }
 
   /**
@@ -116,11 +129,6 @@ object Query {
    */
   case class Narrow(subtpe: TypeRef, child: Query) extends Query {
     def render = s"<narrow: $subtpe ${child.render}>"
-  }
-
-  /** Skips/includes the continuation `child` depending on the value of `cond` */
-  case class Skip(sense: Boolean, cond: Value, child: Query) extends Query {
-    def render = s"<skip: $sense $cond ${child.render}>"
   }
 
   /** Limits the results of list-producing continuation `child` to `num` elements */
@@ -181,9 +189,9 @@ object Query {
     def subst(term: Term[T]): OrderSelection[T] = copy(term = term)
   }
 
-  /** Computes the number of top-level elements of `child` as field `name` */
-  case class Count(name: String, child: Query) extends Query {
-    def render = s"$name:count { ${child.render} }"
+  /** Computes the number of top-level elements of `child`  */
+  case class Count(child: Query) extends Query {
+    def render = s"count { ${child.render} }"
   }
 
   /**
@@ -192,11 +200,6 @@ object Query {
    */
   case class TransformCursor(f: Cursor => Result[Cursor], child: Query) extends Query {
     def render = s"<transform-cursor ${child.render}>"
-  }
-
-  /** A placeholder for a skipped node */
-  case object Skipped extends Query {
-    def render = "<skipped>"
   }
 
   /** The terminal query */
@@ -212,44 +215,17 @@ object Query {
   type VarDefs = List[InputValue]
   type Vars = Map[String, (Type, Value)]
 
-  case class UntypedVarDef(name: String, tpe: Ast.Type, default: Option[Value])
+  /** Precursor of a variable definition before compilation */
+  case class UntypedVarDef(name: String, tpe: Ast.Type, default: Option[Value], directives: List[Directive])
 
-  /**
-   * Extractor for nested Rename/Select patterns in the query algebra
-   *
-   * PossiblyRenamedSelect is an extractor/constructor for a Select node
-   * possibly wrapped in a Rename node so that they can be handled together
-   * conveniently.
-   */
-  object PossiblyRenamedSelect {
-    def apply(sel: Select, resultName: String): Query = sel match {
-      case Select(`resultName`, _, _) => sel
-      case _ => Rename(resultName, sel)
-    }
-
-    def apply(sel: Select, resultName: Option[String]): Query = resultName match {
-      case Some(resultName) => Rename(resultName, sel)
-      case None => sel
-    }
-
-    def unapply(q: Query): Option[(Select, String)] =
-      q match {
-        case Rename(name, sel: Select) => Some((sel, name))
-        case sel: Select => Some((sel, sel.name))
-        case _ => None
-      }
-  }
+  /** Precursor of a fragment definition before compilation */
+  case class UntypedFragment(name: String, tpnme: String, directives: List[Directive], child: Query)
 
   def renameRoot(q: Query, rootName: String): Option[Query] = q match {
-    case Rename(_, sel@Select(`rootName`, _, _)) => Some(sel)
-    case r@Rename(`rootName`, _)                 => Some(r)
-    case Rename(_, sel: Select)                  => Some(Rename(rootName, sel))
-    case sel@Select(`rootName`, _, _)            => Some(sel)
-    case sel: Select                             => Some(Rename(rootName, sel))
-    case w@Wrap(`rootName`, _)                   => Some(w)
-    case w: Wrap                                 => Some(w.copy(name = rootName))
-    case e@Environment(_, child)                 => renameRoot(child, rootName).map(rc => e.copy(child = rc))
-    case t@TransformCursor(_, child)             => renameRoot(child, rootName).map(rc => t.copy(child = rc))
+    case sel: Select if sel.resultName == rootName => Some(sel)
+    case sel: Select                               => Some(sel.copy(alias = Some(rootName)))
+    case e@Environment(_, child)                   => renameRoot(child, rootName).map(rc => e.copy(child = rc))
+    case t@TransformCursor(_, child)               => renameRoot(child, rootName).map(rc => t.copy(child = rc))
     case _ => None
   }
 
@@ -258,18 +234,41 @@ object Query {
     * if it is unique, `None` otherwise.
     */
   def rootName(q: Query): Option[(String, Option[String])] = {
-    def loop(q: Query, alias: Option[String]): Option[(String, Option[String])] =
+    def loop(q: Query): Option[(String, Option[String])] =
       q match {
-        case Select(name, _, _)        => Some((name, alias))
-        case Wrap(name, _)             => Some((name, alias))
-        case Count(name, _)            => Some((name, alias))
-        case Rename(name, child)       => loop(child, alias.orElse(Some(name)))
-        case Environment(_, child)     => loop(child, alias)
-        case TransformCursor(_, child) => loop(child, alias)
-        case _                         => None
+        case UntypedSelect(name, alias, _, _, _) => Some((name, alias))
+        case Select(name, alias, _)              => Some((name, alias))
+        case Environment(_, child)               => loop(child)
+        case TransformCursor(_, child)           => loop(child)
+        case _                                   => None
       }
-    loop(q, None)
+    loop(q)
   }
+
+  /**
+    * Computes the possibly aliased result name of the supplied query
+    * if it is unique, `None` otherwise.
+    */
+  def resultName(q: Query): Option[String] = {
+    def loop(q: Query): Option[String] =
+      q match {
+        case UntypedSelect(name, alias, _, _, _) => Some(alias.getOrElse(name))
+        case Select(name, alias, _)              => Some(alias.getOrElse(name))
+        case Environment(_, child)               => loop(child)
+        case TransformCursor(_, child)           => loop(child)
+        case _                                   => None
+      }
+    loop(q)
+  }
+
+  /**
+    * Renames the root of `target` to match `source` if possible.
+    */
+  def alignResultName(source: Query, target: Query): Option[Query] =
+    for {
+      nme <- resultName(source)
+      res <- renameRoot(target, nme)
+    } yield res
 
   /**
    * Yields a list of the top level queries of the supplied, possibly
@@ -282,20 +281,51 @@ object Query {
     }
 
   /**
-   * Returns the top-level field selections of the supplied query.
+   * Yields the top-level field selections of the supplied query.
    */
   def children(q: Query): List[Query] = {
     def loop(q: Query): List[Query] =
       q match {
+        case UntypedSelect(_, _, _, _, child) => ungroup(child)
         case Select(_, _, child)       => ungroup(child)
-        case Wrap(_, child)            => ungroup(child)
-        case Count(_, child)           => ungroup(child)
-        case Rename(_, child)          => loop(child)
         case Environment(_, child)     => loop(child)
         case TransformCursor(_, child) => loop(child)
         case _                         => Nil
       }
     loop(q)
+  }
+
+  /**
+   * Yields the top-level field selection of the supplied Query
+   * if it is unique, `None` otherwise.
+   */
+  def extractChild(query: Query): Option[Query] = {
+    def loop(q: Query): Option[Query] =
+      q match {
+        case UntypedSelect(_, _, _, _, child) => Some(child)
+        case Select(_, _, child)       => Some(child)
+        case Environment(_, child)     => loop(child)
+        case TransformCursor(_, child) => loop(child)
+        case _ => None
+      }
+    loop(query)
+  }
+
+  /**
+    * Yields the supplied query with its the top-level field selection
+    * of the supplied replaced with `newChild` if it is unique, `None`
+    * otherwise.
+    */
+  def substChild(query: Query, newChild: Query): Option[Query] = {
+    def loop(q: Query): Option[Query] =
+      q match {
+        case u: UntypedSelect            => Some(u.copy(child = newChild))
+        case s: Select                   => Some(s.copy(child = newChild))
+        case e@Environment(_, child)     => loop(child).map(c => e.copy(child = c))
+        case t@TransformCursor(_, child) => loop(child).map(c => t.copy(child = c))
+        case _ => None
+      }
+    loop(query)
   }
 
   /**
@@ -305,8 +335,8 @@ object Query {
   def hasField(query: Query, fieldName: String): Boolean = {
     def loop(q: Query): Boolean =
       ungroup(q).exists {
+        case UntypedSelect(`fieldName`, _, _, _, _) => true
         case Select(`fieldName`, _, _) => true
-        case Rename(_, child)          => loop(child)
         case Environment(_, child)     => loop(child)
         case TransformCursor(_, child) => loop(child)
         case _                         => false
@@ -319,30 +349,40 @@ object Query {
    * the supplied query.
    */
   def fieldAlias(query: Query, fieldName: String): Option[String] = {
-    def loop(q: Query, alias: Option[String]): Option[String] =
+    def loop(q: Query): Option[String] =
       ungroup(q).collectFirstSome {
-        case Select(`fieldName`, _, _) => alias
-        case Wrap(`fieldName`, _)      => alias
-        case Count(`fieldName`, _)     => alias
-        case Rename(alias, child)      => loop(child, Some(alias))
-        case Environment(_, child)     => loop(child, alias)
-        case TransformCursor(_, child) => loop(child, alias)
+        case UntypedSelect(`fieldName`, alias, _, _, _) => alias
+        case Select(`fieldName`, alias, _) => alias
+        case Environment(_, child)     => loop(child)
+        case TransformCursor(_, child) => loop(child)
         case _                         => None
       }
-    loop(query, None)
+    loop(query)
   }
 
   /**
    * Tranform the children of `query` using the supplied function.
    */
-  def mapFields(query: Query)(f: Query => Result[Query]): Result[Query] = {
+  def mapFields(query: Query)(f: Query => Query): Query = {
+    def loop(q: Query): Query =
+      q match {
+        case Group(qs) => Group(qs.map(loop))
+        case s: Select => f(s)
+        case e@Environment(_, child) => e.copy(child = loop(child))
+        case t@TransformCursor(_, child) => t.copy(child = loop(child))
+        case other => other
+      }
+    loop(query)
+  }
+
+  /**
+   * Tranform the children of `query` using the supplied function.
+   */
+  def mapFieldsR(query: Query)(f: Query => Result[Query]): Result[Query] = {
     def loop(q: Query): Result[Query] =
       q match {
         case Group(qs) => qs.traverse(loop).map(Group(_))
         case s: Select => f(s)
-        case w: Wrap => f(w)
-        case c: Count => f(c)
-        case r@Rename(_, child) => loop(child).map(ec => r.copy(child = ec))
         case e@Environment(_, child) => loop(child).map(ec => e.copy(child = ec))
         case t@TransformCursor(_, child) => loop(child).map(ec => t.copy(child = ec))
         case other => other.success
@@ -426,11 +466,11 @@ object Query {
       case Nil => Nil
       case paths =>
         val oneElemPaths = paths.filter(_.sizeCompare(1) == 0).distinct
-        val oneElemQueries: List[Query] = oneElemPaths.map(p => Select(p.head, Nil, Empty))
+        val oneElemQueries: List[Query] = oneElemPaths.map(p => Select(p.head))
         val multiElemPaths = paths.filter(_.length > 1).distinct
         val grouped: List[Query] = multiElemPaths.groupBy(_.head).toList.map {
           case (fieldName, suffixes) =>
-            Select(fieldName, Nil, mergeQueries(mkPathQuery(suffixes.map(_.tail).filterNot(_.isEmpty))))
+            Select(fieldName, mergeQueries(mkPathQuery(suffixes.map(_.tail).filterNot(_.isEmpty))))
         }
         oneElemQueries ++ grouped
     }
@@ -453,15 +493,14 @@ object Query {
         }
 
         val flattened = flattenLevel(qs)
-        val (selects, rest) = flattened.partition { case PossiblyRenamedSelect(_, _) => true ; case _ => false }
+        val (selects, rest) = flattened.partitionMap { case sel: Select => Left(sel) ; case other => Right(other) }
 
         val mergedSelects =
-          selects.groupBy { case PossiblyRenamedSelect(Select(fieldName, _, _), resultName) => (fieldName, resultName) ; case _ => throw new MatchError("Impossible") }.values.map { rsels =>
-            val PossiblyRenamedSelect(Select(fieldName, _, _), resultName) = rsels.head : @unchecked
-            val sels = rsels.collect { case PossiblyRenamedSelect(sel, _) => sel }
+          selects.groupBy { case Select(fieldName, resultName, _) => (fieldName, resultName) }.values.map { sels =>
+            val Select(fieldName, resultName, _) = sels.head : @unchecked
             val children = sels.map(_.child)
             val merged = mergeQueries(children)
-            PossiblyRenamedSelect(Select(fieldName, Nil, merged), resultName)
+            Select(fieldName, resultName, merged)
           }
 
         Group(rest ++ mergedSelects)

--- a/modules/core/src/main/scala/queryinterpreter.scala
+++ b/modules/core/src/main/scala/queryinterpreter.scala
@@ -14,39 +14,28 @@ import fs2.Stream
 import io.circe.Json
 
 import syntax._
-import Cursor.{Context, Env, ListTransformCursor}
+import Cursor.ListTransformCursor
 import Query._
 import QueryInterpreter.ProtoJson
 import ProtoJson._
 
 class QueryInterpreter[F[_]](mapping: Mapping[F]) {
-  import mapping.{mkResponse, M, RootCursor, RootEffect, RootStream}
+  import mapping.{M, RootCursor, RootEffect, RootStream}
 
   /** Interpret `query` with expected type `rootTpe`.
    *
    *  The query is fully interpreted, including deferred or staged
    *  components.
    *
-   *  The resulting Json value should include standard GraphQL error
-   *  information in the case of failure.
+   *  GraphQL errors are accumulated in the result.
    */
-  def run(query: Query, rootTpe: Type, env: Env): Stream[F,Json] =
-    runRoot(query, rootTpe, env).evalMap(mkResponse)
-
-  /** Interpret `query` with expected type `rootTpe`.
-   *
-   *  The query is fully interpreted, including deferred or staged
-   *  components.
-   *
-   *  Errors are accumulated on the `Left` of the result.
-   */
-  def runRoot(query: Query, rootTpe: Type, env: Env): Stream[F,Result[Json]] = {
+  def run(query: Query, rootTpe: Type, env: Env): Stream[F, Result[Json]] = {
     val rootCursor = RootCursor(Context(rootTpe), None, env)
     val mergedResults =
       if(mapping.schema.subscriptionType.map(_ =:= rootTpe).getOrElse(false))
-        runRootStream(query, rootTpe, rootCursor)
+        runSubscription(query, rootTpe, rootCursor)
       else
-        Stream.eval(runRootEffects(query, rootTpe, rootCursor))
+        Stream.eval(runOneShot(query, rootTpe, rootCursor))
 
     (for {
       pvalue <- ResultT(mergedResults)
@@ -54,7 +43,10 @@ class QueryInterpreter[F[_]](mapping: Mapping[F]) {
     } yield value).value
   }
 
-  def runRootStream(query: Query, rootTpe: Type, rootCursor: Cursor): Stream[F, Result[ProtoJson]] =
+  /**
+   *  Run a subscription query yielding a stream of results.
+   */
+  def runSubscription(query: Query, rootTpe: Type, rootCursor: Cursor): Stream[F, Result[ProtoJson]] =
     ungroup(query) match {
       case Nil => Result(ProtoJson.fromJson(Json.Null)).pure[Stream[F, *]]
       case List(root) =>
@@ -65,13 +57,16 @@ class QueryInterpreter[F[_]](mapping: Mapping[F]) {
             effect(root, rootTpe / fieldName, rootCursor.fullEnv.addFromQuery(root)).map(_.flatMap { // TODO Rework in terms of cursor
               case (q, c) => runValue(q, rootTpe, c)
             })
-        ).getOrElse(Result.failure("EffectMapping required for subscriptions").pure[Stream[F, *]])
+        ).getOrElse(Result.internalError("EffectMapping required for subscriptions").pure[Stream[F, *]])
 
       case _ =>
-        Result.failure("Only one root selection permitted for subscriptions").pure[Stream[F, *]]
+        Result.internalError("Only one root selection permitted for subscriptions").pure[Stream[F, *]]
     }
 
-  def runRootEffects(query: Query, rootTpe: Type, rootCursor: Cursor): F[Result[ProtoJson]] = {
+  /**
+   *  Run a non-subscription query yielding a single result.
+   */
+  def runOneShot(query: Query, rootTpe: Type, rootCursor: Cursor): F[Result[ProtoJson]] = {
     case class PureQuery(query: Query)
     case class EffectfulQuery(query: Query, rootEffect: RootEffect)
 
@@ -83,7 +78,7 @@ class QueryInterpreter[F[_]](mapping: Mapping[F]) {
       }
 
     if(hasRootStream)
-      Result.failure("RootStream only permitted in subscriptions").pure[F].widen
+      Result.internalError("RootStream only permitted in subscriptions").pure[F].widen
     else {
       val (effectfulQueries, pureQueries) = ungrouped.partitionMap { query =>
         (for {
@@ -195,7 +190,7 @@ class QueryInterpreter[F[_]](mapping: Mapping[F]) {
               fields <- runFields(child, tp1, c)
             } yield fields
 
-        case (Introspect(schema, PossiblyRenamedSelect(Select("__typename", Nil, Empty), resultName)), tpe: NamedType) =>
+        case (Introspect(schema, s@Select("__typename", _, Empty)), tpe: NamedType) =>
           (tpe match {
             case o: ObjectType => Some(o.name)
             case i: InterfaceType =>
@@ -209,49 +204,48 @@ class QueryInterpreter[F[_]](mapping: Mapping[F]) {
             case _ => None
           }) match {
             case Some(name) =>
-              List((resultName, ProtoJson.fromJson(Json.fromString(name)))).success
+              List((s.resultName, ProtoJson.fromJson(Json.fromString(name)))).success
             case None =>
               Result.failure(s"'__typename' cannot be applied to non-selectable type '$tpe'")
           }
 
-        case (PossiblyRenamedSelect(sel, resultName), NullableType(tpe)) =>
+        case (sel: Select, NullableType(tpe)) =>
           cursor.asNullable.sequence.map { rc =>
             for {
               c      <- rc
               fields <- runFields(sel, tpe, c)
             } yield fields
-          }.getOrElse(List((resultName, ProtoJson.fromJson(Json.Null))).success)
+          }.getOrElse(List((sel.resultName, ProtoJson.fromJson(Json.Null))).success)
 
-        case (PossiblyRenamedSelect(Select(fieldName, _, child), resultName), _) =>
+        case (sel@Select(_, _, Count(Select(countName, _, _))), _) =>
+          def size(c: Cursor): Result[Int] =
+            if (c.isList) c.asList(Iterator).map(_.size)
+            else 1.success
+
+          for {
+            c0     <- cursor.field(countName, None)
+            count  <- if (c0.isNullable) c0.asNullable.flatMap(_.map(size).getOrElse(0.success))
+                      else size(c0)
+          } yield List((sel.resultName, ProtoJson.fromJson(Json.fromInt(count))))
+
+        case (sel@Select(fieldName, resultName, child), _) =>
           val fieldTpe = tpe.field(fieldName).getOrElse(ScalarType.AttributeType)
           for {
-            c        <- cursor.field(fieldName, Some(resultName))
+            c        <- cursor.field(fieldName, resultName)
             value    <- runValue(child, fieldTpe, c)
-          } yield List((resultName, value))
+          } yield List((sel.resultName, value))
 
-        case (Rename(resultName, Wrap(_, child)), tpe) =>
-          runFields(Wrap(resultName, child), tpe, cursor)
-
-        case (Wrap(fieldName, child), tpe) =>
+        case (c@Component(_, _, cont), _) =>
           for {
-            value <- runValue(child, tpe, cursor)
-          } yield List((fieldName, value))
+            componentName <- resultName(cont).toResultOrError("Join continuation has unexpected shape")
+            value <- runValue(c, tpe, cursor)
+          } yield List((componentName, ProtoJson.select(value, componentName)))
 
-        case (Rename(resultName, Count(_, child)), tpe) =>
-          runFields(Count(resultName, child), tpe, cursor)
-
-        case (Count(fieldName, Select(countName, _, _)), _) =>
-          cursor.field(countName, None).flatMap { c0 =>
-            if (c0.isNullable)
-              c0.asNullable.flatMap {
-                case None => 0.success
-                case Some(c1) =>
-                  if (c1.isList) c1.asList(Iterator).map(_.size)
-                  else 1.success
-              }
-            else if (c0.isList) c0.asList(Iterator).map(_.size)
-            else 1.success
-          }.map { value => List((fieldName, ProtoJson.fromJson(Json.fromInt(value)))) }
+        case (e@Effect(_, cont), _) =>
+          for {
+            effectName <- resultName(cont).toResultOrError("Effect continuation has unexpected shape")
+            value <- runValue(e, tpe, cursor)
+          } yield List((effectName, value))
 
         case (Group(siblings), _) =>
           siblings.flatTraverse(query => runFields(query, tpe, cursor))
@@ -369,17 +363,11 @@ class QueryInterpreter[F[_]](mapping: Mapping[F]) {
     if (!cursorCompatible(tpe, cursor.tpe))
       Result.internalError(s"Mismatched query and cursor type in runValue: $tpe ${cursor.tpe}")
     else {
-      def mkResult[T](ot: Option[T]): Result[T] = ot match {
-        case Some(t) => t.success
-        case None => Result.internalError(s"Join continuation has unexpected shape")
-      }
-
       (query, tpe.dealias) match {
         case (Environment(childEnv: Env, child: Query), tpe) =>
           runValue(child, tpe, cursor.withEnv(childEnv))
 
-        case (Wrap(_, Component(_, _, _)), ListType(tpe)) =>
-          // Keep the wrapper with the component when going under the list
+        case (Component(_, _, _), ListType(tpe)) =>
           cursor.asList(Iterator) match {
             case Result.Success(ic) =>
               val builder = Vector.newBuilder[ProtoJson]
@@ -392,32 +380,33 @@ class QueryInterpreter[F[_]](mapping: Mapping[F]) {
                 }
               }
               ProtoJson.fromValues(builder.result()).success
+            case Result.Warning(ps, _) => Result.Failure(ps)
             case fail@Result.Failure(_) => fail
             case err@Result.InternalError(_) => err
-            case Result.Warning(ps, _) => Result.Failure(ps)
           }
 
-        case (Wrap(fieldName, child), _) =>
-          for {
-            pvalue <- runValue(child, tpe, cursor)
-          } yield ProtoJson.fromFields(List((fieldName, pvalue)))
-
-        case (Component(mapping, join, PossiblyRenamedSelect(child, resultName)), _) =>
+        case (Component(mapping, join, child), _) =>
           join(child, cursor).flatMap {
             case Group(conts) =>
-              conts.traverse { case cont =>
-                for {
-                  componentName <- mkResult(rootName(cont).map(nme => nme._2.getOrElse(nme._1)))
-                } yield
-                  ProtoJson.select(
-                    ProtoJson.component(mapping, cont, cursor),
-                    componentName
-                  )
-              }.map(ProtoJson.fromValues)
+              for {
+                childName <- resultName(child).toResultOrError("Join child has unexpected shape")
+                elems     <- conts.traverse { case cont =>
+                              for {
+                                componentName <- resultName(cont).toResultOrError("Join continuation has unexpected shape")
+                              } yield
+                                ProtoJson.select(
+                                  ProtoJson.component(mapping, cont, cursor),
+                                  componentName
+                                )
+                              }
+              } yield
+                ProtoJson.fromFields(
+                  List(childName -> ProtoJson.fromValues(elems))
+                )
 
             case cont =>
               for {
-                renamedCont <- mkResult(renameRoot(cont, resultName))
+                renamedCont <- alignResultName(child, cont).toResultOrError("Join continuation has unexpected shape")
               } yield ProtoJson.component(mapping, renamedCont, cursor)
           }
 

--- a/modules/core/src/main/scala/valuemapping.scala
+++ b/modules/core/src/main/scala/valuemapping.scala
@@ -11,7 +11,7 @@ import io.circe.Json
 import org.tpolecat.sourcepos.SourcePos
 
 import syntax._
-import Cursor.{Context, DeferredCursor, Env}
+import Cursor.{DeferredCursor}
 
 abstract class ValueMapping[F[_]](implicit val M: MonadThrow[F]) extends Mapping[F] with ValueMappingLike[F]
 

--- a/modules/core/src/test/scala/arb/AstArb.scala
+++ b/modules/core/src/test/scala/arb/AstArb.scala
@@ -93,7 +93,8 @@ trait AstArb {
         variable     <- arbitrary[Name]
         tpe          <- arbitrary[Type]
         defaultValue <- option(genValueForType(tpe))
-      } yield VariableDefinition(variable, tpe, defaultValue)
+        directives   <- shortListOf(arbitrary[Directive])
+      } yield VariableDefinition(variable, tpe, defaultValue, directives)
     }
 
   implicit lazy val arbSelectionFragmentSpread: Arbitrary[Selection.FragmentSpread] =

--- a/modules/core/src/test/scala/compiler/AttributesSuite.scala
+++ b/modules/core/src/test/scala/compiler/AttributesSuite.scala
@@ -61,7 +61,7 @@ final class AttributesSuite extends CatsEffectSuite {
       {
         "errors" : [
           {
-            "message" : "Unknown field 'tagCountVA' in select"
+            "message" : "No field 'tagCountVA' for type Item"
           }
         ]
       }
@@ -86,7 +86,7 @@ final class AttributesSuite extends CatsEffectSuite {
       {
         "errors" : [
           {
-            "message" : "Unknown field 'tagCountCA' in select"
+            "message" : "No field 'tagCountCA' for type Item"
           }
         ]
       }

--- a/modules/core/src/test/scala/compiler/CascadeSuite.scala
+++ b/modules/core/src/test/scala/compiler/CascadeSuite.scala
@@ -1,0 +1,751 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package compiler
+
+import PartialFunction.condOpt
+
+import cats.effect.IO
+import io.circe.literal._
+import munit.CatsEffectSuite
+
+import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
+import Query._
+import QueryCompiler._
+import Value._
+
+final class CascadeSuite extends CatsEffectSuite {
+  test("elaboration of simple query") {
+    val query = """
+      query {
+        foo(filter: { foo: "foo", fooBar: 23 }, limit: 10) {
+          cascaded {
+            foo
+            bar
+            fooBar
+            limit
+          }
+        }
+      }
+    """
+
+    val expected =
+      Environment(
+        Env.NonEmptyEnv(Map("filter" -> CascadeMapping.CascadedFilter(Some("foo"), None, Some(23), Some(10)))),
+        Select("foo",
+          Select("cascaded",
+            Group(
+              List(
+                Select("foo"),
+                Select("bar"),
+                Select("fooBar"),
+                Select("limit")
+              )
+            )
+          )
+        )
+      )
+
+    val res = CascadeMapping.compiler.compile(query)
+
+    assertEquals(res.map(_.query), Result.Success(expected))
+  }
+
+  test("simple query") {
+    val query = """
+      query {
+        foo(filter: { foo: "foo", fooBar: 23 }, limit: 10) {
+          cascaded {
+            foo
+            bar
+            fooBar
+            limit
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "foo" : {
+            "cascaded" : {
+              "foo" : "foo",
+              "bar" : null,
+              "fooBar" : 23,
+              "limit" : 10
+            }
+          }
+        }
+      }
+    """
+
+    val res = CascadeMapping.compileAndRun(query)
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("simple cascade (1)") {
+    val query = """
+      query {
+        foo(filter: { foo: "foo", fooBar: 23 }, limit: 10) {
+          cascaded { foo bar fooBar limit }
+          bar {
+            cascaded { foo bar fooBar limit }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "foo" : {
+            "cascaded" : {
+              "foo" : "foo",
+              "bar" : null,
+              "fooBar" : 23,
+              "limit" : 10
+            },
+            "bar" : {
+              "cascaded" : {
+                "foo" : "foo",
+                "bar" : null,
+                "fooBar" : 23,
+                "limit" : null
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val res = CascadeMapping.compileAndRun(query)
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("simple cascade (2)") {
+    val query = """
+      query {
+        foo(filter: { foo: "foo", fooBar: 23 }, limit: 10) {
+          cascaded { foo bar fooBar limit }
+          bar {
+            cascaded { foo bar fooBar limit }
+            foo {
+              cascaded { foo bar fooBar limit }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "foo" : {
+            "cascaded" : {
+              "foo" : "foo",
+              "bar" : null,
+              "fooBar" : 23,
+              "limit" : 10
+            },
+            "bar" : {
+              "cascaded" : {
+                "foo" : "foo",
+                "bar" : null,
+                "fooBar" : 23,
+                "limit" : null
+              },
+              "foo" : {
+                "cascaded" : {
+                  "foo" : "foo",
+                  "bar" : null,
+                  "fooBar" : 23,
+                  "limit" : null
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val res = CascadeMapping.compileAndRun(query)
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("cascade with override (1)") {
+    val query = """
+      query {
+        foo(filter: { foo: "foo", fooBar: 23 }, limit: 10) {
+          cascaded { foo bar fooBar limit }
+          bar1:bar(filter: { bar: true, fooBar: 13 }, limit: 5) {
+            cascaded { foo bar fooBar limit }
+            foo {
+              cascaded { foo bar fooBar limit }
+            }
+          }
+          bar2:bar(filter: { bar: false, fooBar: 11 }, limit: 7) {
+            cascaded { foo bar fooBar limit }
+            foo {
+              cascaded { foo bar fooBar limit }
+            }
+          }
+          bar3:bar {
+            cascaded { foo bar fooBar limit }
+            foo {
+              cascaded { foo bar fooBar limit }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "foo" : {
+            "cascaded" : {
+              "foo" : "foo",
+              "bar" : null,
+              "fooBar" : 23,
+              "limit" : 10
+            },
+            "bar1" : {
+              "cascaded" : {
+                "foo" : "foo",
+                "bar" : true,
+                "fooBar" : 13,
+                "limit" : 5
+              },
+              "foo" : {
+                "cascaded" : {
+                  "foo" : "foo",
+                  "bar" : true,
+                  "fooBar" : 13,
+                  "limit" : null
+                }
+              }
+            },
+            "bar2" : {
+              "cascaded" : {
+                "foo" : "foo",
+                "bar" : false,
+                "fooBar" : 11,
+                "limit" : 7
+              },
+              "foo" : {
+                "cascaded" : {
+                  "foo" : "foo",
+                  "bar" : false,
+                  "fooBar" : 11,
+                  "limit" : null
+                }
+              }
+            },
+            "bar3" : {
+              "cascaded" : {
+                "foo" : "foo",
+                "bar" : null,
+                "fooBar" : 23,
+                "limit" : null
+              },
+              "foo" : {
+                "cascaded" : {
+                  "foo" : "foo",
+                  "bar" : null,
+                  "fooBar" : 23,
+                  "limit" : null
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val res = CascadeMapping.compileAndRun(query)
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("cascade with override (2)") {
+    val query = """
+      query {
+        foo(filter: { foo: "foo", fooBar: 23 }, limit: 10) {
+          cascaded { foo bar fooBar limit }
+          bar1:bar(filter: { bar: true, fooBar: 13 }, limit: 5) {
+            cascaded { foo bar fooBar limit }
+            foo(filter: { foo: "foo1" }, limit: 3) {
+              cascaded { foo bar fooBar limit }
+            }
+          }
+          bar2:bar(filter: { bar: false, fooBar: 11 }, limit: 7) {
+            cascaded { foo bar fooBar limit }
+            foo(filter: { foo: "foo2" }, limit: 5) {
+              cascaded { foo bar fooBar limit }
+            }
+          }
+          bar3:bar {
+            cascaded { foo bar fooBar limit }
+            foo(filter: { foo: "foo3" }, limit: 2) {
+              cascaded { foo bar fooBar limit }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "foo" : {
+            "cascaded" : {
+              "foo" : "foo",
+              "bar" : null,
+              "fooBar" : 23,
+              "limit" : 10
+            },
+            "bar1" : {
+              "cascaded" : {
+                "foo" : "foo",
+                "bar" : true,
+                "fooBar" : 13,
+                "limit" : 5
+              },
+              "foo" : {
+                "cascaded" : {
+                  "foo" : "foo1",
+                  "bar" : true,
+                  "fooBar" : 13,
+                  "limit" : 3
+                }
+              }
+            },
+            "bar2" : {
+              "cascaded" : {
+                "foo" : "foo",
+                "bar" : false,
+                "fooBar" : 11,
+                "limit" : 7
+              },
+              "foo" : {
+                "cascaded" : {
+                  "foo" : "foo2",
+                  "bar" : false,
+                  "fooBar" : 11,
+                  "limit" : 5
+                }
+              }
+            },
+            "bar3" : {
+              "cascaded" : {
+                "foo" : "foo",
+                "bar" : null,
+                "fooBar" : 23,
+                "limit" : null
+              },
+              "foo" : {
+                "cascaded" : {
+                  "foo" : "foo3",
+                  "bar" : null,
+                  "fooBar" : 23,
+                  "limit" : 2
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val res = CascadeMapping.compileAndRun(query)
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("cascade with reset (1)") {
+    val query = """
+      query {
+        foo(filter: { foo: "foo", fooBar: 23 }, limit: 10) {
+          cascaded { foo bar fooBar limit }
+          reset {
+            bar(filter: { bar: true, fooBar: 13 }, limit: 5) {
+              cascaded { foo bar fooBar limit }
+              foo {
+                cascaded { foo bar fooBar limit }
+              }
+            }
+          }
+          bar1:bar(filter: null, limit: 5) {
+            cascaded { foo bar fooBar limit }
+            foo {
+              cascaded { foo bar fooBar limit }
+            }
+          }
+          bar2:bar(filter: { fooBar: null }, limit: 5) {
+            cascaded { foo bar fooBar limit }
+            foo {
+              cascaded { foo bar fooBar limit }
+            }
+          }
+          bar3:bar(limit: 5) {
+            cascaded { foo bar fooBar limit }
+            foo(filter: { foo : null }, limit: 11) {
+              cascaded { foo bar fooBar limit }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "foo" : {
+            "cascaded" : {
+              "foo" : "foo",
+              "bar" : null,
+              "fooBar" : 23,
+              "limit" : 10
+            },
+            "reset" : {
+              "bar" : {
+                "cascaded" : {
+                  "foo" : null,
+                  "bar" : true,
+                  "fooBar" : 13,
+                  "limit" : 5
+                },
+                "foo" : {
+                  "cascaded" : {
+                    "foo" : null,
+                    "bar" : true,
+                    "fooBar" : 13,
+                    "limit" : null
+                  }
+                }
+              }
+            },
+            "bar1" : {
+              "cascaded" : {
+                "foo" : null,
+                "bar" : null,
+                "fooBar" : null,
+                "limit" : 5
+              },
+              "foo" : {
+                "cascaded" : {
+                  "foo" : null,
+                  "bar" : null,
+                  "fooBar" : null,
+                  "limit" : null
+                }
+              }
+            },
+            "bar2" : {
+              "cascaded" : {
+                "foo" : "foo",
+                "bar" : null,
+                "fooBar" : null,
+                "limit" : 5
+              },
+              "foo" : {
+                "cascaded" : {
+                  "foo" : "foo",
+                  "bar" : null,
+                  "fooBar" : null,
+                  "limit" : null
+                }
+              }
+            },
+            "bar3" : {
+              "cascaded" : {
+                "foo" : "foo",
+                "bar" : null,
+                "fooBar" : 23,
+                "limit" : 5
+              },
+              "foo" : {
+                "cascaded" : {
+                  "foo" : null,
+                  "bar" : null,
+                  "fooBar" : 23,
+                  "limit" : 11
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val res = CascadeMapping.compileAndRun(query)
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("repeated cascade with overrides and resets") {
+    val query = """
+      query {
+        foo(filter: { foo: "foo" }) {
+          cascaded { foo }
+          bar {
+            foo {
+              cascaded { foo }
+              bar {
+                foo(filter: { foo: "foo2" }) {
+                  cascaded { foo }
+                  bar {
+                    foo(filter: { foo: null }) {
+                      cascaded { foo }
+                      bar {
+                        foo(filter: { foo: "foo3" }) {
+                          cascaded { foo }
+                          reset {
+                            cascaded { foo }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "foo" : {
+            "cascaded" : {
+              "foo" : "foo"
+            },
+            "bar" : {
+              "foo" : {
+                "cascaded" : {
+                  "foo" : "foo"
+                },
+                "bar" : {
+                  "foo" : {
+                    "cascaded" : {
+                      "foo" : "foo2"
+                    },
+                    "bar" : {
+                      "foo" : {
+                        "cascaded" : {
+                          "foo" : null
+                        },
+                        "bar" : {
+                          "foo" : {
+                            "cascaded" : {
+                              "foo" : "foo3"
+                            },
+                            "reset" : {
+                              "cascaded" : {
+                                "foo" : null
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val res = CascadeMapping.compileAndRun(query)
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+}
+
+object CascadeMapping extends ValueMapping[IO] {
+  val schema =
+    schema"""
+      type Query {
+        foo(filter: FooFilter, limit: Int): Foo
+      }
+      type Foo {
+        bar(filter: BarFilter, limit: Int): Bar
+        reset: Foo!
+        cascaded: FilterValue!
+      }
+      type Bar {
+        cascaded: FilterValue!
+        reset: Bar!
+        foo(filter: FooFilter, limit: Int): Foo
+      }
+      input FooFilter {
+        foo: String
+        fooBar: Int
+      }
+      input BarFilter {
+        bar: Boolean
+        fooBar: Int
+      }
+      type FilterValue {
+        foo: String
+        bar: Boolean
+        fooBar: Int
+        limit: Int
+      }
+    """
+
+  val QueryType = schema.ref("Query")
+  val FooType = schema.ref("Foo")
+  val BarType = schema.ref("Bar")
+  val FilterValueType = schema.ref("FilterValue")
+
+  override val typeMappings =
+    List(
+      ValueObjectMapping[Unit](
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            ValueField("foo", _ => Some(()))
+          )
+      ),
+      ValueObjectMapping[Unit](
+        tpe = FooType,
+        fieldMappings =
+          List(
+            ValueField("cascaded", identity),
+            ValueField("reset", identity),
+            ValueField("bar", _ => Some(()))
+          )
+      ),
+      ValueObjectMapping[Unit](
+        tpe = BarType,
+        fieldMappings =
+          List(
+            ValueField("cascaded", identity),
+            ValueField("reset", identity),
+            ValueField("foo", _ => Some(()))
+          )
+      ),
+      ValueObjectMapping[CascadedFilter](
+        tpe = FilterValueType,
+        fieldMappings =
+          List(
+            CursorField("foo", getFilterValue(_).map(_.foo)),
+            CursorField("bar", getFilterValue(_).map(_.bar)),
+            CursorField("fooBar", getFilterValue(_).map(_.fooBar)),
+            CursorField("limit", getFilterValue(_).map(_.limit))
+          )
+      )
+    )
+
+  def getFilterValue(c: Cursor): Result[CascadedFilter] =
+    c.envR[CascadedFilter]("filter")
+
+  type Tri[T] = Either[Unit, Option[T]]
+  def triToOption[T](t: Tri[T]): Option[T] =
+    t match {
+      case Right(t) => t
+      case Left(()) => None
+    }
+
+  abstract class TriValue[T](matchValue: Value => Option[T]) {
+    def unapply(v: Value): Option[Tri[T]] =
+      v match {
+        case NullValue => Some(Right(None))
+        case AbsentValue => Some(Left(()))
+        case _ => matchValue(v).map(t => Right(Some(t)))
+      }
+  }
+
+  object TriString extends TriValue[String](condOpt(_) { case StringValue(s) => s })
+  object TriInt extends TriValue[Int](condOpt(_) { case IntValue(i) => i })
+  object TriBoolean extends TriValue[Boolean](condOpt(_) { case BooleanValue(b) => b })
+
+  case class CascadedFilter(foo: Option[String], bar: Option[Boolean], fooBar: Option[Int], limit: Option[Int]) {
+    def combine[T](current: Option[T], next: Tri[T]): Option[T] =
+      next match {
+        case Left(()) => current
+        case Right(None) => None
+        case Right(Some(t)) => Some(t)
+      }
+
+    def cascadeFoo(foo0: Tri[String], fooBar0: Tri[Int]): CascadedFilter =
+      copy(
+        foo = combine(foo, foo0),
+        fooBar = combine(fooBar, fooBar0),
+        limit = None
+      )
+
+    def cascadeBar(bar0: Tri[Boolean], fooBar0: Tri[Int]): CascadedFilter =
+      copy(
+        bar = combine(bar, bar0),
+        fooBar = combine(fooBar, fooBar0),
+        limit = None
+      )
+
+    def withLimit(limit0: Tri[Int]): CascadedFilter =
+      copy(limit = triToOption(limit0))
+  }
+
+  object CascadedFilter {
+    def empty: CascadedFilter =
+      CascadedFilter(None, None, None, None)
+  }
+
+  object FooFilter {
+    def unapply(v: Value): Option[CascadedFilter => CascadedFilter] =
+      v match {
+        case ObjectValue(List(("foo", TriString(foo)), ("fooBar", TriInt(fooBar)))) =>
+          Some(_.cascadeFoo(foo, fooBar))
+        case NullValue => Some(_ => CascadedFilter.empty)
+        case AbsentValue => Some(identity)
+        case _ => None
+      }
+  }
+
+  object BarFilter {
+    def unapply(v: Value): Option[CascadedFilter => CascadedFilter] =
+      v match {
+        case ObjectValue(List(("bar", TriBoolean(bar)), ("fooBar", TriInt(fooBar)))) =>
+          Some(_.cascadeBar(bar, fooBar))
+        case NullValue => Some(_ => CascadedFilter.empty)
+        case AbsentValue => Some(identity)
+        case _ => None
+      }
+  }
+
+  override val selectElaborator = SelectElaborator {
+    case (QueryType | BarType, "foo", List(Binding("filter", FooFilter(filter)), Binding("limit", TriInt(limit)))) =>
+      for {
+        current0 <- Elab.env[CascadedFilter]("filter")
+        current  =  current0.getOrElse(CascadedFilter.empty)
+        _        <- Elab.env("filter", filter(current).withLimit(limit))
+      } yield ()
+
+    case (FooType, "bar", List(Binding("filter", BarFilter(filter)), Binding("limit", TriInt(limit)))) =>
+      for {
+        current0 <- Elab.env[CascadedFilter]("filter")
+        current  =  current0.getOrElse(CascadedFilter.empty)
+        _        <- Elab.env("filter", filter(current).withLimit(limit))
+      } yield ()
+
+    case (FooType | BarType, "reset", Nil) =>
+      Elab.env("filter", CascadedFilter.empty)
+  }
+}

--- a/modules/core/src/test/scala/compiler/DirectivesSuite.scala
+++ b/modules/core/src/test/scala/compiler/DirectivesSuite.scala
@@ -1,0 +1,319 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package compiler
+
+import munit.CatsEffectSuite
+
+import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
+import Ast.DirectiveLocation._
+import Query._
+
+final class DirectivesSuite extends CatsEffectSuite {
+  def testDirectiveDefs(s: Schema): List[DirectiveDef] =
+    s.directives.filter {
+      case DirectiveDef("skip"|"include"|"deprecated", _, _, _, _) => false
+      case _ => true
+    }
+
+  test("Simple directive definition") {
+    val expected = DirectiveDef("foo", None, Nil, false, List(FIELD))
+    val schema =
+      Schema("""
+        type Query {
+          foo: Int
+        }
+
+        directive @foo on FIELD
+      """)
+
+    assertEquals(schema.map(testDirectiveDefs), List(expected).success)
+  }
+
+  test("Directive definition with description") {
+    val expected = DirectiveDef("foo", Some("A directive"), Nil, false, List(FIELD))
+    val schema =
+      Schema("""
+        type Query {
+          foo: Int
+        }
+
+        "A directive"
+        directive @foo on FIELD
+      """)
+
+    assertEquals(schema.map(testDirectiveDefs), List(expected).success)
+  }
+
+  test("Directive definition with multiple locations (1)") {
+    val expected = DirectiveDef("foo", None, Nil, false, List(FIELD, FRAGMENT_SPREAD, INLINE_FRAGMENT))
+    val schema =
+      Schema("""
+        type Query {
+          foo: Int
+        }
+
+        directive @foo on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+      """)
+
+    assertEquals(schema.map(testDirectiveDefs), List(expected).success)
+  }
+
+  test("Directive definition with multiple locations (2)") {
+    val expected = DirectiveDef("foo", None, Nil, false, List(FIELD, FRAGMENT_SPREAD, INLINE_FRAGMENT))
+    val schema =
+      Schema("""
+        type Query {
+          foo: Int
+        }
+
+        directive @foo on | FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+      """)
+
+    assertEquals(schema.map(testDirectiveDefs), List(expected).success)
+  }
+
+  test("Directive definition with repeatable") {
+    val expected = DirectiveDef("foo", None, Nil, true, List(FIELD))
+    val schema =
+      Schema("""
+        type Query {
+          foo: Int
+        }
+
+        directive @foo repeatable on FIELD
+      """)
+
+    assertEquals(schema.map(testDirectiveDefs), List(expected).success)
+  }
+
+  test("Directive definition with arguments (1)") {
+    val expected =
+      DirectiveDef(
+        "foo",
+        None,
+        List(InputValue("arg", None, ScalarType.StringType, None, Nil)),
+        false,
+        List(FIELD)
+      )
+
+    val schema =
+      Schema("""
+        type Query {
+          foo: Int
+        }
+
+        directive @foo(arg: String!) on FIELD
+      """)
+
+    assertEquals(schema.map(testDirectiveDefs), List(expected).success)
+  }
+
+  test("Directive definition with arguments (2)") {
+    val expected =
+      DirectiveDef(
+        "foo",
+        None,
+        List(
+          InputValue("arg0", None, ScalarType.StringType, None, Nil),
+          InputValue("arg1", None, NullableType(ScalarType.IntType), None, Nil)
+        ),
+        false,
+        List(FIELD)
+      )
+
+    val schema =
+      Schema("""
+        type Query {
+          foo: Int
+        }
+
+        directive @foo(arg0: String!, arg1: Int) on FIELD
+      """)
+
+    assertEquals(schema.map(testDirectiveDefs), List(expected).success)
+  }
+
+  test("Schema with directives") {
+    val schema =
+    """|schema @foo {
+       |  query: Query
+       |}
+       |scalar Scalar @foo
+       |interface Interface @foo {
+       |  field(e: Enum, i: Input): Int @foo
+       |}
+       |type Object implements Interface @foo {
+       |  field(e: Enum, i: Input): Int @foo
+       |}
+       |union Union @foo = Object
+       |enum Enum @foo {
+       |  VALUE @foo
+       |}
+       |input Input @foo {
+       |  field: Int @foo
+       |}
+       |directive @foo on SCHEMA|SCALAR|OBJECT|FIELD_DEFINITION|ARGUMENT_DEFINITION|INTERFACE|UNION|ENUM|ENUM_VALUE|INPUT_OBJECT|INPUT_FIELD_DEFINITION
+       |""".stripMargin
+
+    val res = SchemaParser.parseText(schema)
+    val ser = res.map(_.toString)
+
+    assertEquals(ser, schema.success)
+  }
+
+  test("Query with directive") {
+    val expected =
+      Operation(
+        UntypedSelect("foo", None, Nil, List(Directive("dir", Nil)),
+          UntypedSelect("id", None, Nil, List(Directive("dir", Nil)), Empty)
+        ),
+        DirectiveMapping.QueryType,
+        List(Directive("dir", Nil))
+      )
+
+    val query =
+      """|query @dir {
+         |  foo @dir {
+         |    id @dir
+         |  }
+         |}
+         |""".stripMargin
+
+    val res = DirectiveMapping.compiler.compile(query)
+
+    assertEquals(res, expected.success)
+  }
+
+  test("Mutation with directive") {
+    val expected =
+      Operation(
+        UntypedSelect("foo", None, Nil, List(Directive("dir", Nil)),
+          UntypedSelect("id", None, Nil, List(Directive("dir", Nil)), Empty)
+        ),
+        DirectiveMapping.MutationType,
+        List(Directive("dir", Nil))
+      )
+
+    val query =
+      """|mutation @dir {
+         |  foo @dir {
+         |    id @dir
+         |  }
+         |}
+         |""".stripMargin
+
+    val res = DirectiveMapping.compiler.compile(query)
+
+    assertEquals(res, expected.success)
+  }
+
+  test("Subscription with directive") {
+    val expected =
+      Operation(
+        UntypedSelect("foo", None, Nil, List(Directive("dir", Nil)),
+          UntypedSelect("id", None, Nil, List(Directive("dir", Nil)), Empty)
+        ),
+        DirectiveMapping.SubscriptionType,
+        List(Directive("dir", Nil))
+      )
+
+    val query =
+      """|subscription @dir {
+         |  foo @dir {
+         |    id @dir
+         |  }
+         |}
+         |""".stripMargin
+
+    val res = DirectiveMapping.compiler.compile(query)
+
+    assertEquals(res, expected.success)
+  }
+
+  test("Fragment with directive") { // TOD: will need new elaborator to expose fragment directives
+    val expected =
+      Operation(
+        UntypedSelect("foo", None, Nil, Nil,
+          Narrow(DirectiveMapping.BazType,
+            UntypedSelect("baz", None, Nil, List(Directive("dir", Nil)), Empty)
+          )
+        ),
+        DirectiveMapping.QueryType,
+        Nil
+      )
+
+    val query =
+      """|query {
+         |  foo {
+         |    ... Frag @dir
+         |  }
+         |}
+         |fragment Frag on Baz @dir {
+         |  baz @dir
+         |}
+         |""".stripMargin
+
+    val res = DirectiveMapping.compiler.compile(query)
+
+    assertEquals(res, expected.success)
+  }
+
+  test("Inline fragment with directive") { // TOD: will need new elaborator to expose fragment directives
+    val expected =
+      Operation(
+        UntypedSelect("foo", None, Nil, Nil,
+          Narrow(DirectiveMapping.BazType,
+            UntypedSelect("baz", None, Nil, List(Directive("dir", Nil)), Empty)
+          )
+        ),
+        DirectiveMapping.QueryType,
+        Nil
+      )
+
+    val query =
+      """|query {
+         |  foo {
+         |    ... on Baz @dir {
+         |      baz @dir
+         |    }
+         |  }
+         |}
+         |""".stripMargin
+
+    val res = DirectiveMapping.compiler.compile(query)
+
+    assertEquals(res, expected.success)
+  }
+}
+
+object DirectiveMapping extends TestMapping {
+  val schema =
+    schema"""
+      type Query {
+        foo: Bar
+      }
+      type Mutation {
+        foo: Bar
+      }
+      type Subscription {
+        foo: Bar
+      }
+      interface Bar {
+        id: ID
+      }
+      type Baz implements Bar {
+        id: ID
+        baz: Int
+      }
+      directive @dir on QUERY|MUTATION|SUBSCRIPTION|FIELD|FRAGMENT_DEFINITION|FRAGMENT_SPREAD|INLINE_FRAGMENT
+    """
+
+  val QueryType = schema.queryType
+  val MutationType = schema.mutationType.get
+  val SubscriptionType = schema.subscriptionType.get
+  val BazType = schema.ref("Baz")
+
+  override val selectElaborator = PreserveArgsElaborator
+}

--- a/modules/core/src/test/scala/compiler/EnvironmentSuite.scala
+++ b/modules/core/src/test/scala/compiler/EnvironmentSuite.scala
@@ -9,8 +9,8 @@ import munit.CatsEffectSuite
 
 import edu.gemini.grackle._
 import edu.gemini.grackle.syntax._
-import Cursor.Env
-import Query._, Value._
+import Query._
+import Value._
 import QueryCompiler._
 
 object EnvironmentMapping extends ValueMapping[IO] {
@@ -76,20 +76,14 @@ object EnvironmentMapping extends ValueMapping[IO] {
     ).toResult(s"Missing argument")
   }
 
-  override val selectElaborator = new SelectElaborator(Map(
-    QueryType -> {
-      case Select("nestedSum", List(Binding("x", IntValue(x)), Binding("y", IntValue(y))), child) =>
-        Environment(Env("x" -> x, "y" -> y), Select("nestedSum", Nil, child)).success
-    },
-    NestedType -> {
-      case Select("sum", List(Binding("x", IntValue(x)), Binding("y", IntValue(y))), child) =>
-        Environment(Env("x" -> x, "y" -> y), Select("sum", Nil, child)).success
-    },
-    NestedSumType -> {
-      case Select("nestedSum", List(Binding("x", IntValue(x)), Binding("y", IntValue(y))), child) =>
-        Environment(Env("x" -> x, "y" -> y), Select("nestedSum", Nil, child)).success
-    }
-  ))
+  override val selectElaborator = SelectElaborator {
+    case (QueryType, "nestedSum", List(Binding("x", IntValue(x)), Binding("y", IntValue(y)))) =>
+      Elab.env("x" -> x, "y" -> y)
+    case (NestedType, "sum", List(Binding("x", IntValue(x)), Binding("y", IntValue(y)))) =>
+      Elab.env("x" -> x, "y" -> y)
+    case (NestedSumType, "nestedSum", List(Binding("x", IntValue(x)), Binding("y", IntValue(y)))) =>
+      Elab.env("x" -> x, "y" -> y)
+  }
 }
 
 final class EnvironmentSuite extends CatsEffectSuite {

--- a/modules/core/src/test/scala/compiler/PreserveArgsElaborator.scala
+++ b/modules/core/src/test/scala/compiler/PreserveArgsElaborator.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package compiler
+
+import edu.gemini.grackle._
+import Query._
+import QueryCompiler._
+
+object PreserveArgsElaborator extends SelectElaborator {
+  case class Preserved(args: List[Binding], directives: List[Directive])
+
+  def subst(query: Query, fieldName: String, preserved: Preserved): Query = {
+    def loop(query: Query): Query =
+      query match {
+        case Select(`fieldName`, alias, child) =>
+          UntypedSelect(fieldName, alias, preserved.args, directives = preserved.directives, child)
+        case Environment(env, child) if env.contains("preserved") => loop(child)
+        case e@Environment(_, child) => e.copy(child = loop(child))
+        case g: Group => g.copy(queries = g.queries.map(loop))
+        case t@TransformCursor(_, child) => t.copy(child = loop(child))
+        case other => other
+      }
+
+    loop(query)
+  }
+
+  override def transform(query: Query): Elab[Query] = {
+    query match {
+      case UntypedSelect(fieldName, _, _, _, _) =>
+        for {
+          t         <- super.transform(query)
+          preserved <- Elab.envE[Preserved]("preserved")
+        } yield subst(t, fieldName, preserved)
+
+      case other => super.transform(other)
+    }
+  }
+
+  def select(ref: TypeRef, name: String, args: List[Binding], directives: List[Directive]): Elab[Unit] =
+    Elab.env("preserved", Preserved(args, directives))
+}

--- a/modules/core/src/test/scala/compiler/QuerySizeSuite.scala
+++ b/modules/core/src/test/scala/compiler/QuerySizeSuite.scala
@@ -21,7 +21,7 @@ class QuerySizeSuite extends CatsEffectSuite {
     """
 
     val compiledQuery = StarWarsMapping.compiler.compile(query).toOption.get.query
-    val res = StarWarsMapping.querySizeValidator.querySize(compiledQuery)
+    val res = StarWarsMapping.querySizeValidator.querySize(compiledQuery, Map.empty)
 
     assertEquals(res, ((2,1)))
   }
@@ -37,7 +37,7 @@ class QuerySizeSuite extends CatsEffectSuite {
     """
 
     val compiledQuery = StarWarsMapping.compiler.compile(query).toOption.get.query
-    val res = StarWarsMapping.querySizeValidator.querySize(compiledQuery)
+    val res = StarWarsMapping.querySizeValidator.querySize(compiledQuery, Map.empty)
 
     assertEquals(res, ((2,2)))
   }
@@ -54,7 +54,7 @@ class QuerySizeSuite extends CatsEffectSuite {
     """
 
     val compiledQuery = StarWarsMapping.compiler.compile(query).toOption.get.query
-    val res = StarWarsMapping.querySizeValidator.querySize(compiledQuery)
+    val res = StarWarsMapping.querySizeValidator.querySize(compiledQuery, Map.empty)
 
     assertEquals(res, ((3,1)))
   }
@@ -75,7 +75,7 @@ class QuerySizeSuite extends CatsEffectSuite {
     """
 
     val compiledQuery = StarWarsMapping.compiler.compile(query).toOption.get.query
-    val res = StarWarsMapping.querySizeValidator.querySize(compiledQuery)
+    val res = StarWarsMapping.querySizeValidator.querySize(compiledQuery, Map.empty)
 
     assertEquals(res, ((4,3)))
   }
@@ -91,7 +91,7 @@ class QuerySizeSuite extends CatsEffectSuite {
     """
 
     val compiledQuery = StarWarsMapping.compiler.compile(query).toOption.get.query
-    val res = StarWarsMapping.querySizeValidator.querySize(compiledQuery)
+    val res = StarWarsMapping.querySizeValidator.querySize(compiledQuery, Map.empty)
 
     assertEquals(res, ((2,1)))
   }
@@ -108,7 +108,7 @@ class QuerySizeSuite extends CatsEffectSuite {
     """
 
     val compiledQuery = StarWarsMapping.compiler.compile(query).toOption.get.query
-    val res = StarWarsMapping.querySizeValidator.querySize(compiledQuery)
+    val res = StarWarsMapping.querySizeValidator.querySize(compiledQuery, Map.empty)
 
     assertEquals(res, ((2,1)))
   }
@@ -133,7 +133,7 @@ class QuerySizeSuite extends CatsEffectSuite {
     """
 
     val compiledQuery = StarWarsMapping.compiler.compile(query).toOption.get.query
-    val res = StarWarsMapping.querySizeValidator.querySize(compiledQuery)
+    val res = StarWarsMapping.querySizeValidator.querySize(compiledQuery, Map.empty)
 
     assertEquals(res, ((3,5)))
   }
@@ -149,7 +149,7 @@ class QuerySizeSuite extends CatsEffectSuite {
     """
 
     val compiledQuery = StarWarsMapping.compiler.compile(query).toOption.get.query
-    val res = StarWarsMapping.querySizeValidator.querySize(compiledQuery)
+    val res = StarWarsMapping.querySizeValidator.querySize(compiledQuery, Map.empty)
 
     assert(res._2 == 2)
   }
@@ -172,7 +172,7 @@ class QuerySizeSuite extends CatsEffectSuite {
     """
 
     val compiledQuery = StarWarsMapping.compiler.compile(query).toOption.get.query
-    val res = StarWarsMapping.querySizeValidator.querySize(compiledQuery)
+    val res = StarWarsMapping.querySizeValidator.querySize(compiledQuery, Map.empty)
 
     assert(res._2 == 5)
   }

--- a/modules/core/src/test/scala/compiler/ScalarsSuite.scala
+++ b/modules/core/src/test/scala/compiler/ScalarsSuite.scala
@@ -15,7 +15,8 @@ import munit.CatsEffectSuite
 
 import edu.gemini.grackle._
 import edu.gemini.grackle.syntax._
-import Query._, Predicate._, Value._
+import Query._
+import Predicate._, Value._
 import QueryCompiler._
 
 import io.circe.Encoder
@@ -168,8 +169,8 @@ object MovieMapping extends ValueMapping[IO] {
   }
 
   object GenreValue {
-    def unapply(e: TypedEnumValue): Option[Genre] =
-      Genre.fromString(e.value.name)
+    def unapply(e: EnumValue): Option[Genre] =
+      Genre.fromString(e.name)
   }
 
   object DateValue {
@@ -192,48 +193,46 @@ object MovieMapping extends ValueMapping[IO] {
       Try(Duration.parse(s.value)).toOption
   }
 
-  override val selectElaborator = new SelectElaborator(Map(
-    QueryType -> {
-      case Select("movieById", List(Binding("id", UUIDValue(id))), child) =>
-        Select("movieById", Nil, Unique(Filter(Eql(MovieType / "id", Const(id)), child))).success
-      case Select("moviesByGenre", List(Binding("genre", GenreValue(genre))), child) =>
-        Select("moviesByGenre", Nil, Filter(Eql(MovieType / "genre", Const(genre)), child)).success
-      case Select("moviesReleasedBetween", List(Binding("from", DateValue(from)), Binding("to", DateValue(to))), child) =>
-        Select("moviesReleasedBetween", Nil,
-          Filter(
-            And(
-              Not(Lt(MovieType / "releaseDate", Const(from))),
-              Lt(MovieType / "releaseDate", Const(to))
-            ),
-            child
-          )
-        ).success
-      case Select("moviesLongerThan", List(Binding("duration", IntervalValue(duration))), child) =>
-        Select("moviesLongerThan", Nil,
-          Filter(
-            Not(Lt(MovieType / "duration", Const(duration))),
-            child
-          )
-        ).success
-      case Select("moviesShownLaterThan", List(Binding("time", TimeValue(time))), child) =>
-        Select("moviesShownLaterThan", Nil,
-          Filter(
-            Not(Lt(MovieType / "showTime", Const(time))),
-            child
-          )
-        ).success
-      case Select("moviesShownBetween", List(Binding("from", DateTimeValue(from)), Binding("to", DateTimeValue(to))), child) =>
-        Select("moviesShownBetween", Nil,
-          Filter(
-            And(
-              Not(Lt(MovieType / "nextShowing", Const(from))),
-              Lt(MovieType / "nextShowing", Const(to))
-            ),
-            child
-          )
-        ).success
-    }
-  ))
+  override val selectElaborator = SelectElaborator {
+    case (QueryType, "movieById", List(Binding("id", UUIDValue(id)))) =>
+      Elab.transformChild(child => Unique(Filter(Eql(MovieType / "id", Const(id)), child)))
+    case (QueryType, "moviesByGenre", List(Binding("genre", GenreValue(genre)))) =>
+      Elab.transformChild(child => Filter(Eql(MovieType / "genre", Const(genre)), child))
+    case (QueryType, "moviesReleasedBetween", List(Binding("from", DateValue(from)), Binding("to", DateValue(to)))) =>
+      Elab.transformChild(child =>
+        Filter(
+          And(
+            Not(Lt(MovieType / "releaseDate", Const(from))),
+            Lt(MovieType / "releaseDate", Const(to))
+          ),
+          child
+        )
+      )
+    case (QueryType, "moviesLongerThan", List(Binding("duration", IntervalValue(duration)))) =>
+      Elab.transformChild(child =>
+        Filter(
+          Not(Lt(MovieType / "duration", Const(duration))),
+          child
+        )
+      )
+    case (QueryType, "moviesShownLaterThan", List(Binding("time", TimeValue(time)))) =>
+      Elab.transformChild(child =>
+        Filter(
+          Not(Lt(MovieType / "showTime", Const(time))),
+          child
+        )
+      )
+    case (QueryType, "moviesShownBetween", List(Binding("from", DateTimeValue(from)), Binding("to", DateTimeValue(to)))) =>
+      Elab.transformChild(child =>
+        Filter(
+          And(
+            Not(Lt(MovieType / "nextShowing", Const(from))),
+            Lt(MovieType / "nextShowing", Const(to))
+          ),
+          child
+        )
+      )
+  }
 }
 
 final class ScalarsSuite extends CatsEffectSuite {

--- a/modules/core/src/test/scala/compiler/SkipIncludeSuite.scala
+++ b/modules/core/src/test/scala/compiler/SkipIncludeSuite.scala
@@ -38,8 +38,8 @@ final class SkipIncludeSuite extends CatsEffectSuite {
 
     val expected =
       Group(List(
-        Rename("b", Select("field", Nil, Select("subfieldB", Nil, Empty))),
-        Rename("c", Select("field", Nil, Select("subfieldA", Nil, Empty)))
+        Select("field", Some("b"), Select("subfieldB")),
+        Select("field", Some("c"), Select("subfieldA"))
       ))
 
     val compiled = SkipIncludeMapping.compiler.compile(query, untypedVars = Some(variables))
@@ -79,24 +79,20 @@ final class SkipIncludeSuite extends CatsEffectSuite {
 
     val expected =
       Group(List(
-        Rename("a", Select("field", Nil, Empty)),
-        Rename("b",
-          Select("field", Nil,
-            Group(List(
-              Select("subfieldA", Nil, Empty),
-              Select("subfieldB", Nil, Empty)
-            ))
-          )
+        Select("field", Some("a")),
+        Select("field", Some("b"),
+          Group(List(
+            Select("subfieldA"),
+            Select("subfieldB")
+          ))
         ),
-        Rename("c",
-          Select("field", Nil,
-            Group(List(
-              Select("subfieldA", Nil, Empty),
-              Select("subfieldB", Nil, Empty)
-            ))
-          )
+        Select("field", Some("c"),
+          Group(List(
+            Select("subfieldA"),
+            Select("subfieldB")
+          ))
         ),
-        Rename("d", Select("field", Nil, Empty))
+        Select("field", Some("d"))
       ))
 
     val compiled = SkipIncludeMapping.compiler.compile(query, untypedVars = Some(variables))
@@ -128,10 +124,10 @@ final class SkipIncludeSuite extends CatsEffectSuite {
     """
 
     val expected =
-      Select("field", Nil,
+      Select("field",
         Group(List(
-          Rename("b", Select("subfieldB", Nil, Empty)),
-          Rename("c", Select("subfieldA", Nil, Empty))
+          Select("subfieldB", Some("b")),
+          Select("subfieldA", Some("c"))
         ))
       )
 
@@ -179,24 +175,20 @@ final class SkipIncludeSuite extends CatsEffectSuite {
 
     val expected =
       Group(List(
-        Rename("a", Select("field", Nil, Empty)),
-        Rename("b",
-          Select("field", Nil,
-            Group(List(
-              Select("subfieldA", Nil, Empty),
-              Select("subfieldB", Nil, Empty)
-            ))
-          )
+        Select("field", Some("a")),
+        Select("field", Some("b"),
+          Group(List(
+            Select("subfieldA"),
+            Select("subfieldB")
+          ))
         ),
-        Rename("c",
-          Select("field", Nil,
-            Group(List(
-              Select("subfieldA", Nil, Empty),
-              Select("subfieldB", Nil, Empty)
-            ))
-          )
+        Select("field", Some("c"),
+          Group(List(
+            Select("subfieldA"),
+            Select("subfieldB")
+          ))
         ),
-        Rename("d", Select("field", Nil, Empty))
+        Select("field", Some("d"))
       ))
 
     val compiled = SkipIncludeMapping.compiler.compile(query, untypedVars = Some(variables))
@@ -226,10 +218,10 @@ final class SkipIncludeSuite extends CatsEffectSuite {
     """
 
     val expected =
-      Select("field", Nil,
+      Select("field",
         Group(List(
-          Rename("b", Select("subfieldB", Nil, Empty)),
-          Rename("c", Select("subfieldA", Nil, Empty))
+          Select("subfieldB", Some("b")),
+          Select("subfieldA", Some("c"))
         ))
       )
 

--- a/modules/core/src/test/scala/compiler/VariablesSuite.scala
+++ b/modules/core/src/test/scala/compiler/VariablesSuite.scala
@@ -9,8 +9,8 @@ import munit.CatsEffectSuite
 
 import edu.gemini.grackle._
 import edu.gemini.grackle.syntax._
-import Query._, Value._
-import QueryCompiler._
+import Query._
+import Value._
 
 final class VariablesSuite extends CatsEffectSuite {
   test("simple variables query") {
@@ -31,11 +31,11 @@ final class VariablesSuite extends CatsEffectSuite {
     """
 
     val expected =
-      Select("user", List(Binding("id", IDValue("4"))),
+      UntypedSelect("user", None, List(Binding("id", IDValue("4"))), Nil,
         Group(List(
-          Select("id", Nil, Empty),
-          Select("name", Nil, Empty),
-          Select("profilePic", List(Binding("size", IntValue(60))), Empty)
+          UntypedSelect("id", None, Nil, Nil, Empty),
+          UntypedSelect("name", None, Nil, Nil, Empty),
+          UntypedSelect("profilePic", None, List(Binding("size", IntValue(60))), Nil, Empty)
         ))
       )
 
@@ -60,9 +60,10 @@ final class VariablesSuite extends CatsEffectSuite {
     """
 
     val expected =
-      Select("users",
+      UntypedSelect("users", None,
         List(Binding("ids", ListValue(List(IDValue("1"), IDValue("2"), IDValue("3"))))),
-        Select("name", Nil, Empty)
+        Nil,
+        UntypedSelect("name", None, Nil, Nil, Empty)
       )
 
     val compiled = VariablesMapping.compiler.compile(query, untypedVars = Some(variables))
@@ -86,9 +87,10 @@ final class VariablesSuite extends CatsEffectSuite {
     """
 
     val expected =
-      Select("usersByType",
-        List(Binding("userType", TypedEnumValue(EnumValue("ADMIN", None, false, None)))),
-        Select("name", Nil, Empty)
+      UntypedSelect("usersByType", None,
+        List(Binding("userType", EnumValue("ADMIN"))),
+        Nil,
+        UntypedSelect("name", None, Nil, Nil, Empty)
       )
 
     val compiled = VariablesMapping.compiler.compile(query, untypedVars = Some(variables))
@@ -112,9 +114,10 @@ final class VariablesSuite extends CatsEffectSuite {
     """
 
     val expected =
-      Select("usersLoggedInByDate",
+      UntypedSelect("usersLoggedInByDate", None,
         List(Binding("date", StringValue("2021-02-22"))),
-        Select("name", Nil, Empty)
+        Nil,
+        UntypedSelect("name", None, Nil, Nil, Empty)
       )
 
     val compiled = VariablesMapping.compiler.compile(query, untypedVars = Some(variables))
@@ -138,9 +141,10 @@ final class VariablesSuite extends CatsEffectSuite {
     """
 
     val expected =
-      Select("queryWithBigDecimal",
+      UntypedSelect("queryWithBigDecimal", None,
         List(Binding("input", IntValue(2021))),
-        Select("name", Nil, Empty)
+        Nil,
+        UntypedSelect("name", None, Nil, Nil, Empty)
       )
 
     val compiled = VariablesMapping.compiler.compile(query, untypedVars = Some(variables))
@@ -169,7 +173,7 @@ final class VariablesSuite extends CatsEffectSuite {
     """
 
     val expected =
-      Select("search",
+      UntypedSelect("search", None,
         List(Binding("pattern",
           ObjectValue(List(
             ("name", StringValue("Foo")),
@@ -179,9 +183,10 @@ final class VariablesSuite extends CatsEffectSuite {
             ("date", AbsentValue)
           ))
         )),
+        Nil,
         Group(List(
-          Select("name", Nil, Empty),
-          Select("id", Nil, Empty)
+          UntypedSelect("name", None, Nil, Nil, Empty),
+          UntypedSelect("id", None, Nil, Nil, Empty)
         ))
       )
 
@@ -211,7 +216,7 @@ final class VariablesSuite extends CatsEffectSuite {
       }
     """
 
-    val expected = Problem("Unknown field(s) 'quux' in input object value of type Pattern")
+    val expected = Problem("Unknown field(s) 'quux' in input object value of type Pattern in variable values")
 
     val compiled = VariablesMapping.compiler.compile(query, untypedVars = Some(variables))
 
@@ -234,9 +239,10 @@ final class VariablesSuite extends CatsEffectSuite {
     """
 
     val expected =
-      Select("users",
+      UntypedSelect("users", None,
         List(Binding("ids", ListValue(List(IDValue("1"), IDValue("2"), IDValue("3"))))),
-        Select("name", Nil, Empty)
+        Nil,
+        UntypedSelect("name", None, Nil, Nil, Empty)
       )
 
     val compiled = VariablesMapping.compiler.compile(query, untypedVars = Some(variables))
@@ -261,7 +267,7 @@ final class VariablesSuite extends CatsEffectSuite {
     """
 
     val expected =
-      Select("search",
+      UntypedSelect("search", None,
         List(Binding("pattern",
           ObjectValue(List(
             ("name", StringValue("Foo")),
@@ -271,9 +277,10 @@ final class VariablesSuite extends CatsEffectSuite {
             ("date", AbsentValue)
           ))
         )),
+        Nil,
         Group(List(
-          Select("name", Nil, Empty),
-          Select("id", Nil, Empty)
+          UntypedSelect("name", None, Nil, Nil, Empty),
+          UntypedSelect("id", None, Nil, Nil, Empty)
         ))
       )
 
@@ -299,19 +306,20 @@ final class VariablesSuite extends CatsEffectSuite {
     """
 
     val expected =
-      Select("search",
+      UntypedSelect("search", None,
         List(Binding("pattern",
           ObjectValue(List(
             ("name", StringValue("Foo")),
             ("age", IntValue(23)),
             ("id", IDValue("123")),
-            ("userType", TypedEnumValue(EnumValue("ADMIN", None, false, None))),
+            ("userType", EnumValue("ADMIN")),
             ("date", AbsentValue)
           ))
         )),
+        Nil,
         Group(List(
-          Select("name", Nil, Empty),
-          Select("id", Nil, Empty)
+          UntypedSelect("name", None, Nil, Nil, Empty),
+          UntypedSelect("id", None, Nil, Nil, Empty)
         ))
       )
 
@@ -337,7 +345,7 @@ final class VariablesSuite extends CatsEffectSuite {
     """
 
     val expected =
-      Select("search",
+      UntypedSelect("search", None,
         List(Binding("pattern",
           ObjectValue(List(
             ("name", StringValue("Foo")),
@@ -347,9 +355,10 @@ final class VariablesSuite extends CatsEffectSuite {
             ("date", StringValue("2021-02-22"))
           ))
         )),
+        Nil,
         Group(List(
-          Select("name", Nil, Empty),
-          Select("id", Nil, Empty)
+          UntypedSelect("name", None, Nil, Nil, Empty),
+          UntypedSelect("id", None, Nil, Nil, Empty)
         ))
       )
 
@@ -390,9 +399,5 @@ object VariablesMapping extends TestMapping {
       scalar BigDecimal
     """
 
-  val QueryType = schema.ref("Query")
-
-  override val selectElaborator = new SelectElaborator(Map(
-    QueryType -> PartialFunction.empty
-  ))
+  override val selectElaborator = PreserveArgsElaborator
 }

--- a/modules/core/src/test/scala/directives/DirectiveValidationSuite.scala
+++ b/modules/core/src/test/scala/directives/DirectiveValidationSuite.scala
@@ -1,0 +1,369 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package directives
+
+import cats.MonadThrow
+import cats.data.Chain
+import cats.effect.IO
+import cats.implicits._
+import munit.CatsEffectSuite
+
+import compiler.PreserveArgsElaborator
+import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
+import Query._
+
+final class DirectiveValidationSuite extends CatsEffectSuite {
+  test("Schema with validly located directives") {
+    val schema =
+      Schema(
+        """
+          schema @onSchema {
+            query: Query @onFieldDefinition
+          }
+
+          type Query @onObject {
+            field: Interface @onFieldDefinition
+          }
+
+          interface Interface @onInterface {
+            field: String @onFieldDefinition
+          }
+
+          type Object1 implements Interface @onObject {
+            field: String @onFieldDefinition
+            fieldWithArg(arg: Input @onArgumentDefinition): String @onFieldDefinition
+            unionField: Union @onFieldDefinition
+            enumField: Enum @onFieldDefinition
+            scalarField: Scalar @onFieldDefinition
+          }
+
+          type Object2 implements Interface @onObject {
+            field: String @onFieldDefinition
+          }
+
+          union Union @onUnion = Object1 | Object2
+
+          enum Enum @onEnum {
+            FOO @onEnumValue
+            BAR @onEnumValue
+          }
+
+          scalar Scalar @onScalar
+
+          input Input @onInputObject {
+            field: String @onInputFieldDefinition
+          }
+
+          directive @onSchema on SCHEMA
+          directive @onScalar on SCALAR
+          directive @onObject on OBJECT
+          directive @onFieldDefinition on FIELD_DEFINITION
+          directive @onArgumentDefinition on ARGUMENT_DEFINITION
+          directive @onInterface on INTERFACE
+          directive @onUnion on UNION
+          directive @onEnum on ENUM
+          directive @onEnumValue on ENUM_VALUE
+          directive @onInputObject on INPUT_OBJECT
+          directive @onInputFieldDefinition on INPUT_FIELD_DEFINITION
+        """
+      )
+
+    assertEquals(schema.toProblems, Chain.empty)
+  }
+
+  test("Schema with invalidly located directives") {
+    val schema =
+      Schema(
+        """
+          schema @onFieldDefinition {
+            query: Query @onSchema
+          }
+
+          type Query @onSchema {
+            field: Interface @onSchema
+          }
+
+          interface Interface @onSchema {
+            field: String @onSchema
+          }
+
+          type Object1 implements Interface @onSchema {
+            field: String @onSchema
+            fieldWithArg(arg: Input @onSchema): String @onSchema
+            unionField: Union @onSchema
+            enumField: Enum @onSchema
+            scalarField: Scalar @onSchema
+          }
+
+          type Object2 implements Interface @onSchema {
+            field: String @onSchema
+          }
+
+          union Union @onSchema = Object1 | Object2
+
+          enum Enum @onSchema {
+            FOO @onSchema
+            BAR @onSchema
+          }
+
+          scalar Scalar @onSchema
+
+          input Input @onSchema {
+            field: String @onSchema
+          }
+
+          directive @onSchema on SCHEMA
+          directive @onFieldDefinition on FIELD_DEFINITION
+        """
+      )
+
+    val problems =
+      Chain(
+        Problem("Directive 'onFieldDefinition' is not allowed on SCHEMA"),
+        Problem("Directive 'onSchema' is not allowed on FIELD_DEFINITION"),
+        Problem("Directive 'onSchema' is not allowed on OBJECT"),
+        Problem("Directive 'onSchema' is not allowed on FIELD_DEFINITION"),
+        Problem("Directive 'onSchema' is not allowed on INTERFACE"),
+        Problem("Directive 'onSchema' is not allowed on FIELD_DEFINITION"),
+        Problem("Directive 'onSchema' is not allowed on OBJECT"),
+        Problem("Directive 'onSchema' is not allowed on FIELD_DEFINITION"),
+        Problem("Directive 'onSchema' is not allowed on FIELD_DEFINITION"),
+        Problem("Directive 'onSchema' is not allowed on ARGUMENT_DEFINITION"),
+        Problem("Directive 'onSchema' is not allowed on FIELD_DEFINITION"),
+        Problem("Directive 'onSchema' is not allowed on FIELD_DEFINITION"),
+        Problem("Directive 'onSchema' is not allowed on FIELD_DEFINITION"),
+        Problem("Directive 'onSchema' is not allowed on OBJECT"),
+        Problem("Directive 'onSchema' is not allowed on FIELD_DEFINITION"),
+        Problem("Directive 'onSchema' is not allowed on UNION"),
+        Problem("Directive 'onSchema' is not allowed on ENUM"),
+        Problem("Directive 'onSchema' is not allowed on ENUM_VALUE"),
+        Problem("Directive 'onSchema' is not allowed on ENUM_VALUE"),
+        Problem("Directive 'onSchema' is not allowed on SCALAR"),
+        Problem("Directive 'onSchema' is not allowed on INPUT_OBJECT"),
+        Problem("Directive 'onSchema' is not allowed on INPUT_FIELD_DEFINITION")
+      )
+
+    assertEquals(schema.toProblems, problems)
+  }
+
+  test("Schema with invalid directive arguments") {
+    val schema =
+      Schema(
+        """
+          type Query {
+            f1: Int @withArg(i: 1)
+            f2: Int @withArg
+            f3: Int @withArg(i: "foo")
+            f4: Int @withArg(x: "foo")
+            f5: Int @withRequiredArg(i: 1)
+            f6: Int @withRequiredArg
+            f7: Int @withRequiredArg(i: "foo")
+            f8: Int @withRequiredArg(x: "foo")
+            f9: Int @deprecated(reason: "foo")
+            f10: Int @deprecated
+            f11: Int @deprecated(reason: 1)
+            f12: Int @deprecated(x: "foo")
+          }
+
+          directive @withArg(i: Int) on FIELD_DEFINITION
+          directive @withRequiredArg(i: Int!) on FIELD_DEFINITION
+        """
+      )
+
+    val problems =
+      Chain(
+        Problem("""Expected Int found '"foo"' for 'i' in directive withArg"""),
+        Problem("""Unknown argument(s) 'x' in directive withArg"""),
+        Problem("""Value of type Int required for 'i' in directive withRequiredArg"""),
+        Problem("""Expected Int found '"foo"' for 'i' in directive withRequiredArg"""),
+        Problem("""Unknown argument(s) 'x' in directive withRequiredArg"""),
+        Problem("""Expected String found '1' for 'reason' in directive deprecated"""),
+        Problem("""Unknown argument(s) 'x' in directive deprecated"""),
+      )
+
+    assertEquals(schema.toProblems, problems)
+  }
+
+  test("Query with validly located directives") {
+    val expected =
+      List(
+        Operation(
+          UntypedSelect("foo", None, Nil, List(Directive("onField", Nil)),
+            Group(
+              List(
+                UntypedSelect("bar",None, Nil, List(Directive("onField", Nil)), Empty),
+                UntypedSelect("bar",None, Nil, List(Directive("onField", Nil)), Empty)
+              )
+            )
+          ),
+          ExecutableDirectiveMapping.QueryType,
+          List(Directive("onQuery",List()))
+        ),
+        Operation(
+          UntypedSelect("foo",None, Nil, List(Directive("onField", Nil)), Empty),
+          ExecutableDirectiveMapping.MutationType,
+          List(Directive("onMutation",List()))
+        ),
+        Operation(
+          UntypedSelect("foo",None, Nil, List(Directive("onField", Nil)), Empty),
+          ExecutableDirectiveMapping.SubscriptionType,
+          List(Directive("onSubscription",List()))
+        )
+      )
+
+    val query =
+      """|query ($var: Boolean @onVariableDefinition) @onQuery {
+         |  foo @onField {
+         |    ...Frag @onFragmentSpread
+         |    ... @onInlineFragment {
+         |      bar @onField
+         |    }
+         |  }
+         |}
+         |
+         |mutation @onMutation {
+         |  foo @onField
+         |}
+         |
+         |subscription @onSubscription {
+         |  foo @onField
+         |}
+         |
+         |fragment Frag on Foo @onFragmentDefinition {
+         |  bar @onField
+         |}
+         |""".stripMargin
+
+    val res = ExecutableDirectiveMapping.compileAllOperations(query)
+    //println(res)
+
+    assertEquals(res, expected.success)
+  }
+
+  test("Query with invalidly located directives") {
+    val problems =
+      Chain(
+        Problem("Directive 'onField' is not allowed on VARIABLE_DEFINITION"),
+        Problem("Directive 'onField' is not allowed on QUERY"),
+        Problem("Directive 'onQuery' is not allowed on FIELD"),
+        Problem("Directive 'onField' is not allowed on FRAGMENT_SPREAD"),
+        Problem("Directive 'onField' is not allowed on INLINE_FRAGMENT"),
+        Problem("Directive 'onQuery' is not allowed on FIELD"),
+        Problem("Directive 'onField' is not allowed on FRAGMENT_DEFINITION"),
+        Problem("Directive 'onQuery' is not allowed on FIELD"),
+        Problem("Directive 'onField' is not allowed on MUTATION"),
+        Problem("Directive 'onQuery' is not allowed on FIELD"),
+        Problem("Directive 'onField' is not allowed on FRAGMENT_DEFINITION"),
+        Problem("Directive 'onQuery' is not allowed on FIELD"),
+        Problem("Directive 'onField' is not allowed on SUBSCRIPTION"),
+        Problem("Directive 'onQuery' is not allowed on FIELD"),
+        Problem("Directive 'onField' is not allowed on FRAGMENT_DEFINITION"),
+        Problem("Directive 'onQuery' is not allowed on FIELD")
+      )
+
+    val query =
+      """|query ($var: Boolean @onField) @onField {
+         |  foo @onQuery {
+         |    ...Frag @onField
+         |    ... @onField {
+         |      bar @onQuery
+         |    }
+         |  }
+         |}
+         |
+         |mutation @onField {
+         |  foo @onQuery
+         |}
+         |
+         |subscription @onField {
+         |  foo @onQuery
+         |}
+         |
+         |fragment Frag on Foo @onField {
+         |  bar @onQuery
+         |}
+         |""".stripMargin
+
+    val res = ExecutableDirectiveMapping.compileAllOperations(query)
+    //println(res)
+
+    assertEquals(res.toProblems, problems)
+  }
+
+  test("Query with invalid directive arguments") {
+    val problems =
+      Chain(
+        Problem("""Expected Int found '"foo"' for 'i' in directive withArg"""),
+        Problem("""Unknown argument(s) 'x' in directive withArg"""),
+        Problem("""Value of type Int required for 'i' in directive withRequiredArg"""),
+        Problem("""Expected Int found '"foo"' for 'i' in directive withRequiredArg"""),
+        Problem("""Unknown argument(s) 'x' in directive withRequiredArg""")
+      )
+
+    val query =
+      """|query {
+         |  foo {
+         |    b1: bar @withArg(i: 1)
+         |    b2: bar @withArg
+         |    b3: bar @withArg(i: "foo")
+         |    b4: bar @withArg(x: "foo")
+         |    b5: bar @withRequiredArg(i: 1)
+         |    b6: bar @withRequiredArg
+         |    b7: bar @withRequiredArg(i: "foo")
+         |    b8: bar @withRequiredArg(x: "foo")
+         |  }
+         |}
+         |""".stripMargin
+
+    val res = ExecutableDirectiveMapping.compileAllOperations(query)
+    //println(res)
+
+    assertEquals(res.toProblems, problems)
+  }
+}
+
+object ExecutableDirectiveMapping extends Mapping[IO] {
+  val M: MonadThrow[IO] = MonadThrow[IO]
+
+  val schema =
+    schema"""
+      type Query {
+        foo: Foo
+      }
+      type Mutation {
+        foo: String
+      }
+      type Subscription {
+        foo: String
+      }
+      type Foo {
+        bar: String
+      }
+      directive @onQuery on QUERY
+      directive @onMutation on MUTATION
+      directive @onSubscription on SUBSCRIPTION
+      directive @onField on FIELD
+      directive @onFragmentDefinition on FRAGMENT_DEFINITION
+      directive @onFragmentSpread on FRAGMENT_SPREAD
+      directive @onInlineFragment on INLINE_FRAGMENT
+      directive @onVariableDefinition on VARIABLE_DEFINITION
+
+      directive @withArg(i: Int) on FIELD
+      directive @withRequiredArg(i: Int!) on FIELD
+    """
+
+  val QueryType = schema.queryType
+  val MutationType = schema.mutationType.get
+  val SubscriptionType = schema.subscriptionType.get
+
+  val typeMappings: List[TypeMapping] = Nil
+
+  override val selectElaborator = PreserveArgsElaborator
+
+  def compileAllOperations(text: String): Result[List[Operation]] =
+    QueryParser.parseText(text).flatMap {
+      case (ops, frags) => ops.parTraverse(compiler.compileOperation(_, None, frags))
+    }
+}

--- a/modules/core/src/test/scala/directives/QueryDirectivesSuite.scala
+++ b/modules/core/src/test/scala/directives/QueryDirectivesSuite.scala
@@ -1,0 +1,198 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package directives
+
+import cats.effect.IO
+import cats.syntax.all._
+import io.circe.literal._
+import munit.CatsEffectSuite
+
+import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
+import Query._, QueryCompiler._
+
+final class QueryDirectivesSuite extends CatsEffectSuite {
+  test("simple query") {
+    val query = """
+      query {
+        user {
+          name
+          handle
+          age
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "user" : {
+            "name" : "Mary",
+            "handle" : "mary",
+            "age" : 42
+          }
+        }
+      }
+    """
+
+    val res = QueryDirectivesMapping.compileAndRun(query)
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("query with directive (1)") {
+    val query = """
+      query {
+        user {
+          name @upperCase
+          handle
+          age
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "user" : {
+            "name" : "MARY",
+            "handle" : "mary",
+            "age" : 42
+          }
+        }
+      }
+    """
+
+    val res = QueryDirectivesMapping.compileAndRun(query)
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("query with directive (2)") {
+    val query = """
+      query {
+        user {
+          name @upperCase
+          handle @upperCase
+          age
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "user" : {
+            "name" : "MARY",
+            "handle" : "MARY",
+            "age" : 42
+          }
+        }
+      }
+    """
+
+    val res = QueryDirectivesMapping.compileAndRun(query)
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("query with directive (3)") {
+    val query = """
+      query {
+        user {
+          name @upperCase
+          handle
+          age @upperCase
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "errors" : [
+          {
+            "message" : "'upperCase' directive may only be applied to fields of type String"
+          }
+        ],
+        "data" : {
+          "user" : {
+            "name" : "MARY",
+            "handle" : "mary",
+            "age" : 42
+          }
+        }
+      }
+    """
+
+    val res = QueryDirectivesMapping.compileAndRun(query)
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+}
+
+object QueryDirectivesMapping extends ValueMapping[IO] {
+  val schema =
+    schema"""
+      type Query {
+        user: User!
+      }
+      type User {
+        name: String!
+        handle: String!
+        age: Int!
+      }
+      directive @upperCase on FIELD
+    """
+
+  val QueryType = schema.ref("Query")
+  val UserType = schema.ref("User")
+
+  val typeMappings =
+    List(
+      ValueObjectMapping[Unit](
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            ValueField("user", _ => ())
+          )
+      ),
+      ValueObjectMapping[Unit](
+        tpe = UserType,
+        fieldMappings =
+          List(
+            ValueField("name", _ => "Mary"),
+            ValueField("handle", _ => "mary"),
+            ValueField("age", _ => 42)
+          )
+      )
+    )
+
+  object upperCaseElaborator extends Phase {
+    override def transform(query: Query): Elab[Query] =
+      query match {
+        case UntypedSelect(nme, alias, _, directives, _) if directives.exists(_.name == "upperCase") =>
+          for {
+            c    <- Elab.context
+            fc   <- Elab.liftR(c.forField(nme, alias))
+            res  <- if (fc.tpe =:= ScalarType.StringType)
+                      super.transform(query).map(TransformCursor(toUpperCase, _))
+                    else
+                      // We could make this fail the whole query by yielding Elab.failure here
+                      Elab.warning(s"'upperCase' directive may only be applied to fields of type String") *> super.transform(query)
+          } yield res
+        case _ =>
+          super.transform(query)
+      }
+
+    def toUpperCase(c: Cursor): Result[Cursor] =
+      FieldTransformCursor[String](c, _.toUpperCase.success).success
+  }
+
+  override def compilerPhases: List[QueryCompiler.Phase] =
+    List(upperCaseElaborator, selectElaborator, componentElaborator, effectElaborator)
+}

--- a/modules/core/src/test/scala/directives/SchemaDirectivesSuite.scala
+++ b/modules/core/src/test/scala/directives/SchemaDirectivesSuite.scala
@@ -1,0 +1,425 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package directives
+
+import cats.effect.IO
+import io.circe.literal._
+import munit.CatsEffectSuite
+
+import edu.gemini.grackle._
+import edu.gemini.grackle.syntax._
+import Cursor._, Query._, QueryCompiler._, Value._
+
+import SchemaDirectivesMapping.AuthStatus
+
+final class SchemaDirectivesSuite extends CatsEffectSuite {
+  test("No auth, success") {
+    val query = """
+      query {
+        products
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "products" : [
+            "Cheese",
+            "Wine",
+            "Bread"
+          ]
+        }
+      }
+    """
+
+    val res = SchemaDirectivesMapping.compileAndRun(query)
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("No auth, fail") {
+    val query = """
+      query {
+        products
+        user {
+          name
+          email
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "errors" : [
+          {
+            "message" : "Unauthorized"
+          }
+        ]
+      }
+    """
+
+    val res = SchemaDirectivesMapping.compileAndRun(query)
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("Authenticated user, success") {
+    val query = """
+      query {
+        products
+        user {
+          name
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "products" : [
+            "Cheese",
+            "Wine",
+            "Bread"
+          ],
+          "user" : {
+            "name" : "Mary"
+          }
+        }
+      }
+    """
+
+    val res = SchemaDirectivesMapping.compileAndRun(query, env = Env("authStatus" -> AuthStatus("USER")))
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("Authenticated user, fail") {
+    val query = """
+      query {
+        products
+        user {
+          name
+          email
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "errors" : [
+          {
+            "message" : "Unauthorized"
+          }
+        ]
+      }
+    """
+
+    val res = SchemaDirectivesMapping.compileAndRun(query, env = Env("authStatus" -> AuthStatus("USER")))
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("Authenticated admin, success") {
+    val query = """
+      query {
+        products
+        user {
+          name
+          email
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "products" : [
+            "Cheese",
+            "Wine",
+            "Bread"
+          ],
+          "user" : {
+            "name" : "Mary",
+            "email" : "mary@example.com"
+          }
+        }
+      }
+    """
+
+    val res = SchemaDirectivesMapping.compileAndRun(query, env = Env("authStatus" -> AuthStatus("ADMIN")))
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("Authenticated user, warn with null") {
+    val query = """
+      query {
+        products
+        user {
+          phone
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "errors" : [
+          {
+            "message" : "Unauthorized access to field 'phone' of type 'User'"
+          }
+        ],
+        "data" : {
+          "products" : [
+            "Cheese",
+            "Wine",
+            "Bread"
+          ],
+          "user" : {
+            "phone" : null
+          }
+        }
+      }
+    """
+
+    val res = SchemaDirectivesMapping.compileAndRun(query, env = Env("authStatus" -> AuthStatus("USER")))
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("Authenticated admin, success with non-null") {
+    val query = """
+      query {
+        products
+        user {
+          phone
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "products" : [
+            "Cheese",
+            "Wine",
+            "Bread"
+          ],
+          "user" : {
+            "phone" : "123456789"
+          }
+        }
+      }
+    """
+
+    val res = SchemaDirectivesMapping.compileAndRun(query, env = Env("authStatus" -> AuthStatus("ADMIN")))
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("Mutation, authenticated user, success") {
+    val query = """
+      mutation {
+        needsBackup
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "needsBackup" : true
+        }
+      }
+    """
+
+    val res = SchemaDirectivesMapping.compileAndRun(query, env = Env("authStatus" -> AuthStatus("USER")))
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("Mutation, no auth, fail") {
+    val query = """
+      mutation {
+        needsBackup
+      }
+    """
+
+    val expected = json"""
+      {
+        "errors" : [
+          {
+            "message" : "Unauthorized"
+          }
+        ]
+      }
+    """
+
+    val res = SchemaDirectivesMapping.compileAndRun(query)
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("Mutation, authenticated admin, success") {
+    val query = """
+      mutation {
+        backup
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "backup" : true
+        }
+      }
+    """
+
+    val res = SchemaDirectivesMapping.compileAndRun(query, env = Env("authStatus" -> AuthStatus("ADMIN")))
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+
+  test("Mutation, authenticated user, fail") {
+    val query = """
+      mutation {
+        backup
+      }
+    """
+
+    val expected = json"""
+      {
+        "errors" : [
+          {
+            "message" : "Unauthorized"
+          }
+        ]
+      }
+    """
+
+    val res = SchemaDirectivesMapping.compileAndRun(query, env = Env("authStatus" -> AuthStatus("USER")))
+
+    //res.flatMap(IO.println) *>
+    assertIO(res, expected)
+  }
+}
+
+object SchemaDirectivesMapping extends ValueMapping[IO] {
+  val schema =
+    schema"""
+      type Query {
+        products: [String!]!
+        user: User! @authenticated
+      }
+
+      type Mutation @authenticated {
+        needsBackup: Boolean!
+        backup: Boolean! @hasRole(requires: ADMIN)
+      }
+
+      type User {
+        name: String!
+        email: String! @hasRole(requires: ADMIN)
+        phone: String  @hasRole(requires: ADMIN)
+      }
+
+      directive @authenticated on FIELD_DEFINITION | OBJECT
+      directive @hasRole(requires: Role = ADMIN) on FIELD_DEFINITION | OBJECT
+
+      enum Role {
+        ADMIN
+        USER
+      }
+    """
+
+  val QueryType = schema.ref("Query")
+  val MutationType = schema.ref("Mutation")
+  val UserType = schema.ref("User")
+
+  val typeMappings =
+    List(
+      ValueObjectMapping[Unit](
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            ValueField("products", _ => List("Cheese", "Wine", "Bread")),
+            ValueField("user", _ => ())
+          )
+      ),
+      ValueObjectMapping[Unit](
+        tpe = MutationType,
+        fieldMappings =
+          List(
+            ValueField("needsBackup", _ => true),
+            ValueField("backup", _ => true)
+          )
+      ),
+      ValueObjectMapping[Unit](
+        tpe = UserType,
+        fieldMappings =
+          List(
+            ValueField("name", _ => "Mary"),
+            ValueField("email", _ => "mary@example.com"),
+            ValueField("phone", _ => Some("123456789")),
+          )
+      )
+    )
+
+  case class AuthStatus(role: String)
+
+  object permissionsElaborator extends Phase {
+    override def transform(query: Query): Elab[Query] = {
+      def checkPermissions(c: Context, name: String, status: Option[AuthStatus], query: Query, nullAndWarn: Boolean): Elab[Query] = {
+        val dirs = c.tpe.directives ++ c.tpe.fieldInfo(name).map(_.directives).getOrElse(Nil)
+        val requiresAuth = dirs.exists(_.name == "authenticated")
+        val roles =
+          dirs.filter(_.name == "hasRole").flatMap(_.args.filter(_.name == "requires")).map(_.value).collect {
+            case EnumValue(role) => role
+          }
+        val requiresRole =
+          if (roles.contains("ADMIN")) Some(AuthStatus("ADMIN"))
+          else if (roles.contains("USER")) Some(AuthStatus("USER"))
+          else None
+
+        (status, requiresAuth, requiresRole) match {
+          case (None, false, None) => Elab.pure(query)
+          case (Some(_), _, None) => Elab.pure(query)
+          case (Some(AuthStatus("ADMIN")), _, _) => Elab.pure(query)
+          case (Some(AuthStatus("USER")), _, Some(AuthStatus("USER"))) =>
+            Elab.pure(query)
+          case _ =>
+            if (!nullAndWarn) Elab.failure(s"Unauthorized")
+            else
+              for {
+                _ <- Elab.warning(s"Unauthorized access to field '$name' of type '${c.tpe}'")
+              } yield TransformCursor(NullFieldCursor(_).success, query)
+        }
+      }
+
+      query match {
+        case s: UntypedSelect =>
+          for {
+            c      <- Elab.context
+            status <- Elab.env[AuthStatus]("authStatus")
+            query0 <- super.transform(query)
+            res    <- checkPermissions(c, s.name, status, query0, s.name == "phone")
+          } yield res
+
+        case _ =>
+          super.transform(query)
+      }
+    }
+  }
+
+  override def compilerPhases: List[QueryCompiler.Phase] =
+    List(permissionsElaborator, selectElaborator, componentElaborator, effectElaborator)
+}

--- a/modules/core/src/test/scala/effects/ValueEffectData.scala
+++ b/modules/core/src/test/scala/effects/ValueEffectData.scala
@@ -33,7 +33,7 @@ class ValueEffectMapping[F[_]: Sync](ref: SignallingRef[F, Int]) extends ValueMa
       fieldMappings =
         List(
           // Compute a ValueCursor
-          RootEffect.computeCursor("foo")((_, p, e) =>
+          RootEffect.computeCursor("foo")((p, e) =>
             ref.update(_+1).as(
               Result(valueCursor(p, e, Struct(42, "hi")))
             )

--- a/modules/core/src/test/scala/schema/SchemaSuite.scala
+++ b/modules/core/src/test/scala/schema/SchemaSuite.scala
@@ -13,16 +13,16 @@ final class SchemaSuite extends CatsEffectSuite {
   test("schema validation: undefined types: typo in the use of a Query result type") {
     val schema =
       Schema(
-      """
-        type Query {
-          episodeById(id: String!): Episod
-        }
+        """
+          type Query {
+            episodeById(id: String!): Episod
+          }
 
-        type Episode {
-          id: String!
-        }
-      """
-    )
+          type Episode {
+            id: String!
+          }
+        """
+      )
 
     schema match {
       case Result.Failure(ps) => assertEquals(ps.map(_.message), NonEmptyChain("Reference to undefined type 'Episod'"))
@@ -85,7 +85,7 @@ final class SchemaSuite extends CatsEffectSuite {
     )
 
     schema match {
-      case Result.Failure(ps) => assertEquals(ps.map(_.message), NonEmptyChain("Only a single deprecated allowed at a given location"))
+      case Result.Failure(ps) => assertEquals(ps.map(_.message), NonEmptyChain("Directive 'deprecated' may not occur more than once"))
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
   }
@@ -101,7 +101,7 @@ final class SchemaSuite extends CatsEffectSuite {
     )
 
     schema match {
-      case Result.Failure(ps) => assertEquals(ps.map(_.message), NonEmptyChain("deprecated must have a single String 'reason' argument, or no arguments"))
+      case Result.Failure(ps) => assertEquals(ps.map(_.message), NonEmptyChain("Unknown argument(s) 'notareason' in directive deprecated"))
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
   }
@@ -133,7 +133,15 @@ final class SchemaSuite extends CatsEffectSuite {
 
     schema match {
       case Result.Failure(ps) =>
-        assertEquals(ps.map(_.message), NonEmptyChain("Reference to undefined type 'Character'", "Reference to undefined type 'Contactable'"))
+        assertEquals(
+          ps.map(_.message),
+          NonEmptyChain(
+            "Reference to undefined type 'Character'",
+            "Reference to undefined type 'Contactable'",
+            "Non-interface type 'Character' declared as implemented by type 'Human'",
+            "Non-interface type 'Contactable' declared as implemented by type 'Human'"
+          )
+        )
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
   }

--- a/modules/core/src/test/scala/sdl/SDLSuite.scala
+++ b/modules/core/src/test/scala/sdl/SDLSuite.scala
@@ -23,9 +23,9 @@ final class SDLSuite extends CatsEffectSuite {
       List(
         SchemaDefinition(
           List(
-            RootOperationTypeDefinition(Query, Named(Name("MyQuery"))),
-            RootOperationTypeDefinition(Mutation, Named(Name("MyMutation"))),
-            RootOperationTypeDefinition(Subscription, Named(Name("MySubscription")))
+            RootOperationTypeDefinition(Query, Named(Name("MyQuery")), Nil),
+            RootOperationTypeDefinition(Mutation, Named(Name("MyMutation")), Nil),
+            RootOperationTypeDefinition(Subscription, Named(Name("MySubscription")), Nil)
           ),
           Nil
         )
@@ -195,34 +195,18 @@ final class SDLSuite extends CatsEffectSuite {
   }
 
   test("parse directive definition") {
-    val schema = """
-      "A directive"
-      directive @delegateField(name: String!) repeatable on OBJECT | INTERFACE | FIELD | FIELD_DEFINITION | ENUM | ENUM_VALUE
-    """
+    val schema =
+      """|type Query {
+         |  foo: Int
+         |}
+         |"A directive"
+         |directive @delegateField(name: String!) repeatable on OBJECT|INTERFACE|FIELD|FIELD_DEFINITION|ENUM|ENUM_VALUE
+         |""".stripMargin
 
-    val expected =
-      List(
-        DirectiveDefinition(
-          Name("delegateField"),
-          Some("A directive"),
-          List(
-            InputValueDefinition(Name("name"), None, NonNull(Left(Named(Name("String")))), None, Nil)
-          ),
-          true,
-          List(
-            DirectiveLocation.OBJECT,
-            DirectiveLocation.INTERFACE,
-            DirectiveLocation.FIELD,
-            DirectiveLocation.FIELD_DEFINITION,
-            DirectiveLocation.ENUM,
-            DirectiveLocation.ENUM_VALUE
-          )
-        )
-      )
+    val res = SchemaParser.parseText(schema)
+    val ser = res.map(_.toString)
 
-    val res = GraphQLParser.Document.parseAll(schema)
-
-    assertEquals(res, Right(expected))
+    assertEquals(ser, schema.success)
   }
 
   test("deserialize schema (1)") {

--- a/modules/doobie-pg/src/test/scala/DoobieSuites.scala
+++ b/modules/doobie-pg/src/test/scala/DoobieSuites.scala
@@ -6,9 +6,7 @@ package edu.gemini.grackle.doobie.test
 import cats.effect.IO
 import doobie.implicits._
 import doobie.Meta
-import io.circe.Json
 
-import edu.gemini.grackle.QueryExecutor
 import edu.gemini.grackle.doobie.postgres.DoobieMonitor
 import edu.gemini.grackle.sql.SqlStatsMonitor
 
@@ -21,12 +19,12 @@ final class ArrayJoinSuite extends DoobieDatabaseSuite with SqlArrayJoinSuite {
 
 final class CoalesceSuite extends DoobieDatabaseSuite with SqlCoalesceSuite {
   type Fragment = doobie.Fragment
-  def mapping: IO[(QueryExecutor[IO, Json], SqlStatsMonitor[IO,Fragment])] =
+  def mapping: IO[(Mapping[IO], SqlStatsMonitor[IO,Fragment])] =
     DoobieMonitor.statsMonitor[IO].map(mon => (new DoobieTestMapping(xa, mon) with SqlCoalesceMapping[IO], mon))
 }
 
 final class ComposedWorldSuite extends DoobieDatabaseSuite with SqlComposedWorldSuite {
-  def mapping: IO[(CurrencyMapping[IO], QueryExecutor[IO, Json])] =
+  def mapping: IO[(CurrencyMapping[IO], Mapping[IO])] =
     for {
       currencyMapping <- CurrencyMapping[IO]
     } yield (currencyMapping, new SqlComposedMapping(new DoobieTestMapping(xa) with SqlWorldMapping[IO], currencyMapping))
@@ -126,7 +124,7 @@ final class MutationSuite extends DoobieDatabaseSuite with SqlMutationSuite {
 }
 
 final class NestedEffectsSuite extends DoobieDatabaseSuite with SqlNestedEffectsSuite {
-  def mapping: IO[(CurrencyService[IO], QueryExecutor[IO, Json])] =
+  def mapping: IO[(CurrencyService[IO], Mapping[IO])] =
     for {
       currencyService0 <- CurrencyService[IO]
     } yield {

--- a/modules/generic/src/main/scala-2/genericmapping2.scala
+++ b/modules/generic/src/main/scala-2/genericmapping2.scala
@@ -13,7 +13,7 @@ import shapeless.ops.coproduct.{LiftAll => CLiftAll}
 import shapeless.ops.record.Keys
 
 import syntax._
-import Cursor.{AbstractCursor, Context, Env}
+import Cursor.AbstractCursor
 import ShapelessUtils._
 
 trait ScalaVersionSpecificGenericMappingLike[F[_]] extends Mapping[F] { self: GenericMappingLike[F] =>

--- a/modules/generic/src/main/scala-3/genericmapping3.scala
+++ b/modules/generic/src/main/scala-3/genericmapping3.scala
@@ -8,7 +8,7 @@ import cats.implicits._
 import shapeless3.deriving._
 
 import syntax._
-import Cursor.{AbstractCursor, Context, Env}
+import Cursor.AbstractCursor
 
 trait ScalaVersionSpecificGenericMappingLike[F[_]] extends Mapping[F] { self: GenericMappingLike[F] =>
   trait MkObjectCursorBuilder[T] {

--- a/modules/generic/src/main/scala/CursorBuilder.scala
+++ b/modules/generic/src/main/scala/CursorBuilder.scala
@@ -10,7 +10,7 @@ import cats.implicits._
 import io.circe.{Encoder, Json}
 
 import syntax._
-import Cursor.{AbstractCursor, Context, Env}
+import Cursor.AbstractCursor
 
 trait CursorBuilder[T] {
   def tpe: Type

--- a/modules/generic/src/main/scala/genericmapping.scala
+++ b/modules/generic/src/main/scala/genericmapping.scala
@@ -8,7 +8,7 @@ import cats.MonadThrow
 import org.tpolecat.sourcepos.SourcePos
 
 import syntax._
-import Cursor.{Context, DeferredCursor, Env}
+import Cursor.DeferredCursor
 
 abstract class GenericMapping[F[_]](implicit val M: MonadThrow[F]) extends Mapping[F] with GenericMappingLike[F]
 

--- a/modules/generic/src/test/scala/EffectsSuite.scala
+++ b/modules/generic/src/test/scala/EffectsSuite.scala
@@ -42,7 +42,7 @@ class GenericEffectMapping[F[_]: Sync](ref: SignallingRef[F, Int]) extends Gener
       fieldMappings =
         List(
           // Compute a ValueCursor
-          RootEffect.computeCursor("foo")((_, p, e) =>
+          RootEffect.computeCursor("foo")((p, e) =>
             ref.update(_+1).as(
               genericCursor(p, e, Struct(42, "hi"))
             )

--- a/modules/generic/src/test/scala/RecursionSuite.scala
+++ b/modules/generic/src/test/scala/RecursionSuite.scala
@@ -82,12 +82,10 @@ object MutualRecursionMapping extends GenericMapping[IO] {
       )
     )
 
-  override val selectElaborator = new SelectElaborator(Map(
-    QueryType -> {
-      case Select(f@("programmeById" | "productionById"), List(Binding("id", IDValue(id))), child) =>
-        Select(f, Nil, Unique(Filter(Eql(ProgrammeType / "id", Const(id)), child))).success
-    }
-  ))
+  override val selectElaborator = SelectElaborator {
+    case (QueryType, "programmeById" | "productionById", List(Binding("id", IDValue(id)))) =>
+      Elab.transformChild(child => Unique(Filter(Eql(ProgrammeType / "id", Const(id)), child)))
+  }
 }
 
 final class RecursionSuite extends CatsEffectSuite {

--- a/modules/generic/src/test/scala/ScalarsSuite.scala
+++ b/modules/generic/src/test/scala/ScalarsSuite.scala
@@ -154,8 +154,8 @@ object MovieMapping extends GenericMapping[IO] {
   }
 
   object GenreValue {
-    def unapply(e: TypedEnumValue): Option[Genre] =
-      Genre.fromString(e.value.name)
+    def unapply(e: EnumValue): Option[Genre] =
+      Genre.fromString(e.name)
   }
 
   object DateValue {
@@ -178,48 +178,46 @@ object MovieMapping extends GenericMapping[IO] {
       Try(Duration.parse(s.value)).toOption
   }
 
-  override val selectElaborator = new SelectElaborator(Map(
-    QueryType -> {
-      case Select("movieById", List(Binding("id", UUIDValue(id))), child) =>
-        Select("movieById", Nil, Unique(Filter(Eql(MovieType / "id", Const(id)), child))).success
-      case Select("moviesByGenre", List(Binding("genre", GenreValue(genre))), child) =>
-        Select("moviesByGenre", Nil, Filter(Eql(MovieType / "genre", Const(genre)), child)).success
-      case Select("moviesReleasedBetween", List(Binding("from", DateValue(from)), Binding("to", DateValue(to))), child) =>
-        Select("moviesReleasedBetween", Nil,
-          Filter(
-            And(
-              Not(Lt(MovieType / "releaseDate", Const(from))),
-              Lt(MovieType / "releaseDate", Const(to))
-            ),
-            child
-          )
-        ).success
-      case Select("moviesLongerThan", List(Binding("duration", IntervalValue(duration))), child) =>
-        Select("moviesLongerThan", Nil,
-          Filter(
-            Not(Lt(MovieType / "duration", Const(duration))),
-            child
-          )
-        ).success
-      case Select("moviesShownLaterThan", List(Binding("time", TimeValue(time))), child) =>
-        Select("moviesShownLaterThan", Nil,
-          Filter(
-            Not(Lt(MovieType / "showTime", Const(time))),
-            child
-          )
-        ).success
-      case Select("moviesShownBetween", List(Binding("from", DateTimeValue(from)), Binding("to", DateTimeValue(to))), child) =>
-        Select("moviesShownBetween", Nil,
-          Filter(
-            And(
-              Not(Lt(MovieType / "nextShowing", Const(from))),
-              Lt(MovieType / "nextShowing", Const(to))
-            ),
-            child
-          )
-        ).success
-    }
-  ))
+  override val selectElaborator = SelectElaborator {
+    case (QueryType, "movieById", List(Binding("id", UUIDValue(id)))) =>
+      Elab.transformChild(child => Unique(Filter(Eql(MovieType / "id", Const(id)), child)))
+    case (QueryType, "moviesByGenre", List(Binding("genre", GenreValue(genre)))) =>
+      Elab.transformChild(child => Filter(Eql(MovieType / "genre", Const(genre)), child))
+    case (QueryType, "moviesReleasedBetween", List(Binding("from", DateValue(from)), Binding("to", DateValue(to)))) =>
+      Elab.transformChild(child =>
+        Filter(
+          And(
+            Not(Lt(MovieType / "releaseDate", Const(from))),
+            Lt(MovieType / "releaseDate", Const(to))
+          ),
+          child
+        )
+      )
+    case (QueryType, "moviesLongerThan", List(Binding("duration", IntervalValue(duration)))) =>
+      Elab.transformChild(child =>
+        Filter(
+          Not(Lt(MovieType / "duration", Const(duration))),
+          child
+        )
+      )
+    case (QueryType, "moviesShownLaterThan", List(Binding("time", TimeValue(time)))) =>
+      Elab.transformChild(child =>
+        Filter(
+          Not(Lt(MovieType / "showTime", Const(time))),
+          child
+        )
+      )
+    case (QueryType, "moviesShownBetween", List(Binding("from", DateTimeValue(from)), Binding("to", DateTimeValue(to)))) =>
+      Elab.transformChild(child =>
+        Filter(
+          And(
+            Not(Lt(MovieType / "nextShowing", Const(from))),
+            Lt(MovieType / "nextShowing", Const(to))
+          ),
+          child
+        )
+      )
+  }
 }
 
 final class ScalarsSuite extends CatsEffectSuite {

--- a/modules/skunk/js-jvm/src/test/scala/SkunkDatabaseSuite.scala
+++ b/modules/skunk/js-jvm/src/test/scala/SkunkDatabaseSuite.scala
@@ -62,7 +62,7 @@ trait SkunkDatabaseSuite extends SqlDatabaseSuite {
 
     def list(c: Codec): Codec = {
       val cc = c._1.asInstanceOf[_root_.skunk.Codec[Any]]
-      val ty = _root_.skunk.data.Type(s"_${cc.types.head.name}", cc.types) 
+      val ty = _root_.skunk.data.Type(s"_${cc.types.head.name}", cc.types)
       val encode = (elem: Any) => cc.encode(elem).head.get
       val decode = (str: String) => cc.decode(0, List(Some(str))).left.map(_.message)
       (_root_.skunk.Codec.array(encode, decode, ty), false)

--- a/modules/skunk/js-jvm/src/test/scala/SkunkSuites.scala
+++ b/modules/skunk/js-jvm/src/test/scala/SkunkSuites.scala
@@ -6,9 +6,7 @@ package edu.gemini.grackle.skunk.test
 import cats.effect.IO
 import skunk.codec.{all => codec}
 import skunk.implicits._
-import io.circe.Json
 
-import edu.gemini.grackle.QueryExecutor
 import edu.gemini.grackle.skunk.SkunkMonitor
 import edu.gemini.grackle.sql.SqlStatsMonitor
 
@@ -23,12 +21,12 @@ final class ArrayJoinSuite extends SkunkDatabaseSuite with SqlArrayJoinSuite {
 
 final class CoalesceSuite extends SkunkDatabaseSuite with SqlCoalesceSuite {
   type Fragment = skunk.AppliedFragment
-  def mapping: IO[(QueryExecutor[IO, Json], SqlStatsMonitor[IO,Fragment])] =
+  def mapping: IO[(Mapping[IO], SqlStatsMonitor[IO,Fragment])] =
     SkunkMonitor.statsMonitor[IO].map(mon => (new SkunkTestMapping(pool, mon) with SqlCoalesceMapping[IO], mon))
 }
 
 final class ComposedWorldSuite extends SkunkDatabaseSuite with SqlComposedWorldSuite {
-  def mapping: IO[(CurrencyMapping[IO], QueryExecutor[IO, Json])] =
+  def mapping: IO[(CurrencyMapping[IO], Mapping[IO])] =
     for {
       currencyMapping <- CurrencyMapping[IO]
     } yield (currencyMapping, new SqlComposedMapping(new SkunkTestMapping(pool) with SqlWorldMapping[IO], currencyMapping))
@@ -131,7 +129,7 @@ final class MutationSuite extends SkunkDatabaseSuite with SqlMutationSuite {
 }
 
 final class NestedEffectsSuite extends SkunkDatabaseSuite with SqlNestedEffectsSuite {
-  def mapping: IO[(CurrencyService[IO], QueryExecutor[IO, Json])] =
+  def mapping: IO[(CurrencyService[IO], Mapping[IO])] =
     for {
       currencyService0 <- CurrencyService[IO]
     } yield {

--- a/modules/skunk/js-jvm/src/test/scala/subscription/SubscriptionSuite.scala
+++ b/modules/skunk/js-jvm/src/test/scala/subscription/SubscriptionSuite.scala
@@ -13,7 +13,7 @@ import skunk.implicits._
 
 import edu.gemini.grackle.skunk.test.SkunkDatabaseSuite
 
-class SubscriptionSpec extends SkunkDatabaseSuite {
+class SubscriptionSuite extends SkunkDatabaseSuite {
 
   lazy val mapping = SubscriptionMapping.mkMapping(pool)
 
@@ -61,7 +61,7 @@ class SubscriptionSpec extends SkunkDatabaseSuite {
       for {
 
         // start a fiber that subscibes and takes the first two notifications
-        fi <- mapping.compileAndRunAll(query).take(2).compile.toList.start
+        fi <- mapping.compileAndRunSubscription(query).take(2).compile.toList.start
 
         // We're racing now, so wait a sec before starting notifications
         _  <- IO.sleep(1.second)

--- a/modules/sql/shared/src/main/scala/SqlMappingValidator.scala
+++ b/modules/sql/shared/src/main/scala/SqlMappingValidator.scala
@@ -54,7 +54,7 @@ trait SqlMappingValidator extends MappingValidator {
           case NullableType(ScalarType.IDType)      if columnRef.scalaTypeName == typeName[Option[String]]  => Chain.empty
           case NullableType(ScalarType.IntType)     if columnRef.scalaTypeName == typeName[Option[Int]]     => Chain.empty
 
-          case tpe @ ScalarType(_, _) =>
+          case tpe: ScalarType =>
             typeMapping(tpe) match {
               case Some(lm: LeafMapping[_]) =>
                 if (lm.scalaTypeName == columnRef.scalaTypeName) Chain.empty

--- a/modules/sql/shared/src/test/scala/SqlArrayJoinSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlArrayJoinSuite.scala
@@ -5,14 +5,13 @@ package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
 import edu.gemini.grackle._
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlArrayJoinSuite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("base query") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlCoalesceSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlCoalesceSuite.scala
@@ -17,7 +17,7 @@ import grackle.test.GraphQLResponseTests.assertWeaklyEqual
 trait SqlCoalesceSuite extends CatsEffectSuite {
 
   type Fragment
-  def mapping: IO[(QueryExecutor[IO, Json], SqlStatsMonitor[IO, Fragment])]
+  def mapping: IO[(Mapping[IO], SqlStatsMonitor[IO, Fragment])]
 
   test("simple coalesced query") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlComposedWorldSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlComposedWorldSuite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.{assertWeaklyEqual, assertWeaklyEqualIO}
 
 trait SqlComposedWorldSuite extends CatsEffectSuite {
-  def mapping: IO[(CurrencyMapping[IO], QueryExecutor[IO, Json])]
+  def mapping: IO[(CurrencyMapping[IO], Mapping[IO])]
 
   test("simple effectful query") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlCompositeKeySuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlCompositeKeySuite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlCompositeKeySuite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("root query") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlCursorJsonMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlCursorJsonMapping.scala
@@ -90,10 +90,8 @@ trait SqlCursorJsonMapping[F[_]] extends SqlTestMapping[F] {
       PrimitiveMapping(CategoryType)
     )
 
-  override val selectElaborator = new SelectElaborator(Map(
-    QueryType -> {
-      case Select("brands", List(Binding("id", IntValue(id))), child) =>
-        Select("brands", Nil, Unique(Filter(Eql(BrandType / "id", Const(id)), child))).success
-    }
-  ))
+  override val selectElaborator = SelectElaborator {
+    case (QueryType, "brands", List(Binding("id", IntValue(id)))) =>
+      Elab.transformChild(child => Unique(Filter(Eql(BrandType / "id", Const(id)), child)))
+  }
 }

--- a/modules/sql/shared/src/test/scala/SqlCursorJsonSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlCursorJsonSuite.scala
@@ -3,7 +3,6 @@
 
 package edu.gemini.grackle.sql.test
 
-import io.circe.Json
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
@@ -12,8 +11,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlCursorJsonSuite extends CatsEffectSuite {
-
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("cursor field returns json") {
     val query =
@@ -43,7 +41,6 @@ trait SqlCursorJsonSuite extends CatsEffectSuite {
     """
 
     val res = mapping.compileAndRun(query)
-
 
     assertWeaklyEqualIO(res, expected)
   }

--- a/modules/sql/shared/src/test/scala/SqlEmbedding2Suite.scala
+++ b/modules/sql/shared/src/test/scala/SqlEmbedding2Suite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlEmbedding2Suite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("paging") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlEmbedding3Suite.scala
+++ b/modules/sql/shared/src/test/scala/SqlEmbedding3Suite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlEmbedding3Suite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("paging") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlEmbeddingSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlEmbeddingSuite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlEmbeddingSuite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("simple embedded query (1)") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlFilterOrderOffsetLimit2Suite.scala
+++ b/modules/sql/shared/src/test/scala/SqlFilterOrderOffsetLimit2Suite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlFilterOrderOffsetLimit2Suite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("base query") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlFilterOrderOffsetLimitSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlFilterOrderOffsetLimitSuite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlFilterOrderOffsetLimitSuite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("base query") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlGraphMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlGraphMapping.scala
@@ -70,12 +70,8 @@ trait SqlGraphMapping[F[_]] extends SqlTestMapping[F] {
       )
     )
 
-  override val selectElaborator: SelectElaborator = new SelectElaborator(Map(
-    QueryType -> {
-      case Select("node", List(Binding("id", IntValue(id))), child) =>
-        Select("node", Nil, Unique(Filter(Eql(NodeType / "id", Const(id)), child))).success
-
-      case other => other.success
-    }
-  ))
+  override val selectElaborator = SelectElaborator {
+    case (QueryType, "node", List(Binding("id", IntValue(id)))) =>
+      Elab.transformChild(child => Unique(Filter(Eql(NodeType / "id", Const(id)), child)))
+  }
 }

--- a/modules/sql/shared/src/test/scala/SqlGraphSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlGraphSuite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlGraphSuite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("root query") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlInterfacesMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlInterfacesMapping.scala
@@ -199,12 +199,10 @@ trait SqlInterfacesMapping[F[_]] extends SqlTestMapping[F] { self =>
     }
   }
 
-  override val selectElaborator = new SelectElaborator(Map(
-    QueryType -> {
-      case Select("films", Nil, child) =>
-        Select("films", Nil, Filter(Eql[EntityType](FilmType / "entityType", Const(EntityType.Film)), child)).success
-    }
-  ))
+  override val selectElaborator = SelectElaborator {
+    case (QueryType, "films", Nil) =>
+      Elab.transformChild(child => Filter(Eql[EntityType](FilmType / "entityType", Const(EntityType.Film)), child))
+  }
 
   sealed trait EntityType extends Product with Serializable
   object EntityType {

--- a/modules/sql/shared/src/test/scala/SqlInterfacesSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlInterfacesSuite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlInterfacesSuite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("simple interface query") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlInterfacesSuite2.scala
+++ b/modules/sql/shared/src/test/scala/SqlInterfacesSuite2.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlInterfacesSuite2 extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("when discriminator fails the fragments should be ignored") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlJsonbMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlJsonbMapping.scala
@@ -84,10 +84,8 @@ trait SqlJsonbMapping[F[_]] extends SqlTestMapping[F] {
       ),
     )
 
-  override val selectElaborator = new SelectElaborator(Map(
-    QueryType -> {
-      case Select("record", List(Binding("id", IntValue(id))), child) =>
-        Select("record", Nil, Unique(Filter(Eql(RowType / "id", Const(id)), child))).success
-    }
-  ))
+  override val selectElaborator = SelectElaborator {
+    case (QueryType, "record", List(Binding("id", IntValue(id)))) =>
+      Elab.transformChild(child => Unique(Filter(Eql(RowType / "id", Const(id)), child)))
+  }
 }

--- a/modules/sql/shared/src/test/scala/SqlJsonbSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlJsonbSuite.scala
@@ -3,7 +3,6 @@
 
 package edu.gemini.grackle.sql.test
 
-import io.circe.Json
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
@@ -14,7 +13,7 @@ import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlJsonbSuite extends CatsEffectSuite {
 
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("simple jsonb query") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlLikeSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlLikeSuite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -12,7 +11,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlLikeSuite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("No filter") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlMixedMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlMixedMapping.scala
@@ -89,10 +89,8 @@ trait SqlMixedMapping[F[_]] extends SqlTestMapping[F] with ValueMappingLike[F] {
       Try(UUID.fromString(s.value)).toOption
   }
 
-  override val selectElaborator = new SelectElaborator(Map(
-    QueryType -> {
-      case Select("movie", List(Binding("id", UUIDValue(id))), child) =>
-        Select("movie", Nil, Unique(Filter(Eql(MovieType / "id", Const(id)), child))).success
-    }
-  ))
+  override val selectElaborator = SelectElaborator {
+    case (QueryType, "movie", List(Binding("id", UUIDValue(id)))) =>
+      Elab.transformChild(child => Unique(Filter(Eql(MovieType / "id", Const(id)), child)))
+  }
 }

--- a/modules/sql/shared/src/test/scala/SqlMixedSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlMixedSuite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlMixedSuite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("DB query") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlMovieSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlMovieSuite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -14,7 +13,7 @@ import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlMovieSuite extends CatsEffectSuite {
 
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("query with UUID argument and custom scalar results") {
     val query = """
@@ -455,7 +454,7 @@ trait SqlMovieSuite extends CatsEffectSuite {
       {
         "errors" : [
           {
-            "message" : "Unknown field 'isLong' in select"
+            "message" : "No field 'isLong' for type Movie"
           }
         ]
       }

--- a/modules/sql/shared/src/test/scala/SqlMutationSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlMutationSuite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -14,7 +13,7 @@ import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlMutationSuite extends CatsEffectSuite {
 
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("simple read") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlNestedEffectsSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlNestedEffectsSuite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.{assertWeaklyEqual, assertWeaklyEqualIO}
 
 trait SqlNestedEffectsSuite extends CatsEffectSuite {
-  def mapping: IO[(CurrencyService[IO], QueryExecutor[IO, Json])]
+  def mapping: IO[(CurrencyService[IO], Mapping[IO])]
 
   test("simple effectful service call") {
     val expected = json"""

--- a/modules/sql/shared/src/test/scala/SqlNestedEffectsSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlNestedEffectsSuite.scala
@@ -35,7 +35,39 @@ trait SqlNestedEffectsSuite extends CatsEffectSuite {
     assertWeaklyEqualIO(res, expected)
   }
 
-  test("simple composed query") {
+  test("simple composed query (1)") {
+    val query = """
+      query {
+        country(code: "GBR") {
+          currencies {
+            code
+            exchangeRate
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "country" : {
+            "currencies": [
+              {
+                "code": "GBP",
+                "exchangeRate": 1.25
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = mapping.flatMap(_._2.compileAndRun(query))
+
+    assertWeaklyEqualIO(res, expected)
+  }
+
+  test("simple composed query (2)") {
     val query = """
       query {
         country(code: "GBR") {

--- a/modules/sql/shared/src/test/scala/SqlPaging1Suite.scala
+++ b/modules/sql/shared/src/test/scala/SqlPaging1Suite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlPaging1Suite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("paging (initial)") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlPaging2Suite.scala
+++ b/modules/sql/shared/src/test/scala/SqlPaging2Suite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlPaging2Suite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("paging (initial)") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlPaging3Suite.scala
+++ b/modules/sql/shared/src/test/scala/SqlPaging3Suite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlPaging3Suite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("paging (initial)") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlProjectionSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlProjectionSuite.scala
@@ -4,16 +4,15 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle.QueryExecutor
+import edu.gemini.grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlProjectionSuite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("base query") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlRecursiveInterfacesSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlRecursiveInterfacesSuite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlRecursiveInterfacesSuite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("specialized query on both sides") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlSiblingListsMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlSiblingListsMapping.scala
@@ -4,11 +4,12 @@
 package edu.gemini.grackle.sql.test
 
 import cats.implicits._
-import edu.gemini.grackle.Predicate.{Const, Eql}
-import edu.gemini.grackle.Query.{Binding, Filter, Select, Unique}
-import edu.gemini.grackle.syntax._
-import edu.gemini.grackle.QueryCompiler.SelectElaborator
-import edu.gemini.grackle.Value.StringValue
+import edu.gemini.grackle._
+import Predicate.{Const, Eql}
+import Query.{Binding, Filter, Unique}
+import QueryCompiler._
+import Value.StringValue
+import syntax._
 
 trait SqlSiblingListsData[F[_]] extends SqlTestMapping[F] {
 
@@ -104,14 +105,8 @@ trait SqlSiblingListsData[F[_]] extends SqlTestMapping[F] {
       )
     )
 
-  override val selectElaborator: SelectElaborator = new SelectElaborator(
-    Map(
-      QueryType -> {
-        case Select("a", List(Binding("id", StringValue(id))), child) =>
-          Select("a", Nil, Unique(Filter(Eql(AType / "id", Const(id)), child))).success
-        case other => other.success
-      }
-    )
-  )
-
+  override val selectElaborator = SelectElaborator {
+    case (QueryType, "a", List(Binding("id", StringValue(id)))) =>
+      Elab.transformChild(child => Unique(Filter(Eql(AType / "id", Const(id)), child)))
+  }
 }

--- a/modules/sql/shared/src/test/scala/SqlSiblingListsSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlSiblingListsSuite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlSiblingListsSuite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("base query") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlTreeMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlTreeMapping.scala
@@ -53,12 +53,8 @@ trait SqlTreeMapping[F[_]] extends SqlTestMapping[F] {
       )
     )
 
-  override val selectElaborator: SelectElaborator = new SelectElaborator(Map(
-    QueryType -> {
-      case Select("bintree", List(Binding("id", IntValue(id))), child) =>
-        Select("bintree", Nil, Unique(Filter(Eql(BinTreeType / "id", Const(id)), child))).success
-
-      case other => other.success
-    }
-  ))
+  override val selectElaborator = SelectElaborator {
+    case (QueryType, "bintree", List(Binding("id", IntValue(id)))) =>
+      Elab.transformChild(child => Unique(Filter(Eql(BinTreeType / "id", Const(id)), child)))
+  }
 }

--- a/modules/sql/shared/src/test/scala/SqlTreeSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlTreeSuite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlTreeSuite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("root query") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlUnionSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlUnionSuite.scala
@@ -4,7 +4,6 @@
 package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -13,7 +12,7 @@ import edu.gemini.grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlUnionSuite extends CatsEffectSuite {
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("simple union query") {
     val query = """

--- a/modules/sql/shared/src/test/scala/SqlWorldCompilerSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlWorldCompilerSuite.scala
@@ -9,7 +9,7 @@ import io.circe.literal._
 import munit.CatsEffectSuite
 
 import edu.gemini.grackle._
-import Predicate._
+import Predicate._, Query._
 import sql.{Like, SqlStatsMonitor}
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqual
@@ -62,7 +62,7 @@ trait SqlWorldCompilerSuite extends CatsEffectSuite {
       assertEquals(stats,
         List(
           SqlStatsMonitor.SqlStats(
-            Query.Select("country", Nil, Query.Unique(Query.Filter(Eql(schema.ref("Country") / "code",Const("GBR")),Query.Select("name",List(),Query.Empty)))),
+            Select("country", Unique(Filter(Eql(schema.ref("Country") / "code",Const("GBR")), Select("name")))),
             simpleRestrictedQuerySql,
             List("GBR"),
             1,
@@ -117,7 +117,7 @@ trait SqlWorldCompilerSuite extends CatsEffectSuite {
       assertEquals(stats,
         List(
           SqlStatsMonitor.SqlStats(
-            Query.Select("cities", Nil, Query.Filter(Like(schema.ref("City") / "name","Linh%",true),Query.Select("name",List(),Query.Empty))),
+            Select("cities", Filter(Like(schema.ref("City") / "name","Linh%",true), Select("name"))),
             simpleFilteredQuerySql,
             List("Linh%"),
             3,

--- a/modules/sql/shared/src/test/scala/SqlWorldMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlWorldMapping.scala
@@ -175,77 +175,72 @@ trait SqlWorldMapping[F[_]] extends SqlTestMapping[F] {
       }
   }
 
-  override val selectElaborator = new SelectElaborator(Map(
+  override val selectElaborator = SelectElaborator {
+    case (QueryType, "country", List(Binding("code", StringValue(code)))) =>
+      Elab.transformChild(child => Unique(Filter(Eql(CountryType / "code", Const(code)), child)))
 
-    QueryType -> {
+    case (QueryType, "city", List(Binding("id", IntValue(id)))) =>
+      Elab.transformChild(child => Unique(Filter(Eql(CityType / "id", Const(id)), child)))
 
-      case Select("country", List(Binding("code", StringValue(code))), child) =>
-        Select("country", Nil, Unique(Filter(Eql(CountryType / "code", Const(code)), child))).success
+    case (QueryType, "countries", List(Binding("limit", IntValue(num)), Binding("offset", IntValue(off)), Binding("minPopulation", IntValue(min)), Binding("byPopulation", BooleanValue(byPop)))) =>
+      def limit(query: Query): Query =
+        if (num < 1) query
+        else Limit(num, query)
 
-      case Select("city", List(Binding("id", IntValue(id))), child) =>
-        Select("city", Nil, Unique(Filter(Eql(CityType / "id", Const(id)), child))).success
+      def offset(query: Query): Query =
+        if (off < 1) query
+        else Offset(off, query)
 
-      case Select("countries", List(Binding("limit", IntValue(num)), Binding("offset", IntValue(off)), Binding("minPopulation", IntValue(min)), Binding("byPopulation", BooleanValue(byPop))), child) =>
-        def limit(query: Query): Query =
-          if (num < 1) query
-          else Limit(num, query)
+      def order(query: Query): Query = {
+        if (byPop)
+          OrderBy(OrderSelections(List(OrderSelection[Int](CountryType / "population"))), query)
+        else if (num > 0 || off > 0)
+          OrderBy(OrderSelections(List(OrderSelection[String](CountryType / "code"))), query)
+        else query
+      }
 
-        def offset(query: Query): Query =
-          if (off < 1) query
-          else Offset(off, query)
+      def filter(query: Query): Query =
+        if (min == 0) query
+        else Filter(GtEql(CountryType / "population", Const(min)), query)
 
-        def order(query: Query): Query = {
-          if (byPop)
-            OrderBy(OrderSelections(List(OrderSelection[Int](CountryType / "population"))), query)
-          else if (num > 0 || off > 0)
-            OrderBy(OrderSelections(List(OrderSelection[String](CountryType / "code"))), query)
-          else query
-        }
+      Elab.transformChild(child => limit(offset(order(filter(child)))))
 
-        def filter(query: Query): Query =
-          if (min == 0) query
-          else Filter(GtEql(CountryType / "population", Const(min)), query)
+    case (QueryType, "cities", List(Binding("namePattern", StringValue(namePattern)))) =>
+      if (namePattern == "%")
+        Elab.unit
+      else
+        Elab.transformChild(child => Filter(Like(CityType / "name", namePattern, true), child))
 
-        Select("countries", Nil, limit(offset(order(filter(child))))).success
+    case (QueryType, "language", List(Binding("language", StringValue(language)))) =>
+      Elab.transformChild(child => Unique(Filter(Eql(LanguageType / "language", Const(language)), child)))
 
-      case Select("cities", List(Binding("namePattern", StringValue(namePattern))), child) =>
-        if (namePattern == "%")
-          Select("cities", Nil, child).success
-        else
-          Select("cities", Nil, Filter(Like(CityType / "name", namePattern, true), child)).success
+    case (QueryType, "languages", List(Binding("languages", StringListValue(languages)))) =>
+      Elab.transformChild(child => Filter(In(CityType / "language", languages), child))
 
-      case Select("language", List(Binding("language", StringValue(language))), child) =>
-        Select("language", Nil, Unique(Filter(Eql(LanguageType / "language", Const(language)), child))).success
+    case (QueryType, "search", List(Binding("minPopulation", IntValue(min)), Binding("indepSince", IntValue(year)))) =>
+      Elab.transformChild(child =>
+        Filter(
+          And(
+            Not(Lt(CountryType / "population", Const(min))),
+            Not(Lt(CountryType / "indepyear", Const(Option(year))))
+          ),
+          child
+        )
+      )
 
-      case Select("languages", List(Binding("languages", StringListValue(languages))), child) =>
-        Select("languages", Nil, Filter(In(CityType / "language", languages), child)).success
+    case (QueryType, "search2", List(Binding("indep", BooleanValue(indep)), Binding("limit", IntValue(num)))) =>
+      Elab.transformChild(child => Limit(num, Filter(IsNull[Int](CountryType / "indepyear", isNull = !indep), child)))
 
-      case Select("search", List(Binding("minPopulation", IntValue(min)), Binding("indepSince", IntValue(year))), child) =>
-        Select("search", Nil,
-          Filter(
-            And(
-              Not(Lt(CountryType / "population", Const(min))),
-              Not(Lt(CountryType / "indepyear", Const(Option(year))))
-            ),
-            child
-          )
-        ).success
+    case (QueryType, "numCountries", Nil) =>
+      Elab.transformChild(_ => Count(Select("countries", Select("code2"))))
 
-      case Select("search2", List(Binding("indep", BooleanValue(indep)), Binding("limit", IntValue(num))), child) =>
-        Select("search2", Nil, Limit(num, Filter(IsNull[Int](CountryType / "indepyear", isNull = !indep), child))).success
+    case (CountryType, "numCities", List(Binding("namePattern", AbsentValue))) =>
+      Elab.transformChild(_ => Count(Select("cities", Select("name"))))
 
-      case Select("numCountries", Nil, Empty) =>
-        Count("numCountries", Select("countries", Nil, Select("code2", Nil, Empty))).success
-    },
-    CountryType -> {
-      case Select("numCities", List(Binding("namePattern", AbsentValue)), Empty) =>
-        Count("numCities", Select("cities", Nil, Select("name", Nil, Empty))).success
+    case (CountryType, "numCities", List(Binding("namePattern", StringValue(namePattern)))) =>
+      Elab.transformChild(_ => Count(Select("cities", Filter(Like(CityType / "name", namePattern, true), Select("name")))))
 
-      case Select("numCities", List(Binding("namePattern", StringValue(namePattern))), Empty) =>
-        Count("numCities", Select("cities", Nil, Filter(Like(CityType / "name", namePattern, true), Select("name", Nil, Empty)))).success
-
-      case Select("city", List(Binding("id", IntValue(id))), child) =>
-        Select("city", Nil, Unique(Filter(Eql(CityType / "id", Const(id)), child))).success
-    }
-  ))
+    case (CountryType, "city", List(Binding("id", IntValue(id)))) =>
+      Elab.transformChild(child => Unique(Filter(Eql(CityType / "id", Const(id)), child)))
+  }
 }

--- a/modules/sql/shared/src/test/scala/SqlWorldSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlWorldSuite.scala
@@ -5,7 +5,6 @@ package edu.gemini.grackle.sql.test
 
 import cats.effect.IO
 import cats.implicits._
-import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
@@ -15,7 +14,7 @@ import grackle.test.GraphQLResponseTests.{assertNoErrorsIO, assertWeaklyEqualIO}
 
 trait SqlWorldSuite extends CatsEffectSuite {
 
-  def mapping: QueryExecutor[IO, Json]
+  def mapping: Mapping[IO]
 
   test("simple query") {
     val query = """
@@ -1585,7 +1584,7 @@ trait SqlWorldSuite extends CatsEffectSuite {
       }
     """
 
-    val expected = if (isJS) 
+    val expected = if (isJS)
       json"""
           {
             "data" : {


### PR DESCRIPTION
This excessively large PR is the result of the collision of three overlapping objectives. Whilst they could have been
split apart, that would have resulted in a non-trivial amount of rework as each incremental change was applied.

The three objectives are,

+ Full support of custom query and schema directives.

  Directives are a major GraphQL feature (schema directives are an important part of typical GraphQL access control
  schemes) and it would be premature to declare a 1.0 release without support.

+ Simplify the query algebra.

  The query algebra has accumulated a number of odd cases. For the most part these are unproblematic, but `Rename` in
  particular has proven to be awkward. It manifests in user code as the need to use the `PossiblyRenamedSelect`
  extractor in effect handlers, and this is confusing and error prone.

+ Support threading of state through the query elaborator.

  This enables, amongst other things, a simpler implementation of CSS-style cascading field arguments (eg. to
  implement filter criteria which should be inherited by children).

Support for directives means adding directives attributes throughout the schema and at various places in the query
algebra, notably `Select` nodes. The most straightforward way of disposing of the `Rename` node was to incorporate the
alias it carries directly into the `Select` node. The combination of these two changes, along with the invariants
associated with them, made the current approach taken to the select elaborator likely to be too burdensome for end
users. As a result it seemed sensible to take another look at how select elaboration and rework it in the light of the
desire to also thread state through the process.

Hence the size of this PR.

## Directive support

Directives can be applied to both the GraphQL schema and to queries. Typically directives will be processed by one or
more additional phases during query compilation. Included in the tests are two examples, one demonstrating query
directives (that is, directives which are added to the query by the client), and one demonstrating schema directives
(that is, directives which are added to the query by the application developer).

The query directive example adds an `@upperCase` directive which may be applied to query fields which have `String`
values,

```graphql
type Query {
  user: User!
}
type User {
  name: String!
  handle: String!
  age: Int!
}
directive @upperCase on FIELD
```
If clients apply this directive to a `String` field, the result will be upper cased,
```graphql
query {
  user {
    name
  }
}
```
yields,
```graphql
{
  "data" : {
    "user" : {
      "name" : "Mary"
    }
  }
}
```
whereas,
```graphql
query {
  user {
    name @upperCase
  }
}
```
yields,
```graphql
{
  "data" : {
    "user" : {
      "name" : "MARY"
    }
  }
}
```
This is implemented as an additional phase which is added to the `Mapping`,
```scala
object QueryDirectivesMapping extends ValueMapping[IO] {
  // ... details elided ...

  // Transform which modifies the query to apply upper case logic to fields which
  // have the `@upperCase directive applied.
  object upperCaseElaborator extends Phase {
    override def transform(query: Query): Elab[Query] =
      query match {
        case UntypedSelect(nme, alias, _, directives, _) if directives.exists(_.name == "upperCase") =>
          for {
            c    <- Elab.context
            fc   <- Elab.liftR(c.forField(nme, alias))
            res  <- if (fc.tpe =:= ScalarType.StringType)
                      super.transform(query).map(TransformCursor(toUpperCase, _))
                    else
                      // We could make this fail the whole query by yielding Elab.failure here
                      Elab.warning(s"'@upperCase' may only be applied to fields of type String") *>
                        super.transform(query)
          } yield res
        case _ =>
          super.transform(query)
      }

    def toUpperCase(c: Cursor): Result[Cursor] =
      FieldTransformCursor[String](c, _.toUpperCase.success).success
  }

  // The phase is added to sequence of compiler phases.
  override def compilerPhases: List[QueryCompiler.Phase] =
    List(upperCaseElaborator, selectElaborator, componentElaborator, effectElaborator)
}
```

This phase identifies `Select` nodes with the `@upperCase` directive applied then, if the type of the corresponding
field is `String`, it adds a field transform which converts the value to upper case when the compiled query is
executed.

Note that this logic applies to all fields defined by the schema, without requiring any field-specific logic.

The schema directive example adds a simple access control mechanism along the lines of the one described [here]().

The schema defines `@authenticated` and `@hasRole` directives, along with an enum type which defines `USER` and
`ADMIN` roles. Fields and types with the `@authenticated` directive applied are only accessible to authenticated
users, and fields and types with the `@hasRole(requries: <role>)` directive applied require both authentication and
possession on the specified role.

```graphql
type Query {
  products: [String!]!
  user: User! @authenticated
}

type Mutation @authenticated {
  needsBackup: Boolean!
  backup: Boolean! @hasRole(requires: ADMIN)
}

type User {
  name: String!
  email: String! @hasRole(requires: ADMIN)
  phone: String  @hasRole(requires: ADMIN)
}

directive @authenticated on FIELD_DEFINITION | OBJECT
directive @hasRole(requires: Role = ADMIN) on FIELD_DEFINITION | OBJECT

enum Role {
  ADMIN
  USER
}
```

Here user information is only accessible to authenticated users, and access to e-mail and phone information in
addition requires the ADMIN role. The type level `@authenticate` directive applied to `Mutation` means that mutatios
are only available to authenticated users.

```scala
object SchemaDirectivesMapping extends ValueMapping[IO] {
  // ... details elided ...

  case class AuthStatus(role: String)

  object permissionsElaborator extends Phase {
    override def transform(query: Query): Elab[Query] = {
      def checkPermissions(
        c: Context, name: String,
        status: Option[AuthStatus],
        query: Query,
        nullAndWarn: Boolean
      ): Elab[Query] = {
        val dirs = c.tpe.directives ++ c.tpe.fieldInfo(name).map(_.directives).getOrElse(Nil)
        val requiresAuth = dirs.exists(_.name == "authenticated")
        val roles =
          dirs.filter(_.name == "hasRole").flatMap(_.args.filter(_.name == "requires"))
            .map(_.value).collect {
              case EnumValue(role) => role
            }
        val requiresRole =
          if (roles.contains("ADMIN")) Some(AuthStatus("ADMIN"))
          else if (roles.contains("USER")) Some(AuthStatus("USER"))
          else None

        (status, requiresAuth, requiresRole) match {
          case (None, false, None) => Elab.pure(query)
          case (Some(_), _, None) => Elab.pure(query)
          case (Some(AuthStatus("ADMIN")), _, _) => Elab.pure(query)
          case (Some(AuthStatus("USER")), _, Some(AuthStatus("USER"))) =>
            Elab.pure(query)
          case _ =>
            if (!nullAndWarn) Elab.failure(s"Unauthorized")
            else
              for {
                _ <- Elab.warning(s"Unauthorized access to field '$name' of type '${c.tpe}'")
              } yield TransformCursor(NullFieldCursor(_).success, query)
        }
      }

      query match {
        case s: UntypedSelect =>
          for {
            c      <- Elab.context
            status <- Elab.env[AuthStatus]("authStatus")
            query0 <- super.transform(query)
            res    <- checkPermissions(c, s.name, status, query0, s.name == "phone")
          } yield res

        case _ =>
          super.transform(query)
      }
    }
  }

  override def compilerPhases: List[QueryCompiler.Phase] =
    List(permissionsElaborator, selectElaborator, componentElaborator, effectElaborator)
}
```

As with the query directive example, this mechanism is implemented as a compiler phase. We have left it to the service
that Grackle is embedded in to assemble authentication information and provided to the compiler as an `AuthStatus`
value in the environment under the `"authStatus"` key. The phase transforms the query as before, this time checking
permissions at each select. If the permission check is successful the select is left unmodified. If the permission
check is unsuccessful then either the entire query fails or, in the case of the `phone` field of `User` the permission
violation generates a warning and the field value is returned as `null`.

### Additional changes

+ Added directives to all applicable operation, query and type elements.
+ Added full directive location, argument and repetition validation logic.
+ Schema parser/renderer now has full support for directives.
+ Renamed `Directive` to `DirectiveDef`. The type `Directive` is now an application of a directive.
+ Added `DirectiveDef`s for skip, include and deprecated rather than special casing in introspection and directive
  processing.
+ Properly handle directive locations in introspection.
+ Query minimizer now has full support for directives.
+ Added query directive test as a demo of custom query directives.
+ Added a schema directive based access control/authorization test as a demo of custom schema directives.

## Elaborator rework

To support the threading of state through the query elaboration process an elaboration monad `Elab` has been
introduced. This,
+ Provides access to the schema, context, variables and fragments of a query.
+ Supports the transformation of the children of `Select` to provide semantics for field arguments.
+ Supports the addition of contextual data to the resulting query both to drive run time behaviour and to support
propagation of context to the elaboration of children.
+ Supports the addition of queries for additional attributes to the resulting query.
+ Supports context queries against the query being elaborated.
+ Supports reporting of errors or warnings during elaboration.

The following, taken from the Star Wars demo illustrates the change from the old select elaborator to the new scheme,

```scala
// Old select elaborator
override val selectElaborator = new SelectElaborator(Map(
  QueryType -> {
    case Select("hero", List(Binding("episode", TypedEnumValue(e))), child) =>
      Episode.values.find(_.toString == e.name).map { episode =>
        Select("hero", Nil,
          Unique(Filter(Eql(CharacterType / "id", Const(hero(episode).id)), child))
        ).success
      }.getOrElse(Result.failure(s"Unknown episode '${e.name}'"))

    case Select(f@("character" | "human" | "droid"), List(Binding("id", IDValue(id))), child) =>
      Select(f, Nil, Unique(Filter(Eql(CharacterType / "id", Const(id)), child))).success
  }
))

// New select elaborator
override val selectElaborator = SelectElaborator {
  case (QueryType, "hero", List(Binding("episode", EnumValue(e)))) =>
    for {
      episode <- Elab.liftR(Episode.values.find(_.toString == e).toResult(s"Unknown episode '$e'"))
      _       <- Elab.transformChild(child =>
                   Unique(Filter(Eql(CharacterType / "id", Const(hero(episode).id)), child))
                 )
    } yield ()

  case (QueryType, "character" | "human" | "droid", List(Binding("id", IDValue(id)))) =>
    Elab.transformChild(child => Unique(Filter(Eql(CharacterType / "id", Const(id)), child)))
}
```

The most obvious differences visible here are,
+ Instead of the select elaborator being parametrized with a `Map[TypeRef, PartialFunction[Select, Query]]` we instead
  have a `PartialFunction[(Type, String, List[Binding]), Elab[Unit]`. This means that instead of user code having to
  unpack all the contents of a `Select`, including a possible alias and directives, it's handed only the typically
  relevant components. Moving the `Type` into the argument of the partial function also allows for sharing of logic
  between similar fields of different GraphQL types.
+ Instead of constucting a complete new `Select` node (which is error prone) the `Elab` monad allows a function to be
  applied to the child only, leaving the fiddly work of reconstructing the resulting `Select` to the library.

As well as covering the existing use cases more safely, the new elaborator supports more complex scenarios smoothly.
The cascade demo/test provides an example of CSS-style argument cascades from parent fields to child fields,

```graphql
type Query {
  foo(filter: FooFilter, limit: Int): Foo
}
type Foo {
  bar(filter: BarFilter, limit: Int): Bar
}
type Bar {
  foo(filter: FooFilter, limit: Int): Foo
}
input FooFilter {
  foo: String
  fooBar: Int
}
input BarFilter {
  bar: Boolean
  fooBar: Int
}
```

Here we want the value of `fooBar` in a `FooFilter` argument of a `foo` field to be propagated to the value of
`fooBar` in a `BarFilter` argument of a child `bar` field, and vice versa, recursively. Whilst this was possible
previously it required a fairly complex initial pass over the query to propagate the values. Under the new schema this
is a great deal more straightforward,

```scala
case class CascadedFilter(
  foo: Option[String],
  bar: Option[Boolean],
  fooBar: Option[Int],
  limit: Option[Int]
)

override val selectElaborator = SelectElaborator {
  case (QueryType | BarType, "foo",
         List(Binding("filter", FooFilter(filter)), Binding("limit", TriInt(limit)))) =>
    for {
      current0 <- Elab.env[CascadedFilter]("filter")
      current  =  current0.getOrElse(CascadedFilter.empty)
      _        <- Elab.env("filter", filter(current).withLimit(limit))
    } yield ()

  case (FooType, "bar",
         List(Binding("filter", BarFilter(filter)), Binding("limit", TriInt(limit)))) =>
    for {
      current0 <- Elab.env[CascadedFilter]("filter")
      current  =  current0.getOrElse(CascadedFilter.empty)
      _        <- Elab.env("filter", filter(current).withLimit(limit))
    } yield ()
}
```

Here we take advantage of the ability to read values from an environment inherited from parent nodes in the query and
to update values in the environment that is passed to child nodes and the elaboration proceeds.

## Query algebra changes

+ Removed `Skipped`, `UntypedNarrows` and `Wrap` query algebra cases.
+ Added `UntypedFragmentSpread` and `UntypedInlineFragment` query algebra cases primarily to provide a position in the
  query algebra for directives with the `FRAGMENT_SPREAD` and `INLINE_FRAGMENT` location to live.
+ Removed `Rename` query algebra case and added alias field to `Select`, The `args` and `directives` fields of
  `Select` have been moved to a new `UntypedSelect` query algebra case.
+ `Count` nodes now correspond to values rather than fields and so no longer have a field name and must be nested
  within a `Select`.
+ Added operation name and directives to untyped operation types.
+ Renamed `Query.mapFields` to `mapFieldsR` and introduced a non-Result using `mapFields`.

## Type/schema changes

+ The `Field.isDeprecated` and `deprecationReason` fields have been removed and redefined in terms of directives.
+ `Schema.{queryType, mutationType, subscriptionType}` now correctly handle the case where the declared type is
  nullable.
+ Added `fieldInfo` method to `Type`.
+ Removed redundant `Type.withField` and `withUnderlyingField`.
+ Renamed `EnumValue` to `EnumValueDefinition`.
+ Renamed `EnumType.value` to `valueDefinition`. `EnumType.value` new returns an `EnumValue`.
+ Added `Value.VariableRef`.
+ Collected all value elaboration and validation into `object Value`.

## Query parser/compiler changes

+ `QueryParser.parseText` incompatible signature change. Now returns full set of operations and fragments.
+ `QueryParser.parseDocument` incompatible signature change. Now returns full set of operations and fragments.
+ `QueryParser.parseXxx` removed redundant `fragments` argument.
+ `QueryParser` directive processing generalized from `skip`/`include` to general directives.
+ `QueryParser.parseValue` logic moved to `SchemaParser`.
+ `QueryCompiler.compileUntyped` renamed to `compileOperation`.
+ Fragments are now comiled in the context of each operation where there are more than one. This means that fragments
  are now correctly evaluated in the scope of any operation specific variable bindings.
+ The parser now recognises arguments as optional in directive definitions.
+ The parser now supports directives on operations and variable definitions.

## Mapping/interpreter changes

+ Removed redundant `QueryExecutor` trait.
+ Renamed `Mapping.compileAndRunOne` and `Mapping.compileAndRunAll` to `compileAndRun` and `compileAndRunSubscription`
  respectively.
+ Removed `Mapping.run` methods because they don't properly accumulate GraphQL compilation warnings.
+ Added `RootEffect.computeUnit` for effectful queries/mutations which don't need to modify the query or any special
  handling for root cursor creation.
+ `RootEffect.computeCursor` and `RootStream.computeCursor` no longer take the query as a argument.
+ `RootEffect.computeQuery` and `RootStream.computeQuery` have been replaced by `computeChild` methods which transform
  only the child of the root query. Uses of `computeQuery` were the main places where `PossiblyRenamedSelect` had to
  be used by end users, because the name and alias of the root query had to be preserved. By only giving the end user
  the opportunity to compute the child query and having the library deal with the top level, this complication has
  been removed.
+ `RootStream.computeCursor` no longer takes the query as a argument.
+ `QueryInterpreter.run` no longer generates the full GraphQL response. This is now done in
  `Mapping.compileAndRun`/`compileAndRunSubscription`, allowing compilation warnings to be incorporated in the GraphQL
  response.
+ Various errors now correctly identifed as internal rather than GraphQL errors.

## Miscellaneous changes

+ Added `Result.pure` and `unit`.
+ Fixes to the order of accumulation of GraphQL problems in `Result`.
+ Fixed `ap` of `Parallel[Result]`'s `Applicative` to accumulate problems correctly.
+ Unnested `Context` and `Env` from `object Cursor` because they are now used in non-cursor scenarios.
+ Added `NullFieldCursor` which transforms a cursor such that its children are null.
+ Added `NullCursor` which transforms a cursor such that it is null.
+ Moved `QueryMinimizer` to its own source file.
+ Updated tutorial and demo.
