### PR TITLE
Move to Typelevel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,5 +238,5 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: gsp-graphql-demo_2.13 gsp-graphql-demo_3 benchmarks_2.13 benchmarks_3 rootjs_2.13 rootjs_3 buildinfo_native0.4_2.13 buildinfo_native0.4_3 buildinfo_sjs1_2.13 buildinfo_sjs1_3 profile_2.13 profile_3 rootjvm_2.13 rootjvm_3 rootnative_2.13 rootnative_3 buildinfo_2.13 buildinfo_3
+          modules-ignore: grackle-demo_2.13 grackle-demo_3 benchmarks_2.13 benchmarks_3 rootjs_2.13 rootjs_3 buildinfo_native0.4_2.13 buildinfo_native0.4_3 buildinfo_sjs1_2.13 buildinfo_sjs1_3 profile_2.13 profile_3 rootjvm_2.13 rootjvm_3 rootnative_2.13 rootnative_3 buildinfo_2.13 buildinfo_3
           configs-ignore: test scala-tool scala-doc-tool test-internal

--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ and then browsing to [localhost:4000](http://localhost:4000).
 - Test it out!
 - If you see a typo in the doc, click the link at the bottom and fix it!
 - If you find a bug, open an issue (or fix it and open a PR) at our [GitHub
-  Repository](https://github.com/gemini-hlsw/gsp-graphql).
+  Repository](https://github.com/typelevel/grackle).
 - If you want to make a larger contribution please open an issue first so we can discuss.

--- a/benchmarks/src/main/scala/ParserBenchmark.scala
+++ b/benchmarks/src/main/scala/ParserBenchmark.scala
@@ -28,9 +28,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package edu.gemini.grackle.benchmarks
+package grackle.benchmarks
 
-import edu.gemini.grackle.Schema
+import grackle.Schema
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -46,7 +46,7 @@ import scala.io.Source
  *
  * Or to run the benchmark from within sbt:
  *
- *     jmh:run -i 10 -wi 10 -f 2 -t 1 edu.gemini.grackle.benchmarks.ParserBenchmark
+ *     jmh:run -i 10 -wi 10 -f 2 -t 1 grackle.benchmarks.ParserBenchmark
  *
  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread".
  * Please note that benchmarks should be usually executed at least in

--- a/build.sbt
+++ b/build.sbt
@@ -29,8 +29,8 @@ val Scala3 = "3.3.1"
 ThisBuild / scalaVersion        := Scala2
 ThisBuild / crossScalaVersions  := Seq(Scala2, Scala3)
 
-ThisBuild / tlBaseVersion    := "0.14"
-ThisBuild / organization     := "edu.gemini"
+ThisBuild / tlBaseVersion    := "0.15"
+ThisBuild / organization     := "org.typelevel"
 ThisBuild / organizationName := "Association of Universities for Research in Astronomy, Inc. (AURA)"
 ThisBuild / startYear        := Some(2019)
 ThisBuild / licenses         := Seq(("BSD-3-Clause", new URL("https://opensource.org/licenses/BSD-3-Clause")))
@@ -106,7 +106,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .disablePlugins(RevolverPlugin)
   .settings(commonSettings)
   .settings(
-    name := "gsp-graphql-core",
+    name := "grackle-core",
     libraryDependencies ++=
       Seq(
         "org.typelevel" %%% "cats-parse"   % catsParseVersion,
@@ -131,7 +131,7 @@ lazy val circe = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .dependsOn(core)
   .settings(commonSettings)
   .settings(
-    name := "gsp-graphql-circe",
+    name := "grackle-circe",
   )
 
 lazy val buildInfo = crossProject(JVMPlatform, JSPlatform, NativePlatform)
@@ -151,7 +151,7 @@ lazy val sql = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .dependsOn(core % "test->test;compile->compile", circe, buildInfo % Test)
   .settings(commonSettings)
   .settings(
-    name := "gsp-graphql-sql",
+    name := "grackle-sql",
     libraryDependencies ++= Seq(
       "io.circe"          %%% "circe-generic"      % circeVersion % "test",
       "co.fs2"            %%% "fs2-io"             % fs2Version % "test",
@@ -175,7 +175,7 @@ lazy val doobie = project
   .dependsOn(sql.jvm % "test->test;compile->compile", circe.jvm)
   .settings(commonSettings)
   .settings(
-    name := "gsp-graphql-doobie-pg",
+    name := "grackle-doobie-pg",
     Test / fork := true,
     Test / parallelExecution := false,
     libraryDependencies ++= Seq(
@@ -194,7 +194,7 @@ lazy val skunk = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .dependsOn(sql % "test->test;compile->compile", circe)
   .settings(commonSettings)
   .settings(
-    name := "gsp-graphql-skunk",
+    name := "grackle-skunk",
     Test / parallelExecution := false,
     libraryDependencies ++= Seq(
       "org.tpolecat" %%% "skunk-core"  % skunkVersion,
@@ -216,7 +216,7 @@ lazy val generic = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .dependsOn(core)
   .settings(commonSettings)
   .settings(
-    name := "gsp-graphql-generic",
+    name := "grackle-generic",
     libraryDependencies += (
       scalaVersion.value match {
         case Scala3 => "org.typelevel" %%% "shapeless3-deriving" % shapeless3Version
@@ -230,7 +230,7 @@ lazy val demo = project
   .dependsOn(core.jvm, generic.jvm, doobie)
   .settings(commonSettings)
   .settings(
-    name := "gsp-graphql-demo",
+    name := "grackle-demo",
     libraryDependencies ++= Seq(
       "org.typelevel"     %% "log4cats-slf4j"      % log4catsVersion,
       "ch.qos.logback"    %  "logback-classic"     % logbackVersion,

--- a/demo/src/main/scala/demo/GraphQLService.scala
+++ b/demo/src/main/scala/demo/GraphQLService.scala
@@ -5,7 +5,7 @@ package demo
 
 import cats.effect.Concurrent
 import cats.syntax.all._
-import edu.gemini.grackle.Mapping
+import grackle.Mapping
 import io.circe.{Json, ParsingFailure, parser}
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl

--- a/demo/src/main/scala/demo/starwars/StarWarsMapping.scala
+++ b/demo/src/main/scala/demo/starwars/StarWarsMapping.scala
@@ -4,13 +4,13 @@
 package demo.starwars
 
 import cats.syntax.all._
-import edu.gemini.grackle.Predicate._
-import edu.gemini.grackle.Query._
-import edu.gemini.grackle.QueryCompiler._
-import edu.gemini.grackle.Value._
-import edu.gemini.grackle._
-import edu.gemini.grackle.generic._
-import edu.gemini.grackle.syntax._
+import grackle.Predicate._
+import grackle.Query._
+import grackle.QueryCompiler._
+import grackle.Value._
+import grackle._
+import grackle.generic._
+import grackle.syntax._
 
 trait StarWarsMapping[F[_]] extends GenericMapping[F] { self: StarWarsData[F] =>
   // #schema

--- a/demo/src/main/scala/demo/world/WorldMapping.scala
+++ b/demo/src/main/scala/demo/world/WorldMapping.scala
@@ -5,14 +5,14 @@ package demo.world
 
 import _root_.doobie.{Meta, Transactor}
 import cats.effect.Sync
-import edu.gemini.grackle.Predicate._
-import edu.gemini.grackle.Query._
-import edu.gemini.grackle.QueryCompiler._
-import edu.gemini.grackle.Value._
-import edu.gemini.grackle._
-import edu.gemini.grackle.doobie.postgres.{DoobieMapping, DoobieMonitor, LoggedDoobieMappingCompanion}
-import edu.gemini.grackle.sql.Like
-import edu.gemini.grackle.syntax._
+import grackle.Predicate._
+import grackle.Query._
+import grackle.QueryCompiler._
+import grackle.Value._
+import grackle._
+import grackle.doobie.postgres.{DoobieMapping, DoobieMonitor, LoggedDoobieMappingCompanion}
+import grackle.sql.Like
+import grackle.syntax._
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -33,5 +33,5 @@ To learn about Grackle please read the @ref:[Tutorial](tutorial/index.md) and ma
 
 - Test it out!
 - If you see a typo in the doc, click the link at the bottom and fix it!
-- If you find a bug, open an issue (or fix it and open a PR) at our [GitHub Repository](https://github.com/gemini-hlsw/gsp-graphql).
+- If you find a bug, open an issue (or fix it and open a PR) at our [GitHub Repository](https://github.com/typelevel/grackle).
 - If you want to make a larger contribution please open an issue first so we can discuss.

--- a/docs/src/main/paradox/tutorial/db-backed-model.md
+++ b/docs/src/main/paradox/tutorial/db-backed-model.md
@@ -9,35 +9,23 @@ The demo is packaged as submodule `demo` in the Grackle project. It is a http4s-
 from the SBT REPL using `sbt-revolver`,
 
 ```
-sbt:gsp-graphql> reStart
+sbt:root> demo/reStart
 [info] Application demo not yet started
 [info] Starting application demo in the background ...
 demo Starting demo.Main.main()
-demo[ERROR] Picked up JAVA_TOOL_OPTIONS:  -Xmx3489m
-[success] Total time: 0 s, completed Sep 3, 2023, 5:01:11 AM
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.license.VersionPrinter printVersionOnly
-demo[ERROR] INFO: Flyway Community Edition 9.22.0 by Redgate
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.license.VersionPrinter printVersion
-demo[ERROR] INFO: See release notes here: https://rd.gt/416ObMi
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.license.VersionPrinter printVersion
-demo[ERROR] INFO: 
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.FlywayExecutor execute
-demo[ERROR] INFO: Database: jdbc:postgresql://0.0.0.0:32771/test (PostgreSQL 11.8)
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.schemahistory.JdbcTableSchemaHistory allAppliedMigrations
-demo[ERROR] INFO: Schema history table "public"."flyway_schema_history" does not exist yet
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.command.DbValidate validate
-demo[ERROR] INFO: Successfully validated 1 migration (execution time 00:00.059s)
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.schemahistory.JdbcTableSchemaHistory create
-demo[ERROR] INFO: Creating Schema History table "public"."flyway_schema_history" ...
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.command.DbMigrate migrateGroup
-demo[ERROR] INFO: Current version of schema "public": << Empty Schema >>
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.command.DbMigrate doMigrateGroup
-demo[ERROR] INFO: Migrating schema "public" to version "1 - WorldSetup"
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.sqlscript.DefaultSqlScriptExecutor printWarnings
-demo[ERROR] WARNING: DB: there is already a transaction in progress (SQL State: 25001 - Error Code: 0)
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.command.DbMigrate logSummary
-demo[ERROR] INFO: Successfully applied 1 migration to schema "public", now at version v1 (execution time 00:00.110s)
-demo [io-compute-2] INFO  o.h.e.s.EmberServerBuilderCompanionPlatform - Ember-Server service bound to address: [::]:8080 
+[success] Total time: 0 s, completed 12 Oct 2023, 11:12:09
+demo [io-compute-blocker-8] INFO  o.f.c.i.l.VersionPrinter - Flyway Community Edition 9.22.2 by Redgate
+demo [io-compute-blocker-8] INFO  o.f.c.i.l.VersionPrinter - See release notes here: https://rd.gt/416ObMi
+demo [io-compute-blocker-8] INFO  o.f.c.i.l.VersionPrinter -
+demo [io-compute-blocker-8] INFO  o.f.c.FlywayExecutor - Database: jdbc:postgresql://0.0.0.0:32952/test (PostgreSQL 11.8)
+demo [io-compute-blocker-8] INFO  o.f.c.i.s.JdbcTableSchemaHistory - Schema history table "public"."flyway_schema_history" does not exist yet
+demo [io-compute-blocker-8] INFO  o.f.c.i.c.DbValidate - Successfully validated 1 migration (execution time 00:00.030s)
+demo [io-compute-blocker-8] INFO  o.f.c.i.s.JdbcTableSchemaHistory - Creating Schema History table "public"."flyway_schema_history" ...
+demo [io-compute-blocker-8] INFO  o.f.c.i.c.DbMigrate - Current version of schema "public": << Empty Schema >>
+demo [io-compute-blocker-8] INFO  o.f.c.i.c.DbMigrate - Migrating schema "public" to version "1 - WorldSetup"
+demo [io-compute-blocker-8] WARN  o.f.c.i.s.DefaultSqlScriptExecutor - DB: there is already a transaction in progress (SQL State: 25001 - Error Code: 0)
+demo [io-compute-blocker-8] INFO  o.f.c.i.c.DbMigrate - Successfully applied 1 migration to schema "public", now at version v1 (execution time 00:00.148s)
+demo [io-compute-0] INFO  o.h.e.s.EmberServerBuilderCompanionPlatform - Ember-Server service bound to address: [::]:8080
 ```
 
 This application hosts the demo services for in-memory and db-backend models, as well as a web-based GraphQL client

--- a/docs/src/main/paradox/tutorial/in-memory-model.md
+++ b/docs/src/main/paradox/tutorial/in-memory-model.md
@@ -13,35 +13,23 @@ The demo is packaged as submodule `demo` in the Grackle project. It is a http4s-
 from the SBT REPL using `sbt-revolver`,
 
 ```
-sbt:gsp-graphql> reStart
+sbt:root> demo/reStart
 [info] Application demo not yet started
 [info] Starting application demo in the background ...
 demo Starting demo.Main.main()
-demo[ERROR] Picked up JAVA_TOOL_OPTIONS:  -Xmx3489m
-[success] Total time: 0 s, completed Sep 3, 2023, 5:01:11 AM
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.license.VersionPrinter printVersionOnly
-demo[ERROR] INFO: Flyway Community Edition 9.22.0 by Redgate
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.license.VersionPrinter printVersion
-demo[ERROR] INFO: See release notes here: https://rd.gt/416ObMi
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.license.VersionPrinter printVersion
-demo[ERROR] INFO: 
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.FlywayExecutor execute
-demo[ERROR] INFO: Database: jdbc:postgresql://0.0.0.0:32771/test (PostgreSQL 11.8)
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.schemahistory.JdbcTableSchemaHistory allAppliedMigrations
-demo[ERROR] INFO: Schema history table "public"."flyway_schema_history" does not exist yet
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.command.DbValidate validate
-demo[ERROR] INFO: Successfully validated 1 migration (execution time 00:00.059s)
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.schemahistory.JdbcTableSchemaHistory create
-demo[ERROR] INFO: Creating Schema History table "public"."flyway_schema_history" ...
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.command.DbMigrate migrateGroup
-demo[ERROR] INFO: Current version of schema "public": << Empty Schema >>
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.command.DbMigrate doMigrateGroup
-demo[ERROR] INFO: Migrating schema "public" to version "1 - WorldSetup"
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.sqlscript.DefaultSqlScriptExecutor printWarnings
-demo[ERROR] WARNING: DB: there is already a transaction in progress (SQL State: 25001 - Error Code: 0)
-demo[ERROR] Sep 03, 2023 5:01:18 AM org.flywaydb.core.internal.command.DbMigrate logSummary
-demo[ERROR] INFO: Successfully applied 1 migration to schema "public", now at version v1 (execution time 00:00.110s)
-demo [io-compute-2] INFO  o.h.e.s.EmberServerBuilderCompanionPlatform - Ember-Server service bound to address: [::]:8080 
+[success] Total time: 0 s, completed 12 Oct 2023, 11:12:09
+demo [io-compute-blocker-8] INFO  o.f.c.i.l.VersionPrinter - Flyway Community Edition 9.22.2 by Redgate
+demo [io-compute-blocker-8] INFO  o.f.c.i.l.VersionPrinter - See release notes here: https://rd.gt/416ObMi
+demo [io-compute-blocker-8] INFO  o.f.c.i.l.VersionPrinter -
+demo [io-compute-blocker-8] INFO  o.f.c.FlywayExecutor - Database: jdbc:postgresql://0.0.0.0:32952/test (PostgreSQL 11.8)
+demo [io-compute-blocker-8] INFO  o.f.c.i.s.JdbcTableSchemaHistory - Schema history table "public"."flyway_schema_history" does not exist yet
+demo [io-compute-blocker-8] INFO  o.f.c.i.c.DbValidate - Successfully validated 1 migration (execution time 00:00.030s)
+demo [io-compute-blocker-8] INFO  o.f.c.i.s.JdbcTableSchemaHistory - Creating Schema History table "public"."flyway_schema_history" ...
+demo [io-compute-blocker-8] INFO  o.f.c.i.c.DbMigrate - Current version of schema "public": << Empty Schema >>
+demo [io-compute-blocker-8] INFO  o.f.c.i.c.DbMigrate - Migrating schema "public" to version "1 - WorldSetup"
+demo [io-compute-blocker-8] WARN  o.f.c.i.s.DefaultSqlScriptExecutor - DB: there is already a transaction in progress (SQL State: 25001 - Error Code: 0)
+demo [io-compute-blocker-8] INFO  o.f.c.i.c.DbMigrate - Successfully applied 1 migration to schema "public", now at version v1 (execution time 00:00.148s)
+demo [io-compute-0] INFO  o.h.e.s.EmberServerBuilderCompanionPlatform - Ember-Server service bound to address: [::]:8080
 ```
 
 This application hosts the demo services for in-memory and db-backend models, as well as a web-based GraphQL client

--- a/modules/circe/src/main/scala/circemapping.scala
+++ b/modules/circe/src/main/scala/circemapping.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package circe
 
 import scala.collection.Factory

--- a/modules/circe/src/test/scala/CirceData.scala
+++ b/modules/circe/src/test/scala/CirceData.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package circetests
 
 import cats.effect.IO
@@ -9,8 +9,8 @@ import cats.data.OptionT
 import io.circe.Json
 import io.circe.literal._
 
-import edu.gemini.grackle.circe.CirceMapping
-import edu.gemini.grackle.syntax._
+import grackle.circe.CirceMapping
+import grackle.syntax._
 
 import Query._
 import QueryCompiler._

--- a/modules/circe/src/test/scala/CirceEffectData.scala
+++ b/modules/circe/src/test/scala/CirceEffectData.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package circetests
 
 import cats.effect.Sync
@@ -9,8 +9,8 @@ import cats.implicits._
 import fs2.concurrent.SignallingRef
 import io.circe.{Encoder, Json}
 
-import edu.gemini.grackle.circe.CirceMapping
-import edu.gemini.grackle.syntax._
+import grackle.circe.CirceMapping
+import grackle.syntax._
 
 class TestCirceEffectMapping[F[_]: Sync](ref: SignallingRef[F, Int]) extends CirceMapping[F] {
   val schema =

--- a/modules/circe/src/test/scala/CirceEffectSuite.scala
+++ b/modules/circe/src/test/scala/CirceEffectSuite.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package circetests
 
 import cats.effect.IO

--- a/modules/circe/src/test/scala/CirceSuite.scala
+++ b/modules/circe/src/test/scala/CirceSuite.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package circetests
 
 import io.circe.literal._

--- a/modules/core/src/main/scala-2/syntax2.scala
+++ b/modules/core/src/main/scala-2/syntax2.scala
@@ -1,14 +1,14 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 import cats.data.NonEmptyChain
 import cats.syntax.all._
 import org.typelevel.literally.Literally
-import edu.gemini.grackle.Ast.Document
-import edu.gemini.grackle.GraphQLParser.Document.parseAll
-import edu.gemini.grackle.Schema
+import grackle.Ast.Document
+import grackle.GraphQLParser.Document.parseAll
+import grackle.Schema
 
 trait VersionSpecificSyntax {
   implicit def toStringContextOps(sc: StringContext): StringContextOps =
@@ -28,7 +28,7 @@ object SchemaLiteral extends Literally[Schema] {
         t  => s"Internal error: ${t.getMessage}",
         ps => s"Invalid schema: ${ps.toList.distinct.mkString("\n  🐞 ", "\n  🐞 ", "\n")}",
       )
-    Schema(s).toEither.bimap(mkError, _ => c.Expr(q"_root_.edu.gemini.grackle.Schema($s).toOption.get"))
+    Schema(s).toEither.bimap(mkError, _ => c.Expr(q"_root_.grackle.Schema($s).toOption.get"))
   }
   def make(c: Context)(args: c.Expr[Any]*): c.Expr[Schema] = apply(c)(args: _*)
 }
@@ -38,7 +38,7 @@ object DocumentLiteral extends Literally[Document] {
     import c.universe._
     parseAll(s).bimap(
       pf => show"Invalid document: $pf",
-      _  => c.Expr(q"_root_.edu.gemini.grackle.GraphQLParser.Document.parseAll($s).toOption.get"),
+      _  => c.Expr(q"_root_.grackle.GraphQLParser.Document.parseAll($s).toOption.get"),
     )
   }
   def make(c: Context)(args: c.Expr[Any]*): c.Expr[Document] = apply(c)(args: _*)

--- a/modules/core/src/main/scala-3/syntax3.scala
+++ b/modules/core/src/main/scala-3/syntax3.scala
@@ -1,12 +1,12 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 import cats.syntax.all._
 import org.typelevel.literally.Literally
-import edu.gemini.grackle.Ast.Document
-import edu.gemini.grackle.GraphQLParser.Document.parseAll
+import grackle.Ast.Document
+import grackle.GraphQLParser.Document.parseAll
 
 trait VersionSpecificSyntax:
 

--- a/modules/core/src/main/scala/ast.scala
+++ b/modules/core/src/main/scala/ast.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 object Ast {
 

--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 import scala.annotation.tailrec
 import scala.reflect.ClassTag

--- a/modules/core/src/main/scala/cursor.scala
+++ b/modules/core/src/main/scala/cursor.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 import scala.collection.Factory
 import scala.reflect.{classTag, ClassTag}

--- a/modules/core/src/main/scala/introspection.scala
+++ b/modules/core/src/main/scala/introspection.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 import io.circe.Encoder
 

--- a/modules/core/src/main/scala/jsonextractors.scala
+++ b/modules/core/src/main/scala/jsonextractors.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 import io.circe.Json
 import io.circe.JsonObject

--- a/modules/core/src/main/scala/mapping.scala
+++ b/modules/core/src/main/scala/mapping.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 import scala.collection.Factory
 import scala.reflect.ClassTag

--- a/modules/core/src/main/scala/mappingvalidator.scala
+++ b/modules/core/src/main/scala/mappingvalidator.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 import cats._
 import cats.data.{ Chain, NonEmptyList }

--- a/modules/core/src/main/scala/minimizer.scala
+++ b/modules/core/src/main/scala/minimizer.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 import cats.implicits._
 

--- a/modules/core/src/main/scala/operation.scala
+++ b/modules/core/src/main/scala/operation.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 import syntax._
 import Query._

--- a/modules/core/src/main/scala/parser.scala
+++ b/modules/core/src/main/scala/parser.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 import cats.parse.{LocationMap, Parser, Parser0}
 import cats.parse.Parser._

--- a/modules/core/src/main/scala/predicate.scala
+++ b/modules/core/src/main/scala/predicate.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 import scala.annotation.tailrec
 import scala.util.matching.Regex

--- a/modules/core/src/main/scala/problem.scala
+++ b/modules/core/src/main/scala/problem.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 import cats.Eq
 import io.circe._

--- a/modules/core/src/main/scala/query.scala
+++ b/modules/core/src/main/scala/query.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 import scala.annotation.tailrec
 

--- a/modules/core/src/main/scala/queryinterpreter.scala
+++ b/modules/core/src/main/scala/queryinterpreter.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 import scala.annotation.tailrec
 import scala.collection.mutable

--- a/modules/core/src/main/scala/result.scala
+++ b/modules/core/src/main/scala/result.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 import scala.annotation.tailrec
 import scala.util.control.NonFatal

--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 import cats.implicits._
 import io.circe.Json

--- a/modules/core/src/main/scala/syntax.scala
+++ b/modules/core/src/main/scala/syntax.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 object syntax extends VersionSpecificSyntax {
   implicit class ResultIdOps[A](val a: A) extends AnyVal {

--- a/modules/core/src/main/scala/valuemapping.scala
+++ b/modules/core/src/main/scala/valuemapping.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
 import scala.collection.Factory
 import scala.reflect.ClassTag

--- a/modules/core/src/test/scala/arb/AstArb.scala
+++ b/modules/core/src/test/scala/arb/AstArb.scala
@@ -3,7 +3,7 @@
 
 package arb
 
-import edu.gemini.grackle._
+import grackle._
 import org.scalacheck.{ Arbitrary, Gen }
 
 trait AstArb {

--- a/modules/core/src/test/scala/compiler/CascadeSuite.scala
+++ b/modules/core/src/test/scala/compiler/CascadeSuite.scala
@@ -9,8 +9,8 @@ import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Query._
 import QueryCompiler._
 import Value._

--- a/modules/core/src/test/scala/compiler/CompilerSuite.scala
+++ b/modules/core/src/test/scala/compiler/CompilerSuite.scala
@@ -7,8 +7,8 @@ import cats.data.NonEmptyChain
 import cats.implicits._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Query._
 import Predicate._, Value._, UntypedOperation._
 import QueryCompiler._, ComponentElaborator.TrivialJoin

--- a/modules/core/src/test/scala/compiler/DirectivesSuite.scala
+++ b/modules/core/src/test/scala/compiler/DirectivesSuite.scala
@@ -5,8 +5,8 @@ package compiler
 
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Ast.DirectiveLocation._
 import Query._
 

--- a/modules/core/src/test/scala/compiler/EnvironmentSuite.scala
+++ b/modules/core/src/test/scala/compiler/EnvironmentSuite.scala
@@ -7,8 +7,8 @@ import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Query._
 import Value._
 import QueryCompiler._

--- a/modules/core/src/test/scala/compiler/FragmentSuite.scala
+++ b/modules/core/src/test/scala/compiler/FragmentSuite.scala
@@ -9,8 +9,8 @@ import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Query._
 import Predicate._, Value._
 import QueryCompiler._

--- a/modules/core/src/test/scala/compiler/InputValuesSuite.scala
+++ b/modules/core/src/test/scala/compiler/InputValuesSuite.scala
@@ -6,8 +6,8 @@ package compiler
 import cats.data.NonEmptyChain
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Query._
 import Value._
 

--- a/modules/core/src/test/scala/compiler/PredicatesSuite.scala
+++ b/modules/core/src/test/scala/compiler/PredicatesSuite.scala
@@ -7,8 +7,8 @@ import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Query._
 import Predicate._, Value._
 import QueryCompiler._

--- a/modules/core/src/test/scala/compiler/PreserveArgsElaborator.scala
+++ b/modules/core/src/test/scala/compiler/PreserveArgsElaborator.scala
@@ -3,7 +3,7 @@
 
 package compiler
 
-import edu.gemini.grackle._
+import grackle._
 import Query._
 import QueryCompiler._
 

--- a/modules/core/src/test/scala/compiler/ProblemSuite.scala
+++ b/modules/core/src/test/scala/compiler/ProblemSuite.scala
@@ -8,7 +8,7 @@ import io.circe.JsonObject
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle.Problem
+import grackle.Problem
 
 final class ProblemSuite extends CatsEffectSuite {
 

--- a/modules/core/src/test/scala/compiler/QuerySizeSuite.scala
+++ b/modules/core/src/test/scala/compiler/QuerySizeSuite.scala
@@ -6,7 +6,7 @@ package compiler
 import cats.data.NonEmptyChain
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle.{Problem, Result}
+import grackle.{Problem, Result}
 import starwars.StarWarsMapping
 
 class QuerySizeSuite extends CatsEffectSuite {

--- a/modules/core/src/test/scala/compiler/ScalarsSuite.scala
+++ b/modules/core/src/test/scala/compiler/ScalarsSuite.scala
@@ -13,8 +13,8 @@ import cats.implicits._
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Query._
 import Predicate._, Value._
 import QueryCompiler._

--- a/modules/core/src/test/scala/compiler/SkipIncludeSuite.scala
+++ b/modules/core/src/test/scala/compiler/SkipIncludeSuite.scala
@@ -6,8 +6,8 @@ package compiler
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Query._
 
 final class SkipIncludeSuite extends CatsEffectSuite {

--- a/modules/core/src/test/scala/compiler/TestMapping.scala
+++ b/modules/core/src/test/scala/compiler/TestMapping.scala
@@ -6,7 +6,7 @@ package compiler
 import cats.MonadThrow
 import cats.effect.IO
 
-import edu.gemini.grackle._
+import grackle._
 
 abstract class TestMapping(implicit val M: MonadThrow[IO]) extends Mapping[IO] {
   val typeMappings: List[TypeMapping] = Nil

--- a/modules/core/src/test/scala/compiler/VariablesSuite.scala
+++ b/modules/core/src/test/scala/compiler/VariablesSuite.scala
@@ -7,8 +7,8 @@ import cats.data.NonEmptyChain
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Query._
 import Value._
 

--- a/modules/core/src/test/scala/composed/ComposedData.scala
+++ b/modules/core/src/test/scala/composed/ComposedData.scala
@@ -6,8 +6,8 @@ package composed
 import cats.effect.IO
 import cats.implicits._
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Query._
 import Predicate._, Value._
 import QueryCompiler._

--- a/modules/core/src/test/scala/composed/ComposedListSuite.scala
+++ b/modules/core/src/test/scala/composed/ComposedListSuite.scala
@@ -8,8 +8,8 @@ import cats.implicits._
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Query._
 import Predicate._, Value._
 import QueryCompiler._

--- a/modules/core/src/test/scala/directives/DirectiveValidationSuite.scala
+++ b/modules/core/src/test/scala/directives/DirectiveValidationSuite.scala
@@ -10,8 +10,8 @@ import cats.implicits._
 import munit.CatsEffectSuite
 
 import compiler.PreserveArgsElaborator
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Query._
 
 final class DirectiveValidationSuite extends CatsEffectSuite {

--- a/modules/core/src/test/scala/directives/QueryDirectivesSuite.scala
+++ b/modules/core/src/test/scala/directives/QueryDirectivesSuite.scala
@@ -8,8 +8,8 @@ import cats.syntax.all._
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Query._, QueryCompiler._
 
 final class QueryDirectivesSuite extends CatsEffectSuite {

--- a/modules/core/src/test/scala/directives/SchemaDirectivesSuite.scala
+++ b/modules/core/src/test/scala/directives/SchemaDirectivesSuite.scala
@@ -7,8 +7,8 @@ import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Cursor._, Query._, QueryCompiler._, Value._
 
 import SchemaDirectivesMapping.AuthStatus

--- a/modules/core/src/test/scala/effects/ValueEffectData.scala
+++ b/modules/core/src/test/scala/effects/ValueEffectData.scala
@@ -7,8 +7,8 @@ import cats.effect.Sync
 import cats.implicits._
 import fs2.concurrent.SignallingRef
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 
 class ValueEffectMapping[F[_]: Sync](ref: SignallingRef[F, Int]) extends ValueMapping[F] {
   val schema =

--- a/modules/core/src/test/scala/introspection/IntrospectionSuite.scala
+++ b/modules/core/src/test/scala/introspection/IntrospectionSuite.scala
@@ -8,8 +8,8 @@ import io.circe.{ ACursor, Json }
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import QueryCompiler.IntrospectionLevel
 import IntrospectionLevel._
 

--- a/modules/core/src/test/scala/laws/ResultSuite.scala
+++ b/modules/core/src/test/scala/laws/ResultSuite.scala
@@ -12,7 +12,7 @@ import munit.DisciplineSuite
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalacheck.Arbitrary.{arbitrary => getArbitrary}
 
-import edu.gemini.grackle.{Problem, Result}
+import grackle.{Problem, Result}
 
 class ResultSuite extends DisciplineSuite {
   implicit val eqThrow: Eq[Throwable] = Eq.fromUniversalEquals

--- a/modules/core/src/test/scala/mapping/MappingValidatorSuite.scala
+++ b/modules/core/src/test/scala/mapping/MappingValidatorSuite.scala
@@ -6,9 +6,9 @@ package validator
 import cats.syntax.all._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle.{ ListType, MappingValidator }
-import edu.gemini.grackle.MappingValidator.ValidationException
-import edu.gemini.grackle.syntax._
+import grackle.{ ListType, MappingValidator }
+import grackle.MappingValidator.ValidationException
+import grackle.syntax._
 
 import compiler.TestMapping
 

--- a/modules/core/src/test/scala/minimizer/MinimizerSuite.scala
+++ b/modules/core/src/test/scala/minimizer/MinimizerSuite.scala
@@ -5,7 +5,7 @@ package minimizer
 
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle.{ GraphQLParser, QueryMinimizer }
+import grackle.{ GraphQLParser, QueryMinimizer }
 
 final class MinimizerSuite extends CatsEffectSuite {
   def run(query: String, expected: String, echo: Boolean = false): Unit = {

--- a/modules/core/src/test/scala/parser/ParserSuite.scala
+++ b/modules/core/src/test/scala/parser/ParserSuite.scala
@@ -5,8 +5,8 @@ package parser
 
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle.{ Ast, GraphQLParser }
-import edu.gemini.grackle.syntax._
+import grackle.{ Ast, GraphQLParser }
+import grackle.syntax._
 import Ast._, OperationType._, OperationDefinition._, Selection._, Value._, Type.Named
 
 final class ParserSuite extends CatsEffectSuite {

--- a/modules/core/src/test/scala/schema/SchemaSuite.scala
+++ b/modules/core/src/test/scala/schema/SchemaSuite.scala
@@ -6,8 +6,8 @@ package schema
 import cats.data.NonEmptyChain
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle.{Result, Schema}
-import edu.gemini.grackle.syntax._
+import grackle.{Result, Schema}
+import grackle.syntax._
 
 final class SchemaSuite extends CatsEffectSuite {
   test("schema validation: undefined types: typo in the use of a Query result type") {

--- a/modules/core/src/test/scala/sdl/SDLSuite.scala
+++ b/modules/core/src/test/scala/sdl/SDLSuite.scala
@@ -5,8 +5,8 @@ package sdl
 
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle.{ Ast, GraphQLParser, SchemaParser }
-import edu.gemini.grackle.syntax._
+import grackle.{ Ast, GraphQLParser, SchemaParser }
+import grackle.syntax._
 import Ast._, OperationType._, Type.{ List => _, _ }
 
 final class SDLSuite extends CatsEffectSuite {

--- a/modules/core/src/test/scala/starwars/StarWarsData.scala
+++ b/modules/core/src/test/scala/starwars/StarWarsData.scala
@@ -7,8 +7,8 @@ import cats.effect.IO
 import cats.implicits._
 import io.circe.Encoder
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 
 import Query._
 import Predicate._, Value._

--- a/modules/core/src/test/scala/subscription/SubscriptionSuite.scala
+++ b/modules/core/src/test/scala/subscription/SubscriptionSuite.scala
@@ -12,8 +12,8 @@ import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import QueryCompiler._
 
 final class SubscriptionSuite extends CatsEffectSuite {

--- a/modules/doobie-pg/src/main/scala/DoobieMapping.scala
+++ b/modules/doobie-pg/src/main/scala/DoobieMapping.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package doobie.postgres
 
 import java.sql.ResultSet
@@ -16,7 +16,7 @@ import _root_.doobie.util.fragments
 import org.tpolecat.sourcepos.SourcePos
 import org.tpolecat.typename.TypeName
 
-import edu.gemini.grackle.sql._
+import grackle.sql._
 
 abstract class DoobieMapping[F[_]](
   val transactor: Transactor[F],

--- a/modules/doobie-pg/src/main/scala/DoobieMappingCompanion.scala
+++ b/modules/doobie-pg/src/main/scala/DoobieMappingCompanion.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package doobie.postgres
 
 import _root_.doobie.util.transactor.Transactor

--- a/modules/doobie-pg/src/main/scala/DoobieMonitor.scala
+++ b/modules/doobie-pg/src/main/scala/DoobieMonitor.scala
@@ -1,15 +1,15 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package doobie.postgres
 
 import _root_.doobie.Fragment
 import cats.Applicative
 import cats.implicits._
-import edu.gemini.grackle.QueryInterpreter.ProtoJson
+import grackle.QueryInterpreter.ProtoJson
 import org.typelevel.log4cats.Logger
-import edu.gemini.grackle.sql.SqlStatsMonitor
+import grackle.sql.SqlStatsMonitor
 import cats.effect.Ref
 import cats.effect.Sync
 

--- a/modules/doobie-pg/src/main/scala/package.scala
+++ b/modules/doobie-pg/src/main/scala/package.scala
@@ -1,9 +1,9 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.doobie
+package grackle.doobie
 
-import edu.gemini.grackle.sql.SqlMonitor
+import grackle.sql.SqlMonitor
 import _root_.doobie.Fragment
 
 package object postgres {

--- a/modules/doobie-pg/src/test/scala/DoobieDatabaseSuite.scala
+++ b/modules/doobie-pg/src/test/scala/DoobieDatabaseSuite.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.doobie.test
+package grackle.doobie.test
 
 import java.time.{Duration, LocalDate, LocalTime, OffsetDateTime}
 import java.util.UUID
@@ -12,9 +12,9 @@ import doobie.postgres.circe.jsonb.implicits._
 import doobie.{Get, Meta, Put, Transactor}
 import io.circe.Json
 
-import edu.gemini.grackle.doobie.postgres.{DoobieMapping, DoobieMonitor}
+import grackle.doobie.postgres.{DoobieMapping, DoobieMonitor}
 
-import edu.gemini.grackle.sql.test._
+import grackle.sql.test._
 
 trait DoobieDatabaseSuite extends SqlDatabaseSuite {
   // lazy vals because the container is not initialised until the test is run

--- a/modules/doobie-pg/src/test/scala/DoobieSuites.scala
+++ b/modules/doobie-pg/src/test/scala/DoobieSuites.scala
@@ -1,17 +1,17 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.doobie.test
+package grackle.doobie.test
 
 import cats.effect.IO
 import doobie.implicits._
 import doobie.Meta
 
-import edu.gemini.grackle.doobie.postgres.DoobieMonitor
-import edu.gemini.grackle.sql.SqlStatsMonitor
+import grackle.doobie.postgres.DoobieMonitor
+import grackle.sql.SqlStatsMonitor
 
-import edu.gemini.grackle.sql.test._
-import edu.gemini.grackle.Mapping
+import grackle.sql.test._
+import grackle.Mapping
 
 final class ArrayJoinSuite extends DoobieDatabaseSuite with SqlArrayJoinSuite {
   lazy val mapping = new DoobieTestMapping(xa) with SqlArrayJoinMapping[IO]

--- a/modules/generic/src/main/scala-2/genericmapping2.scala
+++ b/modules/generic/src/main/scala-2/genericmapping2.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package generic
 
 import scala.annotation.{nowarn, tailrec}

--- a/modules/generic/src/main/scala-3/genericmapping3.scala
+++ b/modules/generic/src/main/scala-3/genericmapping3.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package generic
 
 import cats.implicits._

--- a/modules/generic/src/main/scala/CursorBuilder.scala
+++ b/modules/generic/src/main/scala/CursorBuilder.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package generic
 
 import scala.collection.Factory

--- a/modules/generic/src/main/scala/genericmapping.scala
+++ b/modules/generic/src/main/scala/genericmapping.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package generic
 
 import cats.MonadThrow

--- a/modules/generic/src/test/scala/DerivationSuite.scala
+++ b/modules/generic/src/test/scala/DerivationSuite.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package generic
 
 import java.time._
@@ -12,7 +12,7 @@ import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle.syntax._
+import grackle.syntax._
 import Query._, Predicate._, Value._
 import QueryCompiler._
 import ScalarType._

--- a/modules/generic/src/test/scala/EffectsSuite.scala
+++ b/modules/generic/src/test/scala/EffectsSuite.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package generic
 
 import cats.effect.{IO, Sync}
@@ -11,7 +11,7 @@ import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle.syntax._
+import grackle.syntax._
 
 class GenericEffectMapping[F[_]: Sync](ref: SignallingRef[F, Int]) extends GenericMapping[F] {
   import semiauto._

--- a/modules/generic/src/test/scala/RecursionSuite.scala
+++ b/modules/generic/src/test/scala/RecursionSuite.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package generic
 
 import cats.effect.IO
@@ -9,7 +9,7 @@ import cats.implicits._
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle.syntax._
+import grackle.syntax._
 import Query._, Predicate._, Value._
 import QueryCompiler._
 

--- a/modules/generic/src/test/scala/ScalarsSuite.scala
+++ b/modules/generic/src/test/scala/ScalarsSuite.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package generic
 
 import java.time.{Duration, LocalDate, LocalTime, OffsetDateTime}
@@ -15,7 +15,7 @@ import io.circe.Encoder
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle.syntax._
+import grackle.syntax._
 import Query._, Predicate._, Value._
 import QueryCompiler._
 

--- a/modules/skunk/js-jvm/src/test/scala/SkunkDatabaseSuite.scala
+++ b/modules/skunk/js-jvm/src/test/scala/SkunkDatabaseSuite.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.skunk.test
+package grackle.skunk.test
 
 import java.time.Duration
 
@@ -11,9 +11,9 @@ import skunk.Session
 import skunk.codec.{ all => codec }
 import skunk.circe.codec.{ all => ccodec }
 
-import edu.gemini.grackle._, skunk._
+import grackle._, skunk._
 
-import edu.gemini.grackle.sql.test._
+import grackle.sql.test._
 
 trait SkunkDatabaseSuite extends SqlDatabaseSuite {
 

--- a/modules/skunk/js-jvm/src/test/scala/SkunkSuites.scala
+++ b/modules/skunk/js-jvm/src/test/scala/SkunkSuites.scala
@@ -1,17 +1,17 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.skunk.test
+package grackle.skunk.test
 
 import cats.effect.IO
 import skunk.codec.{all => codec}
 import skunk.implicits._
 
-import edu.gemini.grackle.skunk.SkunkMonitor
-import edu.gemini.grackle.sql.SqlStatsMonitor
+import grackle.skunk.SkunkMonitor
+import grackle.sql.SqlStatsMonitor
 
-import edu.gemini.grackle.sql.test._
-import edu.gemini.grackle.Mapping
+import grackle.sql.test._
+import grackle.Mapping
 
 import org.typelevel.twiddles._
 

--- a/modules/skunk/js-jvm/src/test/scala/subscription/SubscriptionMapping.scala
+++ b/modules/skunk/js-jvm/src/test/scala/subscription/SubscriptionMapping.scala
@@ -1,14 +1,14 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.skunk.test.subscription
+package grackle.skunk.test.subscription
 
 import cats.effect.{ Resource, Sync }
 import skunk.Session
 import skunk.codec.all._
 import skunk.implicits._
 
-import edu.gemini.grackle._
+import grackle._
 import syntax._
 import Predicate._
 import Query._

--- a/modules/skunk/js-jvm/src/test/scala/subscription/SubscriptionSuite.scala
+++ b/modules/skunk/js-jvm/src/test/scala/subscription/SubscriptionSuite.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.skunk.test.subscription
+package grackle.skunk.test.subscription
 
 import scala.concurrent.duration._
 
@@ -11,7 +11,7 @@ import io.circe.Json
 import io.circe.literal._
 import skunk.implicits._
 
-import edu.gemini.grackle.skunk.test.SkunkDatabaseSuite
+import grackle.skunk.test.SkunkDatabaseSuite
 
 class SubscriptionSuite extends SkunkDatabaseSuite {
 

--- a/modules/skunk/shared/src/main/scala/SkunkMapping.scala
+++ b/modules/skunk/shared/src/main/scala/SkunkMapping.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package skunk
 
 import scala.util.control.NonFatal
@@ -16,7 +16,7 @@ import _root_.skunk.implicits._
 import org.tpolecat.sourcepos.SourcePos
 import org.tpolecat.typename.TypeName
 
-import edu.gemini.grackle.sql._
+import grackle.sql._
 
 abstract class SkunkMapping[F[_]](
   val pool:    Resource[F, Session[F]],

--- a/modules/skunk/shared/src/main/scala/SkunkMappingCompanion.scala
+++ b/modules/skunk/shared/src/main/scala/SkunkMappingCompanion.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package skunk
 
 import _root_.skunk.Session

--- a/modules/skunk/shared/src/main/scala/SkunkMonitor.scala
+++ b/modules/skunk/shared/src/main/scala/SkunkMonitor.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package skunk
 
 import cats.Applicative

--- a/modules/skunk/shared/src/main/scala/package.scala
+++ b/modules/skunk/shared/src/main/scala/package.scala
@@ -1,9 +1,9 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 
-import edu.gemini.grackle.sql.SqlMonitor
+import grackle.sql.SqlMonitor
 import _root_.skunk.AppliedFragment
 
 package object skunk {

--- a/modules/sql/js-jvm/src/test/scala/SqlDatabaseSuite.scala
+++ b/modules/sql/js-jvm/src/test/scala/SqlDatabaseSuite.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import scala.concurrent.duration._
 

--- a/modules/sql/shared/src/main/scala-2/Like.scala
+++ b/modules/sql/shared/src/main/scala-2/Like.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package sql
 
 import scala.util.matching.Regex

--- a/modules/sql/shared/src/main/scala-3/Like.scala
+++ b/modules/sql/shared/src/main/scala-3/Like.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package sql
 
 import scala.util.matching.Regex

--- a/modules/sql/shared/src/main/scala/FailedJoin.scala
+++ b/modules/sql/shared/src/main/scala/FailedJoin.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql
+package grackle.sql
 
 /** A sentinal value representing the empty column values from a failed join. */
 case object FailedJoin

--- a/modules/sql/shared/src/main/scala/SqlMapping.scala
+++ b/modules/sql/shared/src/main/scala/SqlMapping.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package sql
 
 import scala.annotation.tailrec

--- a/modules/sql/shared/src/main/scala/SqlMappingValidator.scala
+++ b/modules/sql/shared/src/main/scala/SqlMappingValidator.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package sql
 
 import cats.data.Chain

--- a/modules/sql/shared/src/main/scala/SqlModule.scala
+++ b/modules/sql/shared/src/main/scala/SqlModule.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package sql
 
 import cats.{Monoid, Reducible}

--- a/modules/sql/shared/src/main/scala/SqlMonitor.scala
+++ b/modules/sql/shared/src/main/scala/SqlMonitor.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package sql
 
 import QueryInterpreter.ProtoJson

--- a/modules/sql/shared/src/main/scala/SqlStatsMonitor.scala
+++ b/modules/sql/shared/src/main/scala/SqlStatsMonitor.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle
+package grackle
 package sql
 
 import cats.Applicative

--- a/modules/sql/shared/src/test/scala/SqlArrayJoinMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlArrayJoinMapping.scala
@@ -1,9 +1,9 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
-import edu.gemini.grackle.syntax._
+import grackle.syntax._
 
 trait SqlArrayJoinMapping[F[_]] extends SqlTestMapping[F] {
 

--- a/modules/sql/shared/src/test/scala/SqlArrayJoinSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlArrayJoinSuite.scala
@@ -1,10 +1,10 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
-import edu.gemini.grackle._
+import grackle._
 import io.circe.literal._
 import munit.CatsEffectSuite
 

--- a/modules/sql/shared/src/test/scala/SqlCoalesceMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlCoalesceMapping.scala
@@ -1,9 +1,9 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
-import edu.gemini.grackle.syntax._
+import grackle.syntax._
 
 trait SqlCoalesceMapping[F[_]] extends SqlTestMapping[F] {
 

--- a/modules/sql/shared/src/test/scala/SqlCoalesceSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlCoalesceSuite.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import cats.syntax.all._
@@ -9,7 +9,7 @@ import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 import sql.SqlStatsMonitor
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqual

--- a/modules/sql/shared/src/test/scala/SqlComposedWorldMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlComposedWorldMapping.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.{Ref, Sync}
 import cats.implicits._
-import edu.gemini.grackle._
-import edu.gemini.grackle.sql.Like
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.sql.Like
+import grackle.syntax._
 import io.circe.Json
 
 import Query._

--- a/modules/sql/shared/src/test/scala/SqlComposedWorldSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlComposedWorldSuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.{assertWeaklyEqual, assertWeaklyEqualIO}
 

--- a/modules/sql/shared/src/test/scala/SqlCompositeKeyMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlCompositeKeyMapping.scala
@@ -1,9 +1,9 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
-import edu.gemini.grackle.syntax._
+import grackle.syntax._
 
 trait SqlCompositeKeyMapping[F[_]] extends SqlTestMapping[F] {
 

--- a/modules/sql/shared/src/test/scala/SqlCompositeKeySuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlCompositeKeySuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlCursorJsonMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlCursorJsonMapping.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.implicits._
 import io.circe.Json
 import io.circe.syntax.EncoderOps
 
-import edu.gemini.grackle._
+import grackle._
 import syntax._
 import Query._
 import Predicate._

--- a/modules/sql/shared/src/test/scala/SqlCursorJsonSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlCursorJsonSuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlCursorJsonSuite extends CatsEffectSuite {

--- a/modules/sql/shared/src/test/scala/SqlEmbedding2Mapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlEmbedding2Mapping.scala
@@ -1,9 +1,9 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
-import edu.gemini.grackle._
+import grackle._
 import Predicate._
 import Query._
 import QueryCompiler._

--- a/modules/sql/shared/src/test/scala/SqlEmbedding2Suite.scala
+++ b/modules/sql/shared/src/test/scala/SqlEmbedding2Suite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlEmbedding3Mapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlEmbedding3Mapping.scala
@@ -1,9 +1,9 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
-import edu.gemini.grackle.syntax._
+import grackle.syntax._
 
 trait SqlEmbedding3Mapping[F[_]] extends SqlTestMapping[F] {
 

--- a/modules/sql/shared/src/test/scala/SqlEmbedding3Suite.scala
+++ b/modules/sql/shared/src/test/scala/SqlEmbedding3Suite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlEmbeddingMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlEmbeddingMapping.scala
@@ -1,9 +1,9 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
-import edu.gemini.grackle.syntax._
+import grackle.syntax._
 
 trait SqlEmbeddingMapping[F[_]] extends SqlTestMapping[F] {
 

--- a/modules/sql/shared/src/test/scala/SqlEmbeddingSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlEmbeddingSuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlFilterJoinAliasMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlFilterJoinAliasMapping.scala
@@ -1,11 +1,11 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.implicits._
 
-import edu.gemini.grackle._
+import grackle._
 import syntax._
 import Predicate.{Const, Eql}
 import Query.{Binding, Filter, Unique}

--- a/modules/sql/shared/src/test/scala/SqlFilterJoinAliasSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlFilterJoinAliasSuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlFilterOrderOffsetLimit2Mapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlFilterOrderOffsetLimit2Mapping.scala
@@ -1,9 +1,9 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
-import edu.gemini.grackle._, syntax._
+import grackle._, syntax._
 import Query.{Binding, Limit}
 import QueryCompiler.{Elab, SelectElaborator}
 import Value.{AbsentValue, IntValue, NullValue}

--- a/modules/sql/shared/src/test/scala/SqlFilterOrderOffsetLimit2Suite.scala
+++ b/modules/sql/shared/src/test/scala/SqlFilterOrderOffsetLimit2Suite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlFilterOrderOffsetLimitMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlFilterOrderOffsetLimitMapping.scala
@@ -1,11 +1,11 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.implicits._
 
-import edu.gemini.grackle._, syntax._
+import grackle._, syntax._
 import Predicate.{Const, Eql}
 import Query.{Binding, Filter, Limit, Offset, OrderBy, OrderSelection, OrderSelections}
 import QueryCompiler.{Elab, SelectElaborator}

--- a/modules/sql/shared/src/test/scala/SqlFilterOrderOffsetLimitSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlFilterOrderOffsetLimitSuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlGraphMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlGraphMapping.scala
@@ -1,12 +1,12 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.implicits._
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Query._, Predicate._, Value._
 import QueryCompiler._
 

--- a/modules/sql/shared/src/test/scala/SqlGraphSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlGraphSuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlInterfacesMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlInterfacesMapping.scala
@@ -1,12 +1,12 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.kernel.Eq
 import io.circe.Encoder
 
-import edu.gemini.grackle._
+import grackle._
 import syntax._
 import Predicate._
 import Query._

--- a/modules/sql/shared/src/test/scala/SqlInterfacesMapping2.scala
+++ b/modules/sql/shared/src/test/scala/SqlInterfacesMapping2.scala
@@ -1,9 +1,9 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
-import edu.gemini.grackle._
+import grackle._
 import Predicate._
 
 trait SqlInterfacesMapping2[F[_]] extends SqlInterfacesMapping[F] { self =>

--- a/modules/sql/shared/src/test/scala/SqlInterfacesSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlInterfacesSuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlInterfacesSuite2.scala
+++ b/modules/sql/shared/src/test/scala/SqlInterfacesSuite2.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlJsonbMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlJsonbMapping.scala
@@ -1,11 +1,11 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.implicits._
 
-import edu.gemini.grackle._
+import grackle._
 import syntax._
 
 import Query._

--- a/modules/sql/shared/src/test/scala/SqlJsonbSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlJsonbSuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlLikeMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlLikeMapping.scala
@@ -1,10 +1,10 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Query._, Predicate._, Value._
 import QueryCompiler._
 import sql.Like

--- a/modules/sql/shared/src/test/scala/SqlLikeSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlLikeSuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 trait SqlLikeSuite extends CatsEffectSuite {

--- a/modules/sql/shared/src/test/scala/SqlMixedMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlMixedMapping.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import java.util.UUID
 
@@ -10,7 +10,7 @@ import scala.util.Try
 import cats.implicits._
 import io.circe.literal._
 
-import edu.gemini.grackle._
+import grackle._
 import syntax._
 import Query._
 import Predicate._

--- a/modules/sql/shared/src/test/scala/SqlMixedSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlMixedSuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlMovieMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlMovieMapping.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 
 import java.time.{Duration, LocalDate, LocalTime, OffsetDateTime}
@@ -13,7 +13,7 @@ import cats.{Eq, Order}
 import cats.implicits._
 import io.circe.Encoder
 
-import edu.gemini.grackle._
+import grackle._
 import syntax._
 import Query._
 import Predicate._

--- a/modules/sql/shared/src/test/scala/SqlMovieSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlMovieSuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlMutationMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlMutationMapping.scala
@@ -1,11 +1,11 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.syntax.all._
 
-import edu.gemini.grackle._
+import grackle._
 import syntax._
 import Predicate._
 import Query._

--- a/modules/sql/shared/src/test/scala/SqlMutationSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlMutationSuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlNestedEffectsMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlNestedEffectsMapping.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.{Ref, Sync}
 import cats.implicits._
@@ -9,7 +9,7 @@ import io.circe.{Encoder, Json}
 import io.circe.syntax._
 import io.circe.generic.semiauto.deriveEncoder
 
-import edu.gemini.grackle._
+import grackle._
 import sql.Like
 import syntax._
 import Query._

--- a/modules/sql/shared/src/test/scala/SqlNestedEffectsSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlNestedEffectsSuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.{assertWeaklyEqual, assertWeaklyEqualIO}
 

--- a/modules/sql/shared/src/test/scala/SqlPaging1Mapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlPaging1Mapping.scala
@@ -1,11 +1,11 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.implicits._
 
-import edu.gemini.grackle._, syntax._
+import grackle._, syntax._
 import Query.{Binding, Count, FilterOrderByOffsetLimit, OrderSelection, Select}
 import QueryCompiler.{Elab, SelectElaborator}
 import Value.IntValue

--- a/modules/sql/shared/src/test/scala/SqlPaging1Suite.scala
+++ b/modules/sql/shared/src/test/scala/SqlPaging1Suite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlPaging2Mapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlPaging2Mapping.scala
@@ -1,11 +1,11 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.implicits._
 
-import edu.gemini.grackle._, syntax._
+import grackle._, syntax._
 import Query.{Binding, Count, FilterOrderByOffsetLimit, OrderSelection, Select}
 import QueryCompiler.{Elab, SelectElaborator}
 import Value._

--- a/modules/sql/shared/src/test/scala/SqlPaging2Suite.scala
+++ b/modules/sql/shared/src/test/scala/SqlPaging2Suite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlPaging3Mapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlPaging3Mapping.scala
@@ -1,11 +1,11 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.implicits._
 
-import edu.gemini.grackle._, syntax._
+import grackle._, syntax._
 import Cursor.ListTransformCursor
 import Query.{Binding, Count, FilterOrderByOffsetLimit, OrderSelection, Select, TransformCursor}
 import QueryCompiler.{Elab, SelectElaborator}

--- a/modules/sql/shared/src/test/scala/SqlPaging3Suite.scala
+++ b/modules/sql/shared/src/test/scala/SqlPaging3Suite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlProjectionMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlProjectionMapping.scala
@@ -1,11 +1,11 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.implicits._
 
-import edu.gemini.grackle._, syntax._
+import grackle._, syntax._
 import Predicate.{Const, Eql}
 import Query.{Binding, Filter}
 import QueryCompiler._

--- a/modules/sql/shared/src/test/scala/SqlProjectionSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlProjectionSuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlRecursiveInterfacesMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlRecursiveInterfacesMapping.scala
@@ -1,12 +1,12 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.kernel.Eq
 import io.circe.Encoder
 
-import edu.gemini.grackle._
+import grackle._
 import syntax._
 import Predicate._
 

--- a/modules/sql/shared/src/test/scala/SqlRecursiveInterfacesSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlRecursiveInterfacesSuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlSiblingListsMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlSiblingListsMapping.scala
@@ -1,10 +1,10 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.implicits._
-import edu.gemini.grackle._
+import grackle._
 import Predicate.{Const, Eql}
 import Query.{Binding, Filter, Unique}
 import QueryCompiler._

--- a/modules/sql/shared/src/test/scala/SqlSiblingListsSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlSiblingListsSuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlTestMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlTestMapping.scala
@@ -1,11 +1,11 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import org.tpolecat.sourcepos.SourcePos
 
-import edu.gemini.grackle._
+import grackle._
 import sql.SqlMappingLike
 
 trait SqlTestMapping[F[_]] extends SqlMappingLike[F] { outer =>

--- a/modules/sql/shared/src/test/scala/SqlTreeMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlTreeMapping.scala
@@ -1,12 +1,12 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.implicits._
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Query._, Predicate._, Value._
 import QueryCompiler._
 

--- a/modules/sql/shared/src/test/scala/SqlTreeSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlTreeSuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlUnionSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlUnionSuite.scala
@@ -1,13 +1,13 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 

--- a/modules/sql/shared/src/test/scala/SqlUnionsMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlUnionsMapping.scala
@@ -1,10 +1,10 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
-import edu.gemini.grackle._
-import edu.gemini.grackle.syntax._
+import grackle._
+import grackle.syntax._
 import Predicate._
 
 trait SqlUnionsMapping[F[_]] extends SqlTestMapping[F] {

--- a/modules/sql/shared/src/test/scala/SqlWorldCompilerSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlWorldCompilerSuite.scala
@@ -1,14 +1,14 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import io.circe.Json
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 import Predicate._, Query._
 import sql.{Like, SqlStatsMonitor}
 

--- a/modules/sql/shared/src/test/scala/SqlWorldMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlWorldMapping.scala
@@ -1,11 +1,11 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.implicits._
 
-import edu.gemini.grackle._
+import grackle._
 import sql.Like
 import syntax._
 import Query._, Predicate._, Value._

--- a/modules/sql/shared/src/test/scala/SqlWorldSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlWorldSuite.scala
@@ -1,14 +1,14 @@
 // Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package edu.gemini.grackle.sql.test
+package grackle.sql.test
 
 import cats.effect.IO
 import cats.implicits._
 import io.circe.literal._
 import munit.CatsEffectSuite
 
-import edu.gemini.grackle._
+import grackle._
 
 import grackle.test.GraphQLResponseTests.{assertNoErrorsIO, assertWeaklyEqualIO}
 

--- a/profile/src/main/scala/Bench.scala
+++ b/profile/src/main/scala/Bench.scala
@@ -11,7 +11,7 @@ import cats.implicits._
 import _root_.doobie.util.meta.Meta
 import _root_.doobie.util.transactor.Transactor
 
-import edu.gemini.grackle._
+import grackle._
 import doobie.postgres.{DoobieMapping, DoobieMappingCompanion, DoobieMonitor}
 import sql.Like
 import syntax._


### PR DESCRIPTION
+ Repository is now at https://github.com/typelevel/grackle.
+ Package name is now `grackle`.
+ Artefact coordinates are now `"org.typelevel" % "grackle-<module>" % "<version>"`