### PR TITLE
Rely on sbt-typelevel defaults for organization

### DIFF
--- a/benchmarks/src/main/scala/ParserBenchmark.scala
+++ b/benchmarks/src/main/scala/ParserBenchmark.scala
@@ -1,18 +1,17 @@
-/*
- * Copyright 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2023 Grackle Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package grackle.benchmarks
 

--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,6 @@ ThisBuild / crossScalaVersions  := Seq(Scala2, Scala3)
 ThisBuild / tlJdkRelease        := Some(11)
 
 ThisBuild / tlBaseVersion    := "0.16"
-ThisBuild / organization     := "org.typelevel"
-ThisBuild / organizationName := "Association of Universities for Research in Astronomy, Inc. (AURA)"
 ThisBuild / startYear        := Some(2019)
 ThisBuild / licenses         := Seq(License.Apache2)
 ThisBuild / developers       := List(
@@ -258,6 +256,7 @@ lazy val benchmarks = project
   .in(file("benchmarks"))
   .dependsOn(core.jvm)
   .enablePlugins(NoPublishPlugin, AutomateHeaderPlugin, JmhPlugin)
+  .settings(commonSettings)
 
 lazy val profile = project
   .in(file("profile"))


### PR DESCRIPTION
`organizationName` should have changed with the move to Typelevel. Better to rely on the defaults in sbt-typelevel for this.