### PR TITLE
Negative lookahead when parsing keywords

### DIFF
--- a/modules/core/src/main/scala/parser.scala
+++ b/modules/core/src/main/scala/parser.scala
@@ -29,7 +29,7 @@ object GraphQLParser {
   val nameInitial    = ('A' to 'Z') ++ ('a' to 'z') ++ Seq('_')
   val nameSubsequent = nameInitial ++ ('0' to '9')
 
-  def keyword(s: String) = token(string(s) <* not(charIn(nameSubsequent)).backtrack)
+  def keyword(s: String) = token(string(s) <* not(charIn(nameSubsequent)))
 
   def punctuation(s: String) = token(string(s))
 


### PR DESCRIPTION
Fixes a bug in keyword parsing which became more obvious with the addition of type extensions, because this is the first time the parser has needed to recognize adjacent alphabetic keywords (eg. `extend type`).

Prior to this PR the parser would accept `extendtype` as equivalent to `extend type`. The [spec requires](https://spec.graphql.org/October2021/#Name) keywords to be parsed in the same way as names which have negative lookahead preventing them from being followed by a name continuation character. In practice this means that adjacent keywords must be separated by whitespace, comments or commas.