### PR TITLE
Add coverage for Grackle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
         if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
         run: sbt +update
 
-      - run: sbt '++ ${{ matrix.scala }}' coverage coreJVM/test coverageReport
+      - run: sbt '++ ${{ matrix.scala }}' coverage rootJVM/test coverageReport
 
       - uses: codecov/codecov-action@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.12]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -268,7 +267,7 @@ jobs:
         if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
         run: sbt +update
 
-      - run: sbt '++ ${{ matrix.scala }}' coverage rootJVM/test coverageReport
+      - run: sbt coverage rootJVM/test coverageReport
 
       - uses: codecov/codecov-action@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,37 @@ jobs:
           modules-ignore: grackle-demo_2.13 grackle-demo_3 benchmarks_2.13 benchmarks_3 rootjs_2.13 rootjs_3 docs_2.13 docs_3 buildinfo_native0.4_2.13 buildinfo_native0.4_3 buildinfo_sjs1_2.13 buildinfo_sjs1_3 profile_2.13 profile_3 rootjvm_2.13 rootjvm_3 rootnative_2.13 rootnative_3 buildinfo_2.13 buildinfo_3
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
+  coverage:
+    name: Generate coverage report (2.13 JVM only)
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.12]
+        java: [temurin@11]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java (temurin@11)
+        id: setup-java-temurin-11
+        if: matrix.java == 'temurin@11'
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
+        run: sbt +update
+
+      - run: sbt '++ ${{ matrix.scala }}' coverage coreJVM/test coverageReport
+
+      - uses: codecov/codecov-action@v3
+
   site:
     name: Generate Site
     strategy:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/org.typelevel/grackle-core_2.13?versionPrefix=0)](https://img.shields.io/maven-central/v/org.typelevel/grackle-core_2.13?versionPrefix=0)
 [![javadoc](https://javadoc.io/badge2/org.typelevel/grackle-core_2.13/javadoc.svg)](https://javadoc.io/doc/org.typelevel/grackle-core_2.13)
 [![Typelevel library](https://img.shields.io/badge/typelevel-library-green.svg)](https://typelevel.org/projects/#grackle)
+[![codecov](https://codecov.io/gh/typelevel/grackle/branch/main/graph/badge.svg)](https://codecov.io/gh/typelevel/grackle)
 [![Discord](https://img.shields.io/discord/632277896739946517.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)][grackle-dev]
 
 ## Overview
@@ -32,9 +33,9 @@ the last four years.
 
 ## Getting Started
 
-+ See the [tutorial](https://typelevel.org/grackle) and accompanying [demo](https://github.com/typelevel/grackle/tree/main/demo/src/main).
-+ Online Scaladoc is available [here](https://javadoc.io/doc/org.typelevel/grackle-core_2.13).
-+ Ask us anything the in **#grackle** channel on the Typelevel [discord server][grackle-dev].
+- See the [tutorial](https://typelevel.org/grackle) and accompanying [demo](https://github.com/typelevel/grackle/tree/main/demo/src/main).
+- Online Scaladoc is available [here](https://javadoc.io/doc/org.typelevel/grackle-core_2.13).
+- Ask us anything the in **#grackle** channel on the Typelevel [discord server][grackle-dev].
 
 To add Grackle to your project you should add the following to your `build.sbt`,
 
@@ -57,7 +58,7 @@ libraryDependencies += "org.typelevel" %% "grackle-skunk" % "0.15.0"
 
 ## Community
 
-Grackle is proud to be a [Typelevel](https://typelevel.org/) project.  We are committed to providing a friendly, safe
+Grackle is proud to be a [Typelevel](https://typelevel.org/) project. We are committed to providing a friendly, safe
 and welcoming environment for all, and ask that the community adhere to the [Scala Code of
 Conduct](https://www.scala-lang.org/conduct/) in all venues.
 
@@ -66,7 +67,7 @@ discussions][grackle-pulls], and [discord][grackle-dev].
 
 The Typelevel [discord][grackle-dev] has a **#grackle** channel, as well as channels for related
 projects channels such as **#cats**, **#cats-effect**, **#fs2**, **#doobie** and **#skunk**. If you're new to the Typelevel
-ecosystem the **#beginners** channel might also be useful.  Please join us!
+ecosystem the **#beginners** channel might also be useful. Please join us!
 
 ## Contributing
 

--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,19 @@ ThisBuild / githubWorkflowBuild     ~= { steps =>
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11"))
 ThisBuild / tlBspCrossProjectPlatforms := Set(JVMPlatform)
 
+ThisBuild / githubWorkflowAddedJobs +=
+  WorkflowJob(
+    id = "coverage",
+    name = s"Generate coverage report (2.13 JVM only)",
+    scalas = List(Scala2),
+    steps = githubWorkflowJobSetup.value.toList ++
+      List(
+        WorkflowStep.Sbt(List("coverage", "coreJVM/test", "coverageReport")),
+        WorkflowStep.Use(UseRef.Public("codecov", "codecov-action", "v3"))
+      )
+  )
+
+
 ThisBuild / tlSitePublishBranch := Some("main")
 
 lazy val commonSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ ThisBuild / githubWorkflowAddedJobs +=
     scalas = List(Scala2),
     steps = githubWorkflowJobSetup.value.toList ++
       List(
-        WorkflowStep.Sbt(List("coverage", "coreJVM/test", "coverageReport")),
+        WorkflowStep.Sbt(List("coverage", "rootJVM/test", "coverageReport")),
         WorkflowStep.Use(UseRef.Public("codecov", "codecov-action", "v3"))
       )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,8 @@ ThisBuild / githubWorkflowAddedJobs +=
   WorkflowJob(
     id = "coverage",
     name = s"Generate coverage report (2.13 JVM only)",
-    scalas = List(Scala2),
+    scalas = Nil,
+    sbtStepPreamble = Nil,
     steps = githubWorkflowJobSetup.value.toList ++
       List(
         WorkflowStep.Sbt(List("coverage", "rootJVM/test", "coverageReport")),

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,3 +8,4 @@ addSbtPlugin("nl.zolotko.sbt"            % "sbt-jfr"                       % "0.
 addSbtPlugin("com.eed3si9n"              % "sbt-buildinfo"                 % "0.11.0")
 addSbtPlugin("org.scala-js"              % "sbt-scalajs"                   % "1.14.0")
 addSbtPlugin("org.scala-native"          % "sbt-scala-native"              % "0.4.16")
+addSbtPlugin("org.scoverage"             % "sbt-scoverage"                 % "2.0.9")


### PR DESCRIPTION
This PR addresses #183 and adds support for code coverage to Grackle.

- Updated the build.sbt file 
- Updated the ci.yml file based on `githubWorkflowGenerate`
- Updated the README with a badge to show coverage based on `typelevel/grackle:main` - Note that for this to work and show the actual result, the uploading process to codecov should occur. This is all set up in this PR, but a repo token needs to be setup (I think in the environment).

Please review, and let me know if any further changes are required.