### PR TITLE
exclude demo, benchmarks and profile from coverage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -249,6 +249,7 @@ lazy val demo = project
   .settings(commonSettings)
   .settings(
     name := "grackle-demo",
+    coverageEnabled := false,
     libraryDependencySchemes += "org.typelevel" %% "cats-parse" % "always", // Workaround until http4s updates to 1.0.0 as well
     libraryDependencies ++= Seq(
       "org.typelevel"     %% "log4cats-slf4j"      % log4catsVersion,
@@ -271,6 +272,9 @@ lazy val benchmarks = project
   .dependsOn(core.jvm)
   .enablePlugins(NoPublishPlugin, AutomateHeaderPlugin, JmhPlugin)
   .settings(commonSettings)
+  .settings(    
+    coverageEnabled := false,
+)
 
 lazy val profile = project
   .in(file("profile"))
@@ -290,7 +294,8 @@ lazy val profile = project
         pathToGcRoots = true.some,
       )
     ),
-    fork := true
+    fork := true,
+    coverageEnabled := false,
   )
 
 lazy val docs = project

--- a/build.sbt
+++ b/build.sbt
@@ -305,7 +305,8 @@ lazy val docs = project
   .settings(
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-effect" % catsEffectVersion
-    )
+    ),
+    coverageEnabled := false,
   )
 
 lazy val unidocs = project
@@ -313,6 +314,7 @@ lazy val unidocs = project
   .enablePlugins(TypelevelUnidocPlugin)
   .settings(
     name := "grackle-docs",
+    coverageEnabled := false,
     ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(
       core.jvm,
       circe.jvm,


### PR DESCRIPTION
In the course of #507 @milessabin proposed that we exclude demo, benchmarks and profile from coverage for straightforward reasons. 

@armanbilge proposed a mechanism of doing so, which is the path followed in the current PR which addresses the same. This uses the `coverageEnabled` flag in sbt project settings.