### PR TITLE
Change flyway dependency for demo module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -251,18 +251,18 @@ lazy val demo = project
     name := "grackle-demo",
     coverageEnabled := false,
     libraryDependencies ++= Seq(
-      "org.typelevel"     %% "log4cats-slf4j"      % log4catsVersion,
-      "ch.qos.logback"    %  "logback-classic"     % logbackVersion,
-      "org.tpolecat"      %% "doobie-core"         % doobieVersion,
-      "org.tpolecat"      %% "doobie-postgres"     % doobieVersion,
-      "org.tpolecat"      %% "doobie-hikari"       % doobieVersion,
-      "org.http4s"        %% "http4s-ember-server" % http4sVersion,
-      "org.http4s"        %% "http4s-ember-client" % http4sVersion,
-      "org.http4s"        %% "http4s-circe"        % http4sVersion,
-      "org.http4s"        %% "http4s-dsl"          % http4sVersion,
-      "org.flywaydb"      %  "flyway-core"         % flywayVersion,
-      "io.chrisdavenport" %% "whale-tail-manager"  % whaleTailVersion,
-      "com.github.jnr"    % "jnr-unixsocket"       % jnrUnixsocketVersion
+      "org.typelevel"     %% "log4cats-slf4j"             % log4catsVersion,
+      "ch.qos.logback"    %  "logback-classic"            % logbackVersion,
+      "org.tpolecat"      %% "doobie-core"                % doobieVersion,
+      "org.tpolecat"      %% "doobie-postgres"            % doobieVersion,
+      "org.tpolecat"      %% "doobie-hikari"              % doobieVersion,
+      "org.http4s"        %% "http4s-ember-server"        % http4sVersion,
+      "org.http4s"        %% "http4s-ember-client"        % http4sVersion,
+      "org.http4s"        %% "http4s-circe"               % http4sVersion,
+      "org.http4s"        %% "http4s-dsl"                 % http4sVersion,
+      "org.flywaydb"      %  "flyway-database-postgresql" % flywayVersion,
+      "io.chrisdavenport" %% "whale-tail-manager"         % whaleTailVersion,
+      "com.github.jnr"    % "jnr-unixsocket"              % jnrUnixsocketVersion
     )
   )
 


### PR DESCRIPTION
There is a breaking change in Flyway 10.0.0, which introduced modularized database support. We need to use flyway module specific for PostgreSQL now, since core has no support for it.