### PR TITLE
Fixes for empty SQL sub-objects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ ThisBuild / scalaVersion        := Scala2
 ThisBuild / crossScalaVersions  := Seq(Scala2, Scala3)
 ThisBuild / tlJdkRelease        := Some(11)
 
-ThisBuild / tlBaseVersion    := "0.16"
+ThisBuild / tlBaseVersion    := "0.17"
 ThisBuild / startYear        := Some(2019)
 ThisBuild / licenses         := Seq(License.Apache2)
 ThisBuild / developers       := List(

--- a/modules/sql/shared/src/test/scala/SqlMixedMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlMixedMapping.scala
@@ -41,6 +41,7 @@ trait SqlMixedMapping[F[_]] extends SqlTestMapping[F] with ValueMappingLike[F] {
     schema"""
         type Query {
           movie(id: UUID!): Movie
+          movies: [Movie!]!
           foo: Foo!
           bar: Bar
         }
@@ -48,6 +49,8 @@ trait SqlMixedMapping[F[_]] extends SqlTestMapping[F] with ValueMappingLike[F] {
           id: UUID!
           title: String!
           nested: Bar
+          genre: String!
+          rating: Float!
         }
         type Foo {
           value: Int!
@@ -73,6 +76,7 @@ trait SqlMixedMapping[F[_]] extends SqlTestMapping[F] with ValueMappingLike[F] {
         fieldMappings =
           List(
             SqlObject("movie"),
+            SqlObject("movies"),
             ValueField[Unit]("foo", _ => Foo(23)),
             CirceField("bar", json"""{ "message": "Hello world" }""")
           )
@@ -83,7 +87,9 @@ trait SqlMixedMapping[F[_]] extends SqlTestMapping[F] with ValueMappingLike[F] {
           List(
             SqlField("id", movies.id, key = true),
             SqlField("title", movies.title),
-            CirceField("nested", json"""{ "message": "Hello world nested" }""")
+            CirceField("nested", json"""{ "message": "Hello world nested" }"""),
+            ValueField[Unit]("genre", _ => "comedy"),
+            CirceField("rating", json"""7.8""")
           )
       ),
       ValueObjectMapping[Foo](

--- a/modules/sql/shared/src/test/scala/SqlMixedSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlMixedSuite.scala
@@ -134,7 +134,7 @@ trait SqlMixedSuite extends CatsEffectSuite {
     assertWeaklyEqualIO(res, expected)
   }
 
-  test("mixed query nested") {
+  test("mixed query nested (1)") {
     val query = """
       query {
         movie(id: "6a7837fc-b463-4d32-b628-0f4b3065cb21") {
@@ -155,6 +155,226 @@ trait SqlMixedSuite extends CatsEffectSuite {
                "message": "Hello world nested"
             }
           }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query)
+
+    assertWeaklyEqualIO(res, expected)
+  }
+
+  test("mixed query nested (2)") {
+    val query = """
+      query {
+        movie(id: "6a7837fc-b463-4d32-b628-0f4b3065cb21") {
+          nested {
+            message
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "movie" : {
+            "nested" : {
+               "message": "Hello world nested"
+            }
+          }
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query)
+
+    assertWeaklyEqualIO(res, expected)
+  }
+
+  test("mixed query nested (3)") {
+    val query = """
+      query {
+        movies {
+          rating
+          nested {
+            message
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "movies" : [
+            {
+              "rating" : 7.8,
+              "nested" : {
+                "message" : "Hello world nested"
+              }
+            },
+            {
+              "rating" : 7.8,
+              "nested" : {
+                "message" : "Hello world nested"
+              }
+            },
+            {
+              "rating" : 7.8,
+              "nested" : {
+                "message" : "Hello world nested"
+              }
+            },
+            {
+              "rating" : 7.8,
+              "nested" : {
+                "message" : "Hello world nested"
+              }
+            },
+            {
+              "rating" : 7.8,
+              "nested" : {
+                "message" : "Hello world nested"
+              }
+            },
+            {
+              "rating" : 7.8,
+              "nested" : {
+                "message" : "Hello world nested"
+              }
+            },
+            {
+              "rating" : 7.8,
+              "nested" : {
+                "message" : "Hello world nested"
+              }
+            },
+            {
+              "rating" : 7.8,
+              "nested" : {
+                "message" : "Hello world nested"
+              }
+            },
+            {
+              "rating" : 7.8,
+              "nested" : {
+                "message" : "Hello world nested"
+              }
+            },
+            {
+              "rating" : 7.8,
+              "nested" : {
+                "message" : "Hello world nested"
+              }
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query)
+
+    assertWeaklyEqualIO(res, expected)
+  }
+
+  test("mixed query only leaf (1)") {
+    val query = """
+      query {
+        movies {
+          genre
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "movies" : [
+            {
+              "genre" : "comedy"
+            },
+            {
+              "genre" : "comedy"
+            },
+            {
+              "genre" : "comedy"
+            },
+            {
+              "genre" : "comedy"
+            },
+            {
+              "genre" : "comedy"
+            },
+            {
+              "genre" : "comedy"
+            },
+            {
+              "genre" : "comedy"
+            },
+            {
+              "genre" : "comedy"
+            },
+            {
+              "genre" : "comedy"
+            },
+            {
+              "genre" : "comedy"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query)
+
+    assertWeaklyEqualIO(res, expected)
+  }
+
+  test("mixed query only leaf (2)") {
+    val query = """
+      query {
+        movies {
+          rating
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "movies" : [
+            {
+              "rating" : 7.8
+            },
+            {
+              "rating" : 7.8
+            },
+            {
+              "rating" : 7.8
+            },
+            {
+              "rating" : 7.8
+            },
+            {
+              "rating" : 7.8
+            },
+            {
+              "rating" : 7.8
+            },
+            {
+              "rating" : 7.8
+            },
+            {
+              "rating" : 7.8
+            },
+            {
+              "rating" : 7.8
+            },
+            {
+              "rating" : 7.8
+            }
+          ]
         }
       }
     """


### PR DESCRIPTION
The handling of empty SQL subobjects (previously represented by a context-free singleton `EmptySqlQuery`) was incorrect in several scenarios.

This showed up in particular in mixed mappings where non-SQL fields were nested in SQL objects. This manifested itself as unexpectedly empty arrays of subobjects, or possibly hit previously unimplemented methods of `EmptySqlQuery`. Both are fixed by ensuring that SQL ids are included when we, in effect, "join" a SQL with a non-SQL object. `EmptySqlQuery` is now a non-singleton and has a context and the unimplemented methods have been either implemented or removed.