### PR TITLE
Elaborate introspection in out of line fragments

### DIFF
--- a/modules/generic/src/main/scala-2/genericmapping2.scala
+++ b/modules/generic/src/main/scala-2/genericmapping2.scala
@@ -87,13 +87,6 @@ trait ScalaVersionSpecificGenericMappingLike[F[_]] extends Mapping[F] { self: Ge
 
       override def field(fieldName: String, resultName: Option[String]): Result[Cursor] =
         mkCursorForField(this, fieldName, resultName) orElse {
-          fieldMap.get(fieldName) match {
-            case None =>
-              println(s"No field '$fieldName' for type $tpe")
-              println(fieldMap)
-            case _ =>
-          }
-
           fieldMap.get(fieldName).toResult(s"No field '$fieldName' for type $tpe").flatMap { f =>
             f(context.forFieldOrAttribute(fieldName, resultName), focus, Some(this), Env.empty)
           }


### PR DESCRIPTION
Introspection fields in out of line fragments should be elaborated. Fixes #520.

Also removed some stray debugging code.