### PR TITLE
Tweak to some collections usage

### DIFF
--- a/modules/circe/src/main/scala/circemapping.scala
+++ b/modules/circe/src/main/scala/circemapping.scala
@@ -116,7 +116,7 @@ trait CirceMappingLike[F[_]] extends Mapping[F] {
             .toResultOrError(s"Expected Int found ${focus.noSpaces}")
         case FloatType         if focus.isNumber  => focus.success
         case e: EnumType       if focus.isString  =>
-          if (focus.asString.map(e.hasValue).getOrElse(false)) focus.success
+          if (focus.asString.exists(e.hasValue)) focus.success
           else Result.internalError(s"Expected Enum ${e.name}, found ${focus.noSpaces}")
         case _: ScalarType     if !focus.isObject => focus.success // custom Scalar; any non-object type is fine
         case _ =>
@@ -182,7 +182,7 @@ trait CirceMappingLike[F[_]] extends Mapping[F] {
 
     def hasField(fieldName: String): Boolean =
       fieldMapping(context, fieldName).isDefined ||
-      tpe.hasField(fieldName) && focus.asObject.map(_.contains(fieldName)).getOrElse(false)
+      tpe.hasField(fieldName) && focus.asObject.exists(_.contains(fieldName))
 
     def field(fieldName: String, resultName: Option[String]): Result[Cursor] = {
       mkCursorForField(this, fieldName, resultName)

--- a/modules/core/src/main/scala/cursor.scala
+++ b/modules/core/src/main/scala/cursor.scala
@@ -63,7 +63,7 @@ trait Cursor {
   def fullEnv: Env = parent.map(_.fullEnv).getOrElse(Env.empty).add(env)
 
   /** Does the environment at this `Cursor` contain a value for the supplied key? */
-  def envContains(nme: String): Boolean = env.contains(nme) || parent.map(_.envContains(nme)).getOrElse(false)
+  def envContains(nme: String): Boolean = env.contains(nme) || parent.exists(_.envContains(nme))
 
   /**
    * Yield the value at this `Cursor` as a value of type `T` if possible,

--- a/modules/core/src/main/scala/queryinterpreter.scala
+++ b/modules/core/src/main/scala/queryinterpreter.scala
@@ -44,7 +44,7 @@ class QueryInterpreter[F[_]](mapping: Mapping[F]) {
   def run(query: Query, rootTpe: Type, env: Env): Stream[F, Result[Json]] = {
     val rootCursor = RootCursor(Context(rootTpe), None, env)
     val mergedResults =
-      if(mapping.schema.subscriptionType.map(_ =:= rootTpe).getOrElse(false))
+      if(mapping.schema.subscriptionType.exists(_ =:= rootTpe))
         runSubscription(query, rootTpe, rootCursor)
       else
         Stream.eval(runOneShot(query, rootTpe, rootCursor))

--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -898,7 +898,7 @@ case class Field(
   def deprecationReason: Option[String] =
     for {
       dir    <- deprecatedDirective
-      reason <- dir.args.collect { case Binding("reason", StringValue(reason)) => reason }.headOption
+      reason <- dir.args.collectFirst { case Binding("reason", StringValue(reason)) => reason }
     } yield reason
 }
 

--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -1261,7 +1261,7 @@ object Directive {
           case None => (Problem(s"Undefined directive '$nme'") :: locs, reps)
           case Some(defn) =>
             val locs0 =
-              if (defn.locations.exists(_ == location)) locs
+              if (defn.locations.contains(location)) locs
               else Problem(s"Directive '$nme' is not allowed on $location") :: locs
 
             val reps0 =

--- a/modules/core/src/main/scala/valuemapping.scala
+++ b/modules/core/src/main/scala/valuemapping.scala
@@ -144,11 +144,11 @@ trait ValueMappingLike[F[_]] extends Mapping[F] {
 
     def narrowsTo(subtpe: TypeRef): Boolean =
       subtpe <:< tpe &&
-        objectMapping(context.asType(subtpe)).map {
+        objectMapping(context.asType(subtpe)).exists {
           case ValueObjectMapping(_, _, classTag) =>
             classTag.runtimeClass.isInstance(focus)
           case _ => false
-        }.getOrElse(false)
+        }
 
 
     def narrow(subtpe: TypeRef): Result[Cursor] =

--- a/modules/sql/shared/src/main/scala/SqlMapping.scala
+++ b/modules/sql/shared/src/main/scala/SqlMapping.scala
@@ -2581,7 +2581,7 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
       def withContext(context: Context, extraCols: List[SqlColumn], extraJoins: List[SqlJoin]): Result[SqlUnion] =
         elems.traverse(_.withContext(context, extraCols, extraJoins)).map(SqlUnion(_))
 
-      def owns(col: SqlColumn): Boolean = cols.exists(_ == col) || elems.exists(_.owns(col))
+      def owns(col: SqlColumn): Boolean = cols.contains(col) || elems.exists(_.owns(col))
       def contains(other: ColumnOwner): Boolean = isSameOwner(other) || elems.exists(_.contains(other))
       def directlyOwns(col: SqlColumn): Boolean = owns(col)
       def findNamedOwner(col: SqlColumn): Option[TableExpr] = None

--- a/modules/sql/shared/src/main/scala/SqlMapping.scala
+++ b/modules/sql/shared/src/main/scala/SqlMapping.scala
@@ -3307,7 +3307,7 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
     /** Specialized representation of a table with exactly one row */
     case class OneRowTable(row: Array[Any]) extends Table {
       def numRows: Int = 1
-      def numCols = row.size
+      def numCols = row.length
 
       def select(col: Int): Option[Any] =
         Some(row(col))
@@ -3341,7 +3341,7 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
 
     case class MultiRowTable(rows: Vector[Array[Any]]) extends Table {
       def numRows = rows.size
-      def numCols = rows.headOption.map(_.size).getOrElse(0)
+      def numCols = rows.headOption.map(_.length).getOrElse(0)
 
       def select(col: Int): Option[Any] = {
         val c = col

--- a/modules/sql/shared/src/test/scala/SqlPaging3Mapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlPaging3Mapping.scala
@@ -160,7 +160,7 @@ trait SqlPaging3Mapping[F[_]] extends SqlTestMapping[F] {
           size  <- c.listSize
           elems <- c.asList(Seq)
         } yield {
-          if(limit.map(size <= _).getOrElse(true)) c
+          if(limit.forall(size <= _)) c
           else ListTransformCursor(c, size-1, elems.init)
         }
       }
@@ -173,7 +173,7 @@ trait SqlPaging3Mapping[F[_]] extends SqlTestMapping[F] {
           for {
             items <- c.field("items", itemsAlias)
             size  <- items.listSize
-          } yield limit.map(size > _).getOrElse(false)
+          } yield limit.exists(size > _)
         } else {
           for {
             num <- c.fieldAs[Long](countField)


### PR DESCRIPTION
This brings some minor improvements to some collections usage. In some occurrences, it only slightly improves readability. Plus, brings some tiny micro-optimization of using `length` on Arrays instead of `size`. While such calls are legitimate, they require an additional implicit conversion to `SeqLike`. Anyway, this may not be that necessary — take it or leave it.