### PR TITLE
support for scalar argument without apostrophes

### DIFF
--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -1011,6 +1011,8 @@ object Value {
         value.success
       case (s: ScalarType, Some(value: BooleanValue)) if !s.isBuiltIn =>
         value.success
+      case (s: ScalarType, Some(enumValue: EnumValue)) if !s.isBuiltIn =>
+        StringValue(enumValue.name).success
 
       case (IDType, Some(value: IDValue)) =>
         value.success

--- a/modules/core/src/test/scala/compiler/ScalarsSuite.scala
+++ b/modules/core/src/test/scala/compiler/ScalarsSuite.scala
@@ -388,6 +388,39 @@ final class ScalarsSuite extends CatsEffectSuite {
     assertIO(res, expected)
   }
 
+  test("query with scalar argument without apostrophes") {
+    val query = """
+      query {
+        moviesLongerThan(duration: PT3H) {
+          title
+          duration
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "moviesLongerThan" : [
+            {
+              "title" : "Celine et Julie Vont en Bateau",
+              "duration" : "PT3H25M"
+            },
+            {
+              "title" : "L'Amour fou",
+              "duration" : "PT4H12M"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = MovieMapping.compileAndRun(query)
+
+    assertIO(res, expected)
+  }
+
+
   test("query with LocalTime argument") {
     val query = """
       query {


### PR DESCRIPTION
GraphQL queries with custom scalar arguments (e.g.  `moviesLongerThan(duration: PT3H)`) are allowed by GraphQL and used to be supported in some previous grackle versions (before Elaborator rework).
This PR brings it back.

There is no need to support such inputs for variables since `untypedVars` are passed as Json and we can not pass the value without apostrophes.

I've decided to treat a custom scalar argument passed in enumeration-style (no apostrophes) as StringValue, so the GraphQL server always supports the input with and without apostrophes out of the box (it's enough to define support StringValue value handler).
Another option would be to keep the Enum value - this would allow to decide whether the enum-type value should be supported, but require the user to handle both StringValue and EnumValue values is so.