### PR TITLE
Fully implement field selection merging and collection rules

### DIFF
--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -256,7 +256,7 @@ sealed trait Type extends Product {
   def <:<(other: Type): Boolean =
     (this.dealias, other.dealias) match {
       case (tp1, tp2) if tp1 == tp2 => true
-      case (tp1, UnionType(_, _, members, _)) => members.exists(tp1 <:< _.dealias)
+      case (tp1, UnionType(_, _, members, _)) => members.exists(tp1 <:< _)
       case (ObjectType(_, _, _, interfaces, _), tp2) => interfaces.exists(_ <:< tp2)
       case (InterfaceType(_, _, _, interfaces, _), tp2) => interfaces.exists(_ <:< tp2)
       case (NullableType(tp1), NullableType(tp2)) => tp1 <:< tp2
@@ -456,6 +456,19 @@ sealed trait Type extends Product {
     case ObjectType(_, _, fields, _, _) => fields.find(_.name == fieldName).map(_.tpe)
     case InterfaceType(_, _, fields, _, _) => fields.find(_.name == fieldName).map(_.tpe)
     case _ => None
+  }
+
+  /**
+    * Yield the named type underlying this type.
+    *
+    * Strips of nullability and enclosing list types until an
+    * underlying named type is reached. This method will always
+    * yield a named type.
+    */
+  def underlyingNamed: NamedType = this match {
+    case NullableType(tpe) => tpe.underlyingNamed
+    case ListType(tpe)     => tpe.underlyingNamed
+    case tpe: NamedType => tpe
   }
 
   /** Is this type a leaf type?

--- a/modules/core/src/test/scala/compiler/FieldMergeSuite.scala
+++ b/modules/core/src/test/scala/compiler/FieldMergeSuite.scala
@@ -1,0 +1,1790 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2023 Grackle Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compiler
+
+import cats.effect.IO
+import cats.implicits._
+import io.circe.Json
+import io.circe.literal._
+import munit.CatsEffectSuite
+
+import grackle._
+import grackle.syntax._
+import PathTerm.UniquePath
+import Query._
+import Predicate._, Value._
+import QueryCompiler._
+
+final class FieldMergeSuite extends CatsEffectSuite {
+  def runOperation(op: Result[Operation]): IO[List[Json]] = {
+    val op0 = op.toOption.get
+    FieldMergeMapping.interpreter.run(op0.query, op0.rootTpe, Env.empty).evalMap(FieldMergeMapping.mkResponse).compile.toList
+  }
+
+  test("merge fields") {
+    val query = """
+      query {
+        user(id: 1) {
+          name
+          profilePic
+          name
+          id
+          foo:name
+          foo:name
+          bar:name
+
+          friends {
+            name
+          }
+
+          friends {
+            profilePic
+          }
+
+          friends {
+            id
+          }
+
+          baz:friends {
+            name
+            quux:name
+          }
+
+          baz:friends {
+            name
+            profilePic
+          }
+          baz:friends {
+            quux:name
+            id
+          }
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(Eql(UniquePath(List("id")), Const("1")),
+            Group(List(
+              Select("name", None, Empty),
+              Select("profilePic", None, Empty),
+              Select("id", None, Empty),
+              Select("name", Some("foo"), Empty),
+              Select("name", Some("bar"), Empty),
+              Select("friends", None,
+                Group(List(
+                  Select("name", None, Empty),
+                  Select("profilePic", None, Empty),
+                  Select("id", None, Empty)
+                ))
+              ),
+              Select("friends", Some("baz"),
+                Group(List(
+                  Select("name", None, Empty),
+                  Select("name", Some("quux"), Empty),
+                  Select("profilePic", None, Empty),
+                  Select("id", None, Empty)
+                ))
+              )
+            ))
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "name" : "Alice",
+            "profilePic" : "A",
+            "id" : "1",
+            "foo" : "Alice",
+            "bar" : "Alice",
+            "friends" : [
+              {
+                "name" : "Bob",
+                "profilePic" : "B",
+                "id" : "2"
+              },
+              {
+                "name" : "Carol",
+                "profilePic" : "C",
+                "id" : "3"
+              }
+            ],
+            "baz" : [
+              {
+                "name" : "Bob",
+                "quux" : "Bob",
+                "profilePic" : "B",
+                "id" : "2"
+              },
+              {
+                "name" : "Carol",
+                "quux" : "Carol",
+                "profilePic" : "C",
+                "id" : "3"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("mergeable alias") {
+    val query = """
+      query {
+        user(id: 1) {
+          profilePic:name
+          name:profilePic
+          profilePic:name
+          name:profilePic
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(Eql(UniquePath(List("id")), Const("1")),
+            Group(List(
+              Select("name", Some("profilePic"), Empty),
+              Select("profilePic", Some("name"), Empty)
+            ))
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "profilePic" : "Alice",
+            "name" : "A"
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("unmergeable alias (1)") {
+    val query = """
+      query {
+        user(id: 1) {
+          name
+          name:profilePic
+        }
+      }
+    """
+
+    val expected =
+      "Cannot merge fields with alias 'name' and names 'name', 'profilePic'"
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.failure(expected))
+  }
+
+  test("unmergeable alias (2)") {
+    val query = """
+      query {
+        user(id: 1) {
+          foo:name
+          foo:profilePic
+        }
+      }
+    """
+
+    val expected =
+      "Cannot merge fields with alias 'foo' and names 'name', 'profilePic'"
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.failure(expected))
+  }
+
+  test("fields with arguments (1)") {
+    val query = """
+      query {
+        user(id: 1) {
+          name
+        }
+        user(id: 1) {
+          profilePic
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(Eql(UniquePath(List("id")), Const("1")),
+            Group(List(
+              Select("name", None, Empty),
+              Select("profilePic", None, Empty)
+            ))
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "name" : "Alice",
+            "profilePic" : "A"
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("fields with arguments (2)") {
+    val query = """
+      query {
+        user(id: 1) {
+          name
+        }
+        user(id: 2) {
+          profilePic
+        }
+      }
+    """
+
+    val expected =
+      "Cannot merge fields named 'user' with different arguments"
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.failure(expected))
+  }
+
+  test("fields with arguments (3)") {
+    val query = """
+      query {
+        user(id: 1) {
+          name
+        }
+        foo:user(id: 1) {
+          profilePic
+        }
+      }
+    """
+
+    val expected =
+      Group(List(
+        Select("user", None,
+          Unique(
+            Filter(Eql(UniquePath(List("id")), Const("1")),
+              Select("name", None, Empty)
+            )
+          )
+        ),
+        Select("user", Some("foo"),
+          Unique(
+            Filter(Eql(UniquePath(List("id")), Const("1")),
+              Select("profilePic", None, Empty)
+            )
+          )
+        )
+      ))
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "name" : "Alice"
+          },
+          "foo" : {
+            "profilePic" : "A"
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("fields with arguments (4)") {
+    val query = """
+      query {
+        user(id: 1) {
+          name
+        }
+        foo:user(id: 2) {
+          profilePic
+        }
+      }
+    """
+
+    val expected =
+      Group(List(
+        Select("user", None,
+          Unique(
+            Filter(Eql(UniquePath(List("id")), Const("1")),
+              Select("name", None, Empty)
+            )
+          )
+        ),
+        Select("user", Some("foo"),
+          Unique(
+            Filter(Eql(UniquePath(List("id")), Const("2")),
+              Select("profilePic", None, Empty)
+            )
+          )
+        )
+      ))
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "name" : "Alice"
+          },
+          "foo" : {
+            "profilePic" : "B"
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("fields with arguments (5)") {
+    val query = """
+      query ($id: ID!) {
+        user(id: $id) {
+          name
+        }
+        user(id: $id) {
+          profilePic
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(Eql(UniquePath(List("id")), Const("1")),
+            Group(List(
+              Select("name", None, Empty),
+              Select("profilePic", None, Empty)
+            ))
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "name" : "Alice",
+            "profilePic" : "A"
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query, untypedVars = Some(json"""{ "id": "1" }"""))
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("fields with arguments (6)") {
+    val query = """
+      query ($id1: ID!, $id2: ID!) {
+        user(id: $id1) {
+          name
+        }
+        user(id: $id2) {
+          profilePic
+        }
+      }
+    """
+
+    val expected =
+      "Cannot merge fields named 'user' with different arguments"
+
+    val compiled = FieldMergeMapping.compiler.compile(query, untypedVars = Some(json"""{ "id1": "1", "id2": "2" }"""))
+
+    assertEquals(compiled.map(_.query), Result.failure(expected))
+  }
+
+  test("fields with arguments (7)") {
+    val query = """
+      query ($id: ID!) {
+        user(id: $id) {
+          name
+        }
+        user(id: 1) {
+          profilePic
+        }
+      }
+    """
+
+    val expected =
+      "Cannot merge fields named 'user' with different arguments"
+
+    val compiled = FieldMergeMapping.compiler.compile(query, untypedVars = Some(json"""{ "id1": "1" }"""))
+
+    assertEquals(compiled.map(_.query), Result.failure(expected))
+  }
+
+
+  test("fields with skip (1)") {
+    val query = """
+      query {
+        user(id: 1) {
+          friends {
+            name
+          }
+          friends @skip(if: true) {
+            profilePic
+          }
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(Eql(UniquePath(List("id")), Const("1")),
+            Select("friends", None,
+              Select("name", None, Empty)
+            )
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "friends" : [
+              {
+                "name" : "Bob"
+              },
+              {
+                "name" : "Carol"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("fields with skip (2)") {
+    val query = """
+      query {
+        user(id: 1) {
+          friends @skip(if: false) {
+            name
+          }
+          friends @skip(if: true) {
+            profilePic
+          }
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(Eql(UniquePath(List("id")), Const("1")),
+            Select("friends", None,
+              Select("name", None, Empty)
+            )
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "friends" : [
+              {
+                "name" : "Bob"
+              },
+              {
+                "name" : "Carol"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("fields with skip (3)") {
+    val query = """
+      query {
+        user(id: 1) {
+          friends {
+            name
+          }
+          friends {
+            profilePic @skip(if: true)
+          }
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(Eql(UniquePath(List("id")), Const("1")),
+            Select("friends", None,
+              Select("name", None, Empty)
+            )
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "friends" : [
+              {
+                "name" : "Bob"
+              },
+              {
+                "name" : "Carol"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("fields with skip (4)") {
+    val query = """
+      query {
+        user(id: 1) {
+          friends {
+            name
+          }
+        }
+        user(id: 2) @skip(if: true) {
+          friends {
+            name
+          }
+        }
+      }
+    """
+
+    val expected =
+      "Cannot merge fields named 'user' with different arguments"
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.failure(expected))
+  }
+
+  test("fields with skip (5)") {
+    val query = """
+      query {
+        user(id: 1) {
+          friends @skip(if: false) {
+            name
+          }
+          friends @skip(if: false) {
+            profilePic
+          }
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(Eql(UniquePath(List("id")), Const("1")),
+            Select("friends", None,
+              Group(List(
+                Select("name", None, Empty),
+                Select("profilePic", None, Empty)
+              ))
+            )
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "friends" : [
+              {
+                "name" : "Bob",
+                "profilePic" : "B"
+              },
+              {
+                "name" : "Carol",
+                "profilePic" : "C"
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("fields with variants (1)") {
+    val query = """
+      query {
+        user(id: 1) {
+          favourite {
+            ... on User {
+              label:name
+            }
+            ... on Page {
+              label:title
+            }
+          }
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(
+            Eql(UniquePath(List("id")), Const("1")),
+            Select("favourite", None,
+              Group(List(
+                Narrow(FieldMergeMapping.UserType, Select("name", Some("label"), Empty)),
+                Narrow(FieldMergeMapping.PageType, Select("title", Some("label"), Empty))
+              ))
+            )
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "favourite" : {
+              "label" : "Bob"
+            }
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("fields with variants (2)") {
+    val query = """
+      query {
+        user(id: 1) {
+          favourite {
+            ... on User {
+              label:age
+            }
+            ... on Page {
+              label:title
+            }
+          }
+        }
+      }
+    """
+
+    val expected =
+      "Cannot merge fields named 'label' of distinct leaf types Int, String"
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.failure(expected))
+  }
+
+  test("fields with variants (3)") {
+    val query = """
+      query {
+        user(id: 1) {
+          favourite {
+            ... on User {
+              likers:friends {
+                name
+              }
+            }
+            ... on Page {
+              likers {
+                name
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(
+            Eql(UniquePath(List("id")), Const("1")),
+            Select("favourite", None,
+              Group(List(
+                Narrow(FieldMergeMapping.UserType,
+                  Select("friends", Some("likers"),
+                    Select("name", None, Empty)
+                  )
+                ),
+                Narrow(FieldMergeMapping.PageType,
+                  Select("likers", None,
+                    Select("name", None, Empty)
+                  )
+                )
+              ))
+            )
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "favourite" : {
+              "likers" : [
+                {
+                  "name" : "Alice"
+                }
+              ]
+            }
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("fields with variants (4)") {
+    val query = """
+      query {
+        user(id: 1) {
+          favourite {
+            ... on User {
+              friends {
+                name
+              }
+            }
+            ... on Page {
+              friends:creator {
+                name
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected =
+      "Cannot merge fields named 'friends' of both list and non-list types"
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.failure(expected))
+  }
+
+  test("fields with variants (5)") {
+    val query = """
+      query {
+        user(id: 1) {
+          favourite {
+            ... on User {
+              favourite {
+                ... on User {
+                  name
+                }
+              }
+            }
+            ... on Page {
+              favourite:creator {
+                name
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected =
+      "Cannot merge fields named 'favourite' of both nullable and non-nullable types"
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.failure(expected))
+  }
+
+  test("fields with variants (6)") {
+    val query = """
+      query {
+        user(id: 1) {
+          favourite {
+            ... on User {
+              label:name
+            }
+            ... on Page {
+              label:creator {
+                id
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected =
+      "Cannot merge fields named 'label' of leaf types String and non-leaf types User"
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.failure(expected))
+  }
+
+  test("fields with directives (1)") {
+    val query = """
+      query {
+        user(id: 1) {
+          name @foo
+          name @foo
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(
+            Eql(UniquePath(List("id")), Const("1")),
+            Select("name", None, Empty)
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "name" : "Alice"
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("fields with directives (2)") {
+    val query = """
+      query {
+        user(id: 1) {
+          name
+          name @foo
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(
+            Eql(UniquePath(List("id")), Const("1")),
+            Select("name", None, Empty)
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "name" : "Alice"
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("fields with directives (3)") {
+    val query = """
+      query {
+        user(id: 1) {
+          name @foo
+          name @bar
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(
+            Eql(UniquePath(List("id")), Const("1")),
+            Select("name", None, Empty)
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "name" : "Alice"
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("inline fragments (1)") {
+    val query = """
+      query {
+        ... on Query {
+          user(id: 1) {
+            name
+          }
+        }
+        ... on Query {
+          user(id: 1) {
+            profilePic
+          }
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(Eql(UniquePath(List("id")), Const("1")),
+            Group(List(
+              Select("name", None, Empty),
+              Select("profilePic", None, Empty)
+            ))
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "name" : "Alice",
+            "profilePic" : "A"
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("inline fragments (2)") {
+    val query = """
+      query {
+        user(id: 1) {
+          ... on User {
+            name
+          }
+        }
+        user(id: 1) {
+          ... on User {
+            profilePic
+          }
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(Eql(UniquePath(List("id")), Const("1")),
+            Group(List(
+              Select("name", None, Empty),
+              Select("profilePic", None, Empty)
+            ))
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "name" : "Alice",
+            "profilePic" : "A"
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("inline fragments (3)") {
+    val query = """
+      query {
+        user(id: 1) {
+          favourite {
+            ... on User {
+              name
+            }
+          }
+        }
+        user(id: 1) {
+          favourite {
+            ... on User {
+              profilePic
+            }
+          }
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(
+            Eql(UniquePath(List("id")), Const("1")),
+            Select("favourite", None,
+              Narrow(FieldMergeMapping.UserType,
+                Group(List(
+                  Select("name", None, Empty),
+                  Select("profilePic", None, Empty)
+                ))
+              )
+            )
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "favourite" : {
+              "name" : "Bob",
+              "profilePic" : "B"
+            }
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("inline fragments (4)") {
+    val query = """
+      query {
+        user(id: 1) {
+          favourite {
+            ... on User {
+              name
+            }
+          }
+        }
+        user(id: 1) {
+          favourite {
+            ... on User {
+              name:profilePic
+            }
+          }
+        }
+      }
+    """
+
+    val expected =
+      "Cannot merge fields with alias 'name' and names 'name', 'profilePic'"
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.failure(expected))
+  }
+
+  test("inline fragments (5)") {
+    val query = """
+      query {
+        user(id: 1) {
+          ... on User {
+            favourite {
+              ... on User {
+                name
+              }
+              ... on Profile {
+                id
+              }
+            }
+          }
+        }
+        user(id: 1) {
+          ... on User {
+            favourite {
+              ... on User {
+                id
+                name
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(
+            Eql(UniquePath(List("id")), Const("1")),
+            Select("favourite", None,
+              Group(List(
+                Narrow(FieldMergeMapping.UserType,
+                  Group(List(
+                    Select("name", None, Empty),
+                    Select("id", None, Empty)
+                  ))
+                ),
+                Narrow(FieldMergeMapping.ProfileType, Select("id", None, Empty))
+              ))
+            )
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "favourite" : {
+              "name" : "Bob",
+              "id" : "2"
+            }
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("inline fragments (6)") {
+    val query = """
+      query {
+        user(id: 1) {
+          favourite {
+            ... on User {
+              id:name
+            }
+            ... on Profile {
+              id
+            }
+          }
+        }
+      }
+    """
+
+    val expected =
+      "Cannot merge fields with alias 'id' and names 'name', 'id'"
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.failure(expected))
+  }
+
+  test("inline fragments (7)") {
+    val query = """
+      query {
+        user(id: 1) {
+          friends {
+            ... on User {
+              friends {
+                name
+              }
+            }
+            ... on Profile {
+              ... on User {
+                friends {
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(
+            Eql(UniquePath(List("id")), Const("1")),
+            Select("friends", None,
+              Group(List(
+                Select("friends", None,
+                  Select("name", None, Empty)
+                ),
+                Narrow(FieldMergeMapping.UserType,
+                  Select("friends", None,
+                    Select("id", None, Empty)
+                  )
+                )
+              ))
+            )
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "friends" : [
+              {
+                "friends" : [
+                  {
+                    "name" : "Alice",
+                    "id" : "1"
+                  }
+                ]
+              },
+              {
+                "friends" : [
+                  {
+                    "name" : "Alice",
+                    "id" : "1"
+                  },
+                  {
+                    "name" : "Bob",
+                    "id" : "2"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("inline fragments (8)") {
+    val query = """
+      query {
+        user(id: 1) {
+          friends {
+            ... on Profile {
+              id
+              ... on User {
+                friends {
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(
+            Eql(UniquePath(List("id")), Const("1")),
+            Select("friends", None,
+              Group(List(
+                Select("id", None, Empty),
+                Narrow(FieldMergeMapping.UserType,
+                  Select("friends", None,
+                    Select("name", None, Empty)
+                  )
+                )
+              ))
+            )
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "friends" : [
+              {
+                "id" : "2",
+                "friends" : [
+                  {
+                    "name" : "Alice"
+                  }
+                ]
+              },
+              {
+                "id" : "3",
+                "friends" : [
+                  {
+                    "name" : "Alice"
+                  },
+                  {
+                    "name" : "Bob"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("inline fragments (9)") {
+    val query = """
+      query {
+        user(id: 1) {
+          friends {
+            ... on Profile {
+              id
+              ... on User {
+                id:name
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected =
+      "Cannot merge fields with alias 'id' and names 'id', 'name'"
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.failure(expected))
+  }
+
+  test("merge across fragments") {
+    val query = """
+      query {
+        user(id: 1) {
+          friends {
+            name
+          }
+          ...userFields
+        }
+      }
+
+      fragment userFields on User {
+        friends {
+          profilePic
+        }
+        id
+      }
+    """
+
+    val expected =
+      Select("user", None,
+        Unique(
+          Filter(
+            Eql(UniquePath(List("id")), Const("1")),
+            Group(
+              List(
+                Select("friends", None,
+                  Group(
+                    List(
+                      Select("name", None, Empty),
+                      Select("profilePic", None, Empty)
+                    )
+                  )
+                ),
+                Select("id", None, Empty)
+              )
+            )
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "friends" : [
+              {
+                "name" : "Bob",
+                "profilePic" : "B"
+              },
+              {
+                "name" : "Carol",
+                "profilePic" : "C"
+              }
+            ],
+            "id" : "1"
+          }
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+
+  test("merge across top level fragments") {
+    val query = """
+      query {
+        user(id: 1) {
+          name
+        }
+
+        ...queryFields
+      }
+
+      fragment queryFields on Query {
+        user(id: 1) {
+          profilePic
+        }
+
+        profiles {
+          id
+        }
+      }
+    """
+
+    val expected =
+      Group(
+        List(
+          Select("user", None,
+            Unique(
+              Filter(Eql(UniquePath(List("id")), Const("1")),
+                Group(
+                  List(
+                    Select("name", None, Empty),
+                    Select("profilePic", None, Empty)
+                  )
+                )
+              )
+            )
+          ),
+          Select("profiles", None,
+            Select("id", None, Empty)
+          )
+        )
+      )
+
+    val expectedResult = json"""
+      {
+        "data" : {
+          "user" : {
+            "name" : "Alice",
+            "profilePic" : "A"
+          },
+          "profiles" : [
+            {
+              "id" : "1"
+            },
+            {
+              "id" : "2"
+            },
+            {
+              "id" : "3"
+            },
+            {
+              "id" : "4"
+            },
+            {
+              "id" : "5"
+            }
+          ]
+        }
+      }
+    """
+
+    val compiled = FieldMergeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+
+    val res = runOperation(compiled)
+
+    assertIO(res, List(expectedResult))
+  }
+}
+
+object FieldMergeData {
+  sealed trait Profile {
+    def id: String
+  }
+
+  case class User(id: String, name: String, age: Int, profilePic: String, friendIds: List[String], favouriteId: Option[String]) extends Profile {
+    def friends: List[User] =
+      friendIds.flatMap(fid => profiles.collect { case u: User if u.id == fid => u })
+    def mutualFriends: List[User] =
+      friendIds.flatMap(fid => profiles.collect { case u: User if u.id == fid && u.friendIds.contains(id) => u })
+    def favourite: Option[Profile] =
+      favouriteId.flatMap(id => profiles.find(_.id == id))
+  }
+
+  case class Page(id: String, title: String, likerIds: List[String], creatorId: String) extends Profile {
+    def likers: List[User] =
+      likerIds.flatMap(lid => profiles.collect { case u: User if u.id == lid => u })
+    def creator: User =
+      profiles.collect { case u: User if u.id == creatorId => u }.head
+  }
+
+  val profiles = List(
+    User("1", "Alice", 23, "A", List("2", "3"), Some("2")),
+    User("2", "Bob", 24, "B", List("1"), Some("4")),
+    User("3", "Carol", 25, "C", List("1", "2"), None),
+    Page("4", "GraphQL", List("1", "3"), "2"),
+    Page("5", "Scala", List("2"), "1")
+  )
+}
+
+object FieldMergeMapping extends ValueMapping[IO] {
+  import FieldMergeData._
+
+  val schema =
+    schema"""
+      type Query {
+        user(id: ID!): User!
+        profiles: [Profile!]!
+      }
+      type User implements Profile {
+        id: String!
+        name: String!
+        age: Int!
+        profilePic: String!
+        friends: [User!]!
+        mutualFriends: [User!]!
+        favourite: UserOrPage
+      }
+      type Page implements Profile {
+        id: String!
+        title: String!
+        likers: [User!]!
+        creator: User!
+      }
+      union UserOrPage = User | Page
+      interface Profile {
+        id: String!
+      }
+
+      directive @foo on FIELD
+      directive @bar on FIELD
+    """
+
+  val QueryType = schema.ref("Query")
+  val ProfileType = schema.ref("Profile")
+  val UserType = schema.ref("User")
+  val PageType = schema.ref("Page")
+
+  val typeMappings =
+    List(
+      ValueObjectMapping[Unit](
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            ValueField("user", _ => profiles.collect { case u: User => u }),
+            ValueField("profiles", _ => profiles)
+          )
+      ),
+      ValueObjectMapping[Profile](
+        tpe = ProfileType,
+        fieldMappings =
+          List(
+            ValueField("id", _.id)
+          )
+      ),
+      ValueObjectMapping[User](
+        tpe = UserType,
+        fieldMappings =
+          List(
+            ValueField("name", _.name),
+            ValueField("age", _.age),
+            ValueField("profilePic", _.profilePic),
+            ValueField("friends", _.friends),
+            ValueField("mutualFriends", _.mutualFriends),
+            ValueField("favourite", _.favourite),
+          )
+      ),
+      ValueObjectMapping[Page](
+        tpe = PageType,
+        fieldMappings =
+          List(
+            ValueField("title", _.title),
+            ValueField("likers", _.likers),
+            ValueField("creator", _.creator)
+          )
+      )
+    )
+
+  override val selectElaborator = SelectElaborator {
+    case (QueryType, "user", List(Binding("id", IDValue(id)))) =>
+      Elab.transformChild(child => Unique(Filter(Eql(FieldMergeMapping.UserType / "id", Const(id)), child)))
+  }
+}

--- a/modules/core/src/test/scala/compiler/InputValuesSuite.scala
+++ b/modules/core/src/test/scala/compiler/InputValuesSuite.scala
@@ -27,13 +27,13 @@ final class InputValuesSuite extends CatsEffectSuite {
   test("null value") {
     val query = """
       query {
-        field {
+        one:field {
           subfield
         }
-        field(arg: null) {
+        two:field(arg: null) {
           subfield
         }
-        field(arg: 23) {
+        three:field(arg: 23) {
           subfield
         }
       }
@@ -41,9 +41,9 @@ final class InputValuesSuite extends CatsEffectSuite {
 
     val expected =
       Group(List(
-        UntypedSelect("field", None, List(Binding("arg", AbsentValue)), Nil, UntypedSelect("subfield", None, Nil, Nil, Empty)),
-        UntypedSelect("field", None, List(Binding("arg", NullValue)), Nil, UntypedSelect("subfield", None, Nil, Nil, Empty)),
-        UntypedSelect("field", None, List(Binding("arg", IntValue(23))), Nil, UntypedSelect("subfield", None, Nil, Nil, Empty))
+        UntypedSelect("field", Some("one"), List(Binding("arg", AbsentValue)), Nil, UntypedSelect("subfield", None, Nil, Nil, Empty)),
+        UntypedSelect("field", Some("two"), List(Binding("arg", NullValue)), Nil, UntypedSelect("subfield", None, Nil, Nil, Empty)),
+        UntypedSelect("field", Some("three"), List(Binding("arg", IntValue(23))), Nil, UntypedSelect("subfield", None, Nil, Nil, Empty))
       ))
 
     val compiled = InputValuesMapping.compiler.compile(query, None)
@@ -54,10 +54,10 @@ final class InputValuesSuite extends CatsEffectSuite {
   test("list value") {
     val query = """
       query {
-        listField(arg: []) {
+        one:listField(arg: []) {
           subfield
         }
-        listField(arg: ["foo", "bar"]) {
+        two:listField(arg: ["foo", "bar"]) {
           subfield
         }
       }
@@ -65,10 +65,10 @@ final class InputValuesSuite extends CatsEffectSuite {
 
     val expected =
       Group(List(
-        UntypedSelect("listField", None, List(Binding("arg", ListValue(Nil))), Nil,
+        UntypedSelect("listField", Some("one"), List(Binding("arg", ListValue(Nil))), Nil,
           UntypedSelect("subfield", None, Nil, Nil, Empty)
         ),
-        UntypedSelect("listField", None, List(Binding("arg", ListValue(List(StringValue("foo"),  StringValue("bar"))))), Nil,
+        UntypedSelect("listField", Some("two"), List(Binding("arg", ListValue(List(StringValue("foo"),  StringValue("bar"))))), Nil,
           UntypedSelect("subfield", None, Nil, Nil, Empty)
         )
       ))

--- a/modules/core/src/test/scala/compiler/VariablesSuite.scala
+++ b/modules/core/src/test/scala/compiler/VariablesSuite.scala
@@ -523,7 +523,6 @@ final class VariablesSuite extends CatsEffectSuite {
     """
 
     val compiled = VariablesMapping.compiler.compile(query, reportUnused = false)
-    println(compiled)
 
     val expected =
       Operation(

--- a/modules/core/src/test/scala/directives/DirectiveValidationSuite.scala
+++ b/modules/core/src/test/scala/directives/DirectiveValidationSuite.scala
@@ -205,8 +205,8 @@ final class DirectiveValidationSuite extends CatsEffectSuite {
           UntypedSelect("foo", None, Nil, List(Directive("onField", Nil)),
             Group(
               List(
-                UntypedSelect("bar",None, Nil, List(Directive("onField", Nil)), Empty),
-                UntypedSelect("bar",None, Nil, List(Directive("onField", Nil)), Empty)
+                UntypedSelect("bar", Some("baz"), Nil, List(Directive("onField", Nil)), Empty),
+                UntypedSelect("bar", None, Nil, List(Directive("onField", Nil)), Empty)
               )
             )
           ),
@@ -244,7 +244,7 @@ final class DirectiveValidationSuite extends CatsEffectSuite {
          |}
          |
          |fragment Frag on Foo @onFragmentDefinition {
-         |  bar @onField
+         |  baz:bar @onField
          |}
          |""".stripMargin
 

--- a/modules/sql/shared/src/test/scala/SqlInterfacesSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlInterfacesSuite.scala
@@ -522,7 +522,7 @@ trait SqlInterfacesSuite extends CatsEffectSuite {
     assertWeaklyEqualIO(res, expected)
   }
 
-  test("interface query with type variant fields in type conditions") {
+  test("interface query with type variant fields in type conditions (1)") {
     val query = """
       query {
         entities {
@@ -535,7 +535,7 @@ trait SqlInterfacesSuite extends CatsEffectSuite {
           }
           ... on Series {
             numberOfEpisodes
-            label
+            alphaLabel:label
           }
         }
       }
@@ -571,24 +571,58 @@ trait SqlInterfacesSuite extends CatsEffectSuite {
               "entityType" : "SERIES",
               "title" : "Series 1",
               "numberOfEpisodes" : 5,
-              "label" : "One"
+              "alphaLabel" : "One"
             },
             {
               "id" : "5",
               "entityType" : "SERIES",
               "title" : "Series 2",
               "numberOfEpisodes" : 6,
-              "label" : "Two"
+              "alphaLabel" : "Two"
             },
             {
               "id" : "6",
               "entityType" : "SERIES",
               "title" : "Series 3",
               "numberOfEpisodes" : 7,
-              "label" : "Three"
+              "alphaLabel" : "Three"
             }
           ]
         }
+      }
+    """
+
+    val res = mapping.compileAndRun(query)
+
+    assertWeaklyEqualIO(res, expected)
+  }
+
+  test("interface query with type variant fields in type conditions (2)") {
+    val query = """
+      query {
+        entities {
+          id
+          entityType
+          title
+          ... on Film {
+            rating
+            label
+          }
+          ... on Series {
+            numberOfEpisodes
+            label
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "errors" : [
+          {
+            "message" : "Cannot merge fields named 'label' of distinct leaf types Int, String"
+          }
+        ]
       }
     """
 


### PR DESCRIPTION
See sections [5.3.2](https://spec.graphql.org/June2018/#sec-Field-Selection-Merging) and [6.3.2](https://spec.graphql.org/June2018/#sec-Field-Collection) of the GraphQL Specification.

Mergeability validation is done very early in compilation, immediately after variable and fragment use is validated.

As much field merging is done during compilation as possible. In some cases this will result in simpler executable queries than were previously generated which might slightly improve query execution time.

Field merging which depends on the runtime type of values has to be deferred to execution time, and potentially involves deep merging of `ProtoJson` result values. This could be expensive, and considerable effort has been taken to avoid it where possible and reduce its impact where not.

In almost all cases where this PR changes behaviour the previous behaviour was incorrect. The only changes in previously correct results are potential object field reorderings in Json results.

A handful of existing tests were violating the mergeability rules and have been corrected.

Fixes #22