### PR TITLE
Tightened up usage of TypeRef

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ ThisBuild / scalaVersion        := Scala2
 ThisBuild / crossScalaVersions  := Seq(Scala2, Scala3)
 ThisBuild / tlJdkRelease        := Some(11)
 
-ThisBuild / tlBaseVersion    := "0.18"
+ThisBuild / tlBaseVersion    := "0.19"
 ThisBuild / startYear        := Some(2019)
 ThisBuild / licenses         := Seq(License.Apache2)
 ThisBuild / developers       := List(

--- a/modules/core/src/main/scala/introspection.scala
+++ b/modules/core/src/main/scala/introspection.scala
@@ -126,7 +126,7 @@ object Introspection {
       """
     ).toOption.get
 
-  val QueryType = schema.queryType
+  val QueryType = schema.uncheckedRef(schema.queryType)
   val __SchemaType = schema.ref("__Schema")
   val __TypeType =  schema.ref("__Type")
   val __FieldType =  schema.ref("__Field")

--- a/modules/core/src/main/scala/queryinterpreter.scala
+++ b/modules/core/src/main/scala/queryinterpreter.scala
@@ -222,11 +222,11 @@ class QueryInterpreter[F[_]](mapping: Mapping[F]) {
             case o: ObjectType => Some(o.name)
             case i: InterfaceType =>
               (schema.types.collectFirst {
-                case o: ObjectType if o <:< i && cursor.narrowsTo(schema.ref(o.name)) => o.name
+                case o: ObjectType if o <:< i && cursor.narrowsTo(schema.uncheckedRef(o)) => o.name
               })
             case u: UnionType =>
               (u.members.map(_.dealias).collectFirst {
-                case nt: NamedType if cursor.narrowsTo(schema.ref(nt.name)) => nt.name
+                case nt: NamedType if cursor.narrowsTo(schema.uncheckedRef(nt)) => nt.name
               })
             case _ => None
           }) match {

--- a/modules/core/src/main/scala/valuemapping.scala
+++ b/modules/core/src/main/scala/valuemapping.scala
@@ -76,13 +76,13 @@ trait ValueMappingLike[F[_]] extends Mapping[F] {
   }
 
   case class ValueObjectMapping[T](
-    tpe: Type,
+    tpe: NamedType,
     fieldMappings: List[FieldMapping],
     classTag: ClassTag[T]
   )(implicit val pos: SourcePos) extends ObjectMapping
 
   def ValueObjectMapping[T](
-    tpe: Type,
+    tpe: NamedType,
     fieldMappings: List[ValueFieldMapping[T]]
   )(implicit classTag: ClassTag[T], pos: SourcePos): ValueObjectMapping[T] =
     new ValueObjectMapping(tpe, fieldMappings.map(_.withParent(tpe)), classTag)

--- a/modules/core/src/test/scala/mapping/MappingValidatorSuite.scala
+++ b/modules/core/src/test/scala/mapping/MappingValidatorSuite.scala
@@ -160,7 +160,7 @@ final class ValidatorSuite extends CatsEffectSuite {
 
     object M extends TestMapping {
       val schema = schema""
-      override val typeMappings  = List(ObjectMapping(schema.ref("Foo"), Nil))
+      override val typeMappings  = List(ObjectMapping(schema.uncheckedRef("Foo"), Nil))
     }
 
     val es = M.validator.validateMapping()
@@ -220,7 +220,7 @@ final class ValidatorSuite extends CatsEffectSuite {
   test("unsafeValidate") {
     object M extends TestMapping {
       val schema = schema"scalar Bar"
-      override val typeMappings = List(ObjectMapping(schema.ref("Foo"), Nil))
+      override val typeMappings = List(ObjectMapping(schema.uncheckedRef("Foo"), Nil))
     }
     intercept[ValidationException] {
       MappingValidator(M).unsafeValidate()

--- a/modules/core/src/test/scala/schema/SchemaSuite.scala
+++ b/modules/core/src/test/scala/schema/SchemaSuite.scala
@@ -470,4 +470,21 @@ final class SchemaSuite extends CatsEffectSuite {
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
   }
+
+  test("operations on undefined types") {
+    val schema = schema""
+
+    val QuuxType = schema.uncheckedRef("Quux")
+    assertEquals(QuuxType.fieldInfo("quux"), None)
+    assertEquals(QuuxType.path(List("foo")), None)
+    assertEquals(QuuxType.pathIsList(List("foo")), false)
+    assertEquals(QuuxType.pathIsNullable(List("foo")), false)
+    assertEquals(QuuxType.underlying, QuuxType)
+    assertEquals(QuuxType.underlyingObject, None)
+    assertEquals(QuuxType.underlyingField("foo"), None)
+    assertEquals(QuuxType.isLeaf, false)
+    assertEquals(QuuxType.asLeaf, None)
+    assertEquals(QuuxType.isUnderlyingLeaf, false)
+    assertEquals(QuuxType.underlyingLeaf, None)
+  }
 }

--- a/modules/sql/shared/src/main/scala/SqlMapping.scala
+++ b/modules/sql/shared/src/main/scala/SqlMapping.scala
@@ -814,12 +814,12 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
 
   object SqlInterfaceMapping {
 
-    case class DefaultInterfaceMapping(tpe: Type, fieldMappings: List[FieldMapping], path: List[String], discriminator: SqlDiscriminator)(
+    case class DefaultInterfaceMapping(tpe: NamedType, fieldMappings: List[FieldMapping], path: List[String], discriminator: SqlDiscriminator)(
       implicit val pos: SourcePos
     ) extends SqlInterfaceMapping
 
     def apply(
-      tpe: Type,
+      tpe: NamedType,
       fieldMappings: List[FieldMapping],
       path: List[String] = Nil,
       discriminator: SqlDiscriminator
@@ -833,12 +833,12 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
 
   object SqlUnionMapping {
 
-    case class DefaultUnionMapping(tpe: Type, fieldMappings: List[FieldMapping], path: List[String], discriminator: SqlDiscriminator)(
+    case class DefaultUnionMapping(tpe: NamedType, fieldMappings: List[FieldMapping], path: List[String], discriminator: SqlDiscriminator)(
       implicit val pos: SourcePos
     ) extends SqlUnionMapping
 
     def apply(
-      tpe: Type,
+      tpe: NamedType,
       fieldMappings: List[FieldMapping],
       path: List[String] = Nil,
       discriminator: SqlDiscriminator,

--- a/modules/sql/shared/src/test/scala/SqlMovieMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlMovieMapping.scala
@@ -98,7 +98,6 @@ trait SqlMovieMapping[F[_]] extends SqlTestMapping[F] { self =>
   val IntervalType = schema.ref("Interval")
   val GenreType = schema.ref("Genre")
   val FeatureType = schema.ref("Feature")
-  val RatingType = schema.ref("Rating")
 
   val typeMappings =
     List(


### PR DESCRIPTION
Tweaked access to `TypeRef`s from `Schema` to make it a little clearer its intent. Also ensure that operations on undefined `TypeRef`s fail sensibly.

This fixes #444. The missing definition would have been caught up front by validating the mapping, however this would most likely have run straight into #230, which also stymies any attempt to enforce validation by default. I'll investigate this further.