### PR TITLE
Cursors resolve fields internally before searching other mappings

### DIFF
--- a/modules/circe/src/test/scala/CircePrioritySuite.scala
+++ b/modules/circe/src/test/scala/CircePrioritySuite.scala
@@ -1,0 +1,107 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2023 Grackle Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grackle
+package circetests
+
+import cats.effect.IO
+import io.circe.Json
+import io.circe.literal._
+import grackle.circe.CirceMapping
+import grackle.syntax._
+import munit.CatsEffectSuite
+
+object CircePriorityMapping extends CirceMapping[IO] {
+
+  val schema = schema"""
+  scalar Foo
+  type Monkey {
+    name: Foo
+  }
+  type Barrel {
+    monkey: Monkey
+  }
+  type Query {
+    present: Barrel
+    fallback: Barrel
+  }
+  """
+
+  val QueryType  = schema.ref("Query")
+  val MonkeyType = schema.ref("Monkey")
+  val BarrelType = schema.ref("Barrel")
+  val FooType    = schema.ref("Foo") 
+
+  val typeMappings: List[TypeMapping] =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings =
+          List(
+            CirceField("present", json"""{ "monkey": { "name": "Bob" }}"""),
+            CirceField("fallback", json"""{ "monkey": {}}"""),
+          )
+      ),
+      ObjectMapping(
+        tpe = MonkeyType,
+        fieldMappings = 
+          List(
+            CirceField("name", Json.fromString("Steve"))
+          )
+      ),
+      LeafMapping[String](FooType)
+    )    
+
+}
+
+final class CircePrioritySuite extends CatsEffectSuite {
+
+  test("Opaque field should not see explicit mapping.") {
+
+    val query = """
+      query {
+        present {
+          monkey {
+            name
+          }
+        }
+        fallback {
+          monkey {
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "present" : {
+            "monkey" : {
+              "name" : "Bob"
+            }
+          },
+          "fallback" : {
+            "monkey" : {
+              "name" : "Steve"
+            }
+          }
+        }
+      }
+    """
+
+    assertIO(CircePriorityMapping.compileAndRun(query), expected)
+  }
+}

--- a/modules/generic/src/main/scala-2/genericmapping2.scala
+++ b/modules/generic/src/main/scala-2/genericmapping2.scala
@@ -83,14 +83,17 @@ trait ScalaVersionSpecificGenericMappingLike[F[_]] extends Mapping[F] { self: Ge
       extends AbstractCursor {
       def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
 
-      override def hasField(fieldName: String): Boolean = fieldMap.contains(fieldName)
+      override def hasField(fieldName: String): Boolean =
+        fieldMap.contains(fieldName) || fieldMapping(context, fieldName).isDefined
 
-      override def field(fieldName: String, resultName: Option[String]): Result[Cursor] =
-        mkCursorForField(this, fieldName, resultName) orElse {
+      override def field(fieldName: String, resultName: Option[String]): Result[Cursor] = {
+        val localField =
           fieldMap.get(fieldName).toResult(s"No field '$fieldName' for type $tpe").flatMap { f =>
             f(context.forFieldOrAttribute(fieldName, resultName), focus, Some(this), Env.empty)
           }
-        }
+
+        localField orElse mkCursorForField(this, fieldName, resultName)
+      }
     }
   }
 
@@ -137,7 +140,7 @@ trait ScalaVersionSpecificGenericMappingLike[F[_]] extends Mapping[F] { self: Ge
       override def hasField(fieldName: String): Boolean = cursor.hasField(fieldName)
 
       override def field(fieldName: String, resultName: Option[String]): Result[Cursor] =
-        mkCursorForField(this, fieldName, resultName) orElse cursor.field(fieldName, resultName)
+        cursor.field(fieldName, resultName) orElse mkCursorForField(this, fieldName, resultName)
 
       override def narrowsTo(subtpe: TypeRef): Boolean =
         subtpe <:< tpe && rtpe <:< subtpe


### PR DESCRIPTION
Previously cursors attempt to resolve fields globally, potentially delegating to an alternative mapping, before resolving relative to the current cursor. In the case of the circe and generic mappings this could result in other mappings hijacking field resolution even when the currently focussed values could resolve the field successfully. Whilst this behaviour wasn't completely unmotivated, it runs counter to the way Grackle mappings are composed in practice.

This supersedes #460.