### PR TITLE
Fixed fragment applicability to union types; no interfaces in unions

### DIFF
--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -1016,9 +1016,12 @@ object QueryCompiler {
      */
     def fragmentApplies(typeCond: NamedType, ctpe: NamedType): Boolean =
       (typeCond.dealias, ctpe.dealias) match {
-        case (_: InterfaceType, u: UnionType) => u.members.forall(_ <:< typeCond)
-        case (_, u: UnionType) => u.members.exists(typeCond <:< _)
-        case _ => typeCond <:< ctpe || ctpe <:< typeCond
+        case (u: UnionType, _) =>
+          u.members.exists(m => fragmentApplies(m, ctpe))
+        case (_, u: UnionType) =>
+          u.members.exists(m => fragmentApplies(typeCond, m))
+        case _ =>
+          typeCond <:< ctpe || ctpe <:< typeCond
       }
 
     def elaborateBinding(b: Binding, vars: Vars): Elab[Binding] =

--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -1749,7 +1749,7 @@ object SchemaValidator {
           case None => List(Problem(s"Undefined type '${member.name}' included in union '${tpe.name}'"))
           case Some(mtpe) =>
             mtpe match {
-              case (_: ObjectType) | (_: InterfaceType) => Nil
+              case (_: ObjectType) => Nil
               case _ => List(Problem(s"Non-object type '${member.name}' included in union '${tpe.name}'"))
             }
         }

--- a/modules/core/src/test/scala/compiler/FragmentSuite.scala
+++ b/modules/core/src/test/scala/compiler/FragmentSuite.scala
@@ -590,36 +590,33 @@ final class FragmentSuite extends CatsEffectSuite {
 
     val User = FragmentMapping.schema.ref("User")
     val Page = FragmentMapping.schema.ref("Page")
-    val UserOrPage = FragmentMapping.schema.ref("UserOrPage")
 
     val expected =
-      Group(List(
-        Select("user",
-          Unique(
-            Filter(Eql(FragmentMapping.UserType / "id", Const("1")),
-              Select("favourite",
-                Group(List(
-                  Introspect(FragmentMapping.schema, Select("__typename")),
-                  Narrow(
-                    User,
-                    Group(List(
-                      Select("id"),
-                      Select("name")
-                    ))
-                  ),
-                  Narrow(
-                    Page,
-                    Group(List(
-                      Select("id"),
-                      Select("title")
-                    ))
-                   )
-                ))
-              )
+      Select("user", None,
+        Unique(
+          Filter(Eql(FragmentMapping.UserType / "id", Const("1")),
+            Select("favourite", None,
+              Group(List(
+                Introspect(FragmentMapping.schema, Select("__typename", None, Empty)),
+                Narrow(
+                  User,
+                  Group(List(
+                    Select("id", None, Empty),
+                    Select("name", None, Empty)
+                  ))
+                ),
+                Narrow(
+                  Page,
+                  Group(List(
+                    Select("id", None, Empty),
+                    Select("title", None, Empty)
+                  ))
+                )
+              ))
             )
           )
-        ),
-      ))
+        )
+      )
 
     val expectedResult = json"""
       {

--- a/modules/core/src/test/scala/extensions/ExtensionsSuite.scala
+++ b/modules/core/src/test/scala/extensions/ExtensionsSuite.scala
@@ -399,7 +399,7 @@ final class ExtensionsSuite extends CatsEffectSuite {
         interface Interface {
           id: String!
         }
-        union Union = Object | Interface
+        union Union = Object
         enum Enum { A, B, C }
         input Input { id: String! }
 

--- a/modules/core/src/test/scala/sdl/SDLSuite.scala
+++ b/modules/core/src/test/scala/sdl/SDLSuite.scala
@@ -331,10 +331,13 @@ final class SDLSuite extends CatsEffectSuite {
          |interface Intrf {
          |  bar: String
          |}
-         |type Obj implements Intrf {
+         |type Obj1 implements Intrf {
          |  bar: String
          |}
-         |union Union = Intrf | Obj
+         |type Obj2 implements Intrf {
+         |  bar: String
+         |}
+         |union Union = Obj1 | Obj2
          |enum Enum {
          |  A
          |  B
@@ -352,7 +355,11 @@ final class SDLSuite extends CatsEffectSuite {
          |extend interface Intrf @Intrf {
          |  baz: Boolean
          |}
-         |extend type Obj @Obj {
+         |extend type Obj1 @Obj {
+         |  baz: Boolean
+         |  quux: String
+         |}
+         |extend type Obj2 @Obj {
          |  baz: Boolean
          |  quux: String
          |}
@@ -378,7 +385,7 @@ final class SDLSuite extends CatsEffectSuite {
     assertEquals(ser, schema.success)
   }
 
-  test("round-trip extensions (no fields or members") {
+  test("round-trip extensions (no fields or members)") {
     val schema =
       """|schema {
          |  query: MyQuery
@@ -390,10 +397,13 @@ final class SDLSuite extends CatsEffectSuite {
          |interface Intrf {
          |  bar: String
          |}
-         |type Obj implements Intrf {
+         |type Obj1 implements Intrf {
          |  bar: String
          |}
-         |union Union = Intrf | Obj
+         |type Obj2 implements Intrf {
+         |  bar: String
+         |}
+         |union Union = Obj1 | Obj2
          |enum Enum {
          |  A
          |  B
@@ -404,7 +414,8 @@ final class SDLSuite extends CatsEffectSuite {
          |extend schema @Sch
          |extend scalar Scalar @Sca
          |extend interface Intrf @Intrf
-         |extend type Obj @Obj
+         |extend type Obj1 @Obj
+         |extend type Obj2 @Obj
          |extend union Union @Uni
          |extend enum Enum @Enu
          |extend input Input @Inp


### PR DESCRIPTION
Fixes `fragmentApplies` so that it now accepts union types for a fragment type condition.

There are some lurking issues in the definition/use of `<:<` for unions which I don't want to address right now ... I'll create a separate issue to track that and pick them up later (#593)

In the process of exploring other test scenarios I realized that the GraphQL spec [explicitly excludes](https://spec.graphql.org/October2021/#sel-HAHdfFDABABlG3ib) interface types as being members of unions. I've modified the schema validator to check for that now, and fixed a couple of tests which became invalid as a result.

Fixes #590.