### PR TITLE
Fix SLF4J warnings for skunk tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -216,12 +216,16 @@ lazy val skunk = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     name := "grackle-skunk",
     Test / parallelExecution := false,
     libraryDependencies ++= Seq(
-      "org.tpolecat" %%% "skunk-core"  % skunkVersion,
-      "org.tpolecat" %%% "skunk-circe" % skunkVersion,
+      "org.tpolecat"  %%% "skunk-core"    % skunkVersion,
+      "org.tpolecat"  %%% "skunk-circe"   % skunkVersion,
+      "org.typelevel" %%  "log4cats-core" % log4catsVersion
     )
   )
   .jvmSettings(
-    Test / fork := true
+    Test / fork := true,
+    libraryDependencies ++= Seq(
+      "ch.qos.logback" % "logback-classic" % logbackVersion % "test"
+    )
   )
   .jsSettings(
     scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule))


### PR DESCRIPTION
The missing logback test dependency resulted in the skunk tests spitting configuration warnings,
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```
Most likely this dependency was removed when the JS/JVM cross build for the skunk module landed. Adding the dependency back in for just the JVM build removes the noise.