### PR TITLE
Bring docs into line with Typelevel organisation Code of Conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ libraryDependencies += "org.typelevel" %% "grackle-skunk" % "0.19.0"
 ## Community
 
 Grackle is proud to be a [Typelevel](https://typelevel.org/) project. We are committed to providing a friendly, safe
-and welcoming environment for all, and ask that the community adhere to the [Scala Code of
-Conduct](https://www.scala-lang.org/conduct/) in all venues.
+and welcoming environment for all, and ask that the community adhere to the [Typelevel Code of
+Conduct](https://typelevel.org/code-of-conduct.html) in all venues.
 
 Conversations around Grackle are currently happening on [GitHub issues][grackle-issues], [PR
 discussions][grackle-pulls], and [discord][grackle-dev].

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,8 +54,8 @@ libraryDependencies += "org.typelevel" %% "grackle-skunk" % "@VERSION@"
 ## Community
 
 Grackle is proud to be a [Typelevel](https://typelevel.org/) project. We are committed to providing a friendly, safe
-and welcoming environment for all, and ask that the community adhere to the [Scala Code of
-Conduct](https://www.scala-lang.org/conduct/) in all venues.
+and welcoming environment for all, and ask that the community adhere to the [Typelevel Code of
+Conduct](https://typelevel.org/code-of-conduct.html) in all venues.
 
 Conversations around Grackle are currently happening on [GitHub issues][grackle-issues], [PR
 discussions][grackle-pulls], and [discord][grackle-dev].


### PR DESCRIPTION
Typelevel has reverted to the Typelevel Code of Conduct organisation wide. This PR updates the docs to align with that.