### PR TITLE
Rework interfaces and implementations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ ThisBuild / scalaVersion        := Scala2
 ThisBuild / crossScalaVersions  := Seq(Scala2, Scala3)
 ThisBuild / tlJdkRelease        := Some(11)
 
-ThisBuild / tlBaseVersion    := "0.19"
+ThisBuild / tlBaseVersion    := "0.20"
 ThisBuild / startYear        := Some(2019)
 ThisBuild / licenses         := Seq(License.Apache2)
 ThisBuild / developers       := List(

--- a/modules/core/src/main/scala/composedmapping.scala
+++ b/modules/core/src/main/scala/composedmapping.scala
@@ -21,25 +21,14 @@ import Cursor.AbstractCursor
 import syntax._
 
 abstract class ComposedMapping[F[_]](implicit val M: MonadThrow[F]) extends Mapping[F] {
-  override def mkCursorForField(parent: Cursor, fieldName: String, resultName: Option[String]): Result[Cursor] = {
-    val context = parent.context
-    val fieldContext = context.forFieldOrAttribute(fieldName, resultName)
-    typeMappings.fieldMapping(context, fieldName) match {
-      case Some(_) =>
-        ComposedCursor(fieldContext, parent.env).success
-      case _ =>
-        super.mkCursorForField(parent, fieldName, resultName)
-    }
-  }
+  override def mkCursorForMappedField(parent: Cursor, fieldContext: Context, fm: FieldMapping): Result[Cursor] =
+    ComposedCursor(fieldContext, parent.env).success
 
   case class ComposedCursor(context: Context, env: Env) extends AbstractCursor {
     val focus = null
     val parent = None
 
     def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
-
-    override def hasField(fieldName: String): Boolean =
-      typeMappings.fieldMapping(context, fieldName).isDefined
 
     override def field(fieldName: String, resultName: Option[String]): Result[Cursor] =
       mkCursorForField(this, fieldName, resultName)

--- a/modules/core/src/main/scala/introspection.scala
+++ b/modules/core/src/main/scala/introspection.scala
@@ -224,15 +224,12 @@ object Introspection {
             case _ => None
           }),
           ValueField("interfaces", flipNullityDealias andThen {
-            case ot: ObjectType     => Some(ot.interfaces.map(_.nullable))
+            case tf: TypeWithFields => Some(tf.interfaces.map(_.nullable))
             case _ => None
           }),
           ValueField("possibleTypes", flipNullityDealias andThen {
             case u: UnionType       => Some(u.members.map(_.nullable))
-            case i: InterfaceType   =>
-              Some(allTypes.collect {
-                case o: ObjectType if o.interfaces.exists(_ =:= i) => NullableType(o)
-              })
+            case i: InterfaceType   => Some(targetSchema.implementations(i).map(_.nullable))
             case _ => None
           }),
           ValueField("enumValues", flipNullityDealias andThen {

--- a/modules/core/src/main/scala/mapping.scala
+++ b/modules/core/src/main/scala/mapping.scala
@@ -181,9 +181,13 @@ abstract class Mapping[F[_]] {
         case om: ObjectMapping => om
       }
 
+    /** Yields the unexpanded `FieldMapping` associated with `fieldName` in `context`, if any. */
+    def rawFieldMapping(context: Context, fieldName: String): Option[FieldMapping] =
+      fieldIndex(context).flatMap(_.get(fieldName))
+
     /** Yields the `FieldMapping` associated with `fieldName` in `context`, if any. */
     def fieldMapping(context: Context, fieldName: String): Option[FieldMapping] =
-      fieldIndex(context).flatMap(_.get(fieldName)).flatMap {
+      rawFieldMapping(context, fieldName).flatMap {
         case ifm: InheritedFieldMapping =>
           ifm.select(context)
         case pfm: PolymorphicFieldMapping =>
@@ -507,7 +511,7 @@ abstract class Mapping[F[_]] {
     }
 
     /** A synthetic field mapping representing a field mapped in an implemented interface */
-    private case class InheritedFieldMapping(candidates: Seq[(MappingPredicate, FieldMapping)])(implicit val pos: SourcePos) extends FieldMapping {
+    case class InheritedFieldMapping(candidates: Seq[(MappingPredicate, FieldMapping)])(implicit val pos: SourcePos) extends FieldMapping {
       def fieldName: String = candidates.head._2.fieldName
       def hidden: Boolean = false
       def subtree: Boolean = false
@@ -522,7 +526,7 @@ abstract class Mapping[F[_]] {
     }
 
     /** A synthetic field mapping representing a field mapped by one or more implementing types */
-    private case class PolymorphicFieldMapping(candidates: Seq[(MappingPredicate, FieldMapping)])(implicit val pos: SourcePos) extends FieldMapping {
+    case class PolymorphicFieldMapping(candidates: Seq[(MappingPredicate, FieldMapping)])(implicit val pos: SourcePos) extends FieldMapping {
       def fieldName: String = candidates.head._2.fieldName
       def hidden: Boolean = false
       def subtree: Boolean = false

--- a/modules/core/src/main/scala/queryinterpreter.scala
+++ b/modules/core/src/main/scala/queryinterpreter.scala
@@ -204,8 +204,8 @@ class QueryInterpreter[F[_]](mapping: Mapping[F]) {
           (tpe.dealias match {
             case o: ObjectType => Some(o.name)
             case i: InterfaceType =>
-              (schema.types.collectFirst {
-                case o: ObjectType if o <:< i && cursor.narrowsTo(schema.uncheckedRef(o)) => o.name
+              (schema.implementations(i).collectFirst {
+                case o if cursor.narrowsTo(schema.uncheckedRef(o)) => o.name
               })
             case u: UnionType =>
               (u.members.map(_.dealias).collectFirst {

--- a/modules/core/src/test/scala/extensions/ExtensionsSuite.scala
+++ b/modules/core/src/test/scala/extensions/ExtensionsSuite.scala
@@ -173,7 +173,7 @@ final class ExtensionsSuite extends CatsEffectSuite {
           extinct: Boolean
         }
 
-        extend type Human {
+        extend type Human implements Organism {
           id: ID!
           extinct: Boolean
         }
@@ -192,7 +192,7 @@ final class ExtensionsSuite extends CatsEffectSuite {
     schema.definition("Human") match {
       case Some(obj: ObjectType) =>
         assertEquals(obj.fields.map(_.name), List("name", "species", "id", "extinct"))
-        assertEquals(obj.interfaces.map(_.name), List("Animal"))
+        assertEquals(obj.interfaces.map(_.name), List("Animal", "Organism"))
       case _ => fail("Human type not found")
     }
   }
@@ -218,6 +218,8 @@ final class ExtensionsSuite extends CatsEffectSuite {
         }
 
         extend interface Animal implements Organism @Intrf
+
+        extend type Human implements Organism
 
         directive @Intrf on INTERFACE
       """
@@ -594,6 +596,7 @@ final class ExtensionsSuite extends CatsEffectSuite {
     val expected =
       NonEmptyChain(
         "Duplicate definition of field 'species' for type 'Animal'",
+        "Type 'Human' does not directly implement transitively implemented interfaces: 'Organism', 'Mineral'",
         "Field 'extinct' from interface 'Organism' is not defined by implementing type 'Animal'",
         "Undefined type 'Mineral' declared as implemented by type 'Animal'",
         "Directive 'Sca' is not allowed on INTERFACE"

--- a/modules/core/src/test/scala/introspection/IntrospectionSuite.scala
+++ b/modules/core/src/test/scala/introspection/IntrospectionSuite.scala
@@ -473,7 +473,8 @@ final class IntrospectionSuite extends CatsEffectSuite {
               {
                 "name" : "interface",
                 "type" : {
-                  "interfaces" : null
+                  "interfaces" : [
+                  ]
                 }
               },
               {
@@ -1209,7 +1210,8 @@ final class IntrospectionSuite extends CatsEffectSuite {
                   }
                 ],
                 "inputFields" : null,
-                "interfaces" : null,
+                "interfaces" : [
+                ],
                 "enumValues" : null,
                 "possibleTypes" : [
                   {

--- a/modules/core/src/test/scala/mapping/MappingValidatorSuite.scala
+++ b/modules/core/src/test/scala/mapping/MappingValidatorSuite.scala
@@ -39,7 +39,7 @@ final class ValidatorSuite extends CatsEffectSuite {
         """
 
       override val typeMappings =
-        TypeMappings.unsafe(
+        TypeMappings.unchecked(
           List(
             ObjectMapping(
               schema.ref("Query"),
@@ -74,7 +74,7 @@ final class ValidatorSuite extends CatsEffectSuite {
         """
 
       override val typeMappings =
-        TypeMappings.unsafe(
+        TypeMappings.unchecked(
           ObjectMapping(schema.ref("Query"))(
             CursorField[String]("foo", _ => ???, Nil)
           ),
@@ -110,7 +110,7 @@ final class ValidatorSuite extends CatsEffectSuite {
         """
 
       override val typeMappings =
-        TypeMappings.unsafe(
+        TypeMappings.unchecked(
           List(
             ObjectMapping(
               schema.ref("Query"),
@@ -147,7 +147,7 @@ final class ValidatorSuite extends CatsEffectSuite {
         """
 
       override val typeMappings =
-        TypeMappings.unsafe(
+        TypeMappings.unchecked(
           List(
             ObjectMapping(
               schema.ref("Query"),
@@ -186,7 +186,7 @@ final class ValidatorSuite extends CatsEffectSuite {
         """
 
       override val typeMappings =
-        TypeMappings.unsafe(
+        TypeMappings.unchecked(
           List(
             ObjectMapping(
               schema.ref("Query"),
@@ -357,7 +357,7 @@ final class ValidatorSuite extends CatsEffectSuite {
         """
 
       override val typeMappings =
-        TypeMappings.unsafe(
+        TypeMappings.unchecked(
           List(
             ObjectMapping(
               schema.ref("Query"),
@@ -396,7 +396,7 @@ final class ValidatorSuite extends CatsEffectSuite {
         """
 
       override val typeMappings =
-        TypeMappings.unsafe(
+        TypeMappings.unchecked(
           List(
             ObjectMapping(
               schema.ref("Query"),
@@ -474,7 +474,7 @@ final class ValidatorSuite extends CatsEffectSuite {
         """
 
       override val typeMappings =
-        TypeMappings.unsafe(
+        TypeMappings.unchecked(
           List(
             ObjectMapping(
               schema.ref("Query"),

--- a/modules/core/src/test/scala/starwars/StarWarsData.scala
+++ b/modules/core/src/test/scala/starwars/StarWarsData.scala
@@ -145,6 +145,8 @@ object StarWarsMapping extends ValueMapping[IO] {
       }
       interface Character {
         id: String!
+        taggedId1: String!
+        taggedId2: String!
         name: String
         numberOfFriends: Int
         friends: [Character!]
@@ -152,6 +154,8 @@ object StarWarsMapping extends ValueMapping[IO] {
       }
       type Human implements Character {
         id: String!
+        taggedId1: String!
+        taggedId2: String!
         name: String
         numberOfFriends: Int
         friends: [Character!]
@@ -160,6 +164,8 @@ object StarWarsMapping extends ValueMapping[IO] {
       }
       type Droid implements Character {
         id: String!
+        taggedId1: String!
+        taggedId2: String!
         name: String
         numberOfFriends: Int
         friends: [Character!]
@@ -192,6 +198,7 @@ object StarWarsMapping extends ValueMapping[IO] {
         fieldMappings =
           List(
             ValueField("id", _.id),
+            ValueField("taggedId1", c => s"character-${c.id}"),
             ValueField("name", _.name),
             ValueField("appearsIn", _.appearsIn),
             ValueField("numberOfFriends", _ => 0),
@@ -202,6 +209,8 @@ object StarWarsMapping extends ValueMapping[IO] {
         tpe = HumanType,
         fieldMappings =
           List(
+            ValueField("taggedId1", h => s"human-${h.id}"),
+            ValueField("taggedId2", h => s"human2-${h.id}"),
             ValueField("homePlanet", _.homePlanet)
           )
       ),
@@ -209,6 +218,7 @@ object StarWarsMapping extends ValueMapping[IO] {
         tpe = DroidType,
         fieldMappings =
           List(
+            ValueField("taggedId2", h => s"droid2-${h.id}"),
             ValueField("primaryFunction", _.primaryFunction)
           )
       ),

--- a/modules/core/src/test/scala/starwars/StarWarsSuite.scala
+++ b/modules/core/src/test/scala/starwars/StarWarsSuite.scala
@@ -478,4 +478,230 @@ final class StarWarsSuite extends CatsEffectSuite {
 
     assertIO(res, expected)
   }
+
+  test("interface variant (1)") {
+    val query = """
+      query {
+        characters(offset: 3, limit: 4) {
+          ... on Human {
+            taggedId1
+          }
+          ... on Droid {
+            taggedId1
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "characters" : [
+            {
+              "taggedId1" : "human-1003"
+            },
+            {
+              "taggedId1" : "human-1004"
+            },
+            {
+              "taggedId1" : "character-2000"
+            },
+            {
+              "taggedId1" : "character-2001"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = StarWarsMapping.compileAndRun(query)
+
+    assertIO(res, expected)
+  }
+
+  test("interface variant (2)") {
+    val query = """
+      query {
+        characters(offset: 3, limit: 4) {
+          taggedId1
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "characters" : [
+            {
+              "taggedId1" : "human-1003"
+            },
+            {
+              "taggedId1" : "human-1004"
+            },
+            {
+              "taggedId1" : "character-2000"
+            },
+            {
+              "taggedId1" : "character-2001"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = StarWarsMapping.compileAndRun(query)
+
+    assertIO(res, expected)
+  }
+
+  test("interface variant (3)") {
+    val query = """
+      query {
+        characters(offset: 3, limit: 4) {
+          taggedId1
+          ... on Human {
+            taggedId1
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "characters" : [
+            {
+              "taggedId1" : "human-1003"
+            },
+            {
+              "taggedId1" : "human-1004"
+            },
+            {
+              "taggedId1" : "character-2000"
+            },
+            {
+              "taggedId1" : "character-2001"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = StarWarsMapping.compileAndRun(query)
+
+    assertIO(res, expected)
+  }
+
+  test("interface variant (4)") {
+    val query = """
+      query {
+        characters(offset: 3, limit: 4) {
+          ... on Human {
+            taggedId2
+          }
+          ... on Droid {
+            taggedId2
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "characters" : [
+            {
+              "taggedId2" : "human2-1003"
+            },
+            {
+              "taggedId2" : "human2-1004"
+            },
+            {
+              "taggedId2" : "droid2-2000"
+            },
+            {
+              "taggedId2" : "droid2-2001"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = StarWarsMapping.compileAndRun(query)
+
+    assertIO(res, expected)
+  }
+
+  test("interface variant (5)") {
+    val query = """
+      query {
+        characters(offset: 3, limit: 4) {
+          taggedId2
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "characters" : [
+            {
+              "taggedId2" : "human2-1003"
+            },
+            {
+              "taggedId2" : "human2-1004"
+            },
+            {
+              "taggedId2" : "droid2-2000"
+            },
+            {
+              "taggedId2" : "droid2-2001"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = StarWarsMapping.compileAndRun(query)
+
+    assertIO(res, expected)
+  }
+
+  test("interface variant (6)") {
+    val query = """
+      query {
+        characters(offset: 3, limit: 4) {
+          taggedId2
+          ... on Human {
+            taggedId2
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "characters" : [
+            {
+              "taggedId2" : "human2-1003"
+            },
+            {
+              "taggedId2" : "human2-1004"
+            },
+            {
+              "taggedId2" : "droid2-2000"
+            },
+            {
+              "taggedId2" : "droid2-2001"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = StarWarsMapping.compileAndRun(query)
+
+    assertIO(res, expected)
+  }
 }

--- a/modules/generic/src/main/scala-2/genericmapping2.scala
+++ b/modules/generic/src/main/scala-2/genericmapping2.scala
@@ -83,9 +83,6 @@ trait ScalaVersionSpecificGenericMappingLike[F[_]] extends Mapping[F] { self: Ge
       extends AbstractCursor {
       def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
 
-      override def hasField(fieldName: String): Boolean =
-        fieldMap.contains(fieldName) || typeMappings.fieldMapping(context, fieldName).isDefined
-
       override def field(fieldName: String, resultName: Option[String]): Result[Cursor] = {
         val localField =
           fieldMap.get(fieldName).toResult(s"No field '$fieldName' for type $tpe").flatMap { f =>
@@ -136,8 +133,6 @@ trait ScalaVersionSpecificGenericMappingLike[F[_]] extends Mapping[F] { self: Ge
 
       def focus: Any = cursor.focus
       val context: Context = cursor.context.asType(tpe0)
-
-      override def hasField(fieldName: String): Boolean = cursor.hasField(fieldName)
 
       override def field(fieldName: String, resultName: Option[String]): Result[Cursor] =
         cursor.field(fieldName, resultName) orElse mkCursorForField(this, fieldName, resultName)

--- a/modules/generic/src/main/scala-3/genericmapping3.scala
+++ b/modules/generic/src/main/scala-3/genericmapping3.scala
@@ -73,9 +73,6 @@ trait ScalaVersionSpecificGenericMappingLike[F[_]] extends Mapping[F] { self: Ge
       extends AbstractCursor {
       def withEnv(env0: Env): Cursor = copy(env = env.add(env0))
 
-      override def hasField(fieldName: String): Boolean =
-        fieldMap.contains(fieldName) || typeMappings.fieldMapping(context, fieldName).isDefined
-
       override def field(fieldName: String, resultName: Option[String]): Result[Cursor] = {
         val localField =
           fieldMap.get(fieldName).toResult(s"No field '$fieldName' for type $tpe").flatMap { f =>
@@ -115,8 +112,6 @@ trait ScalaVersionSpecificGenericMappingLike[F[_]] extends Mapping[F] { self: Ge
 
       def focus: Any = cursor.focus
       val context: Context = cursor.context.asType(tpe0)
-
-      override def hasField(fieldName: String): Boolean = cursor.hasField(fieldName)
 
       override def field(fieldName: String, resultName: Option[String]): Result[Cursor] =
         cursor.field(fieldName, resultName) orElse mkCursorForField(this, fieldName, resultName)

--- a/modules/generic/src/main/scala/genericmapping.scala
+++ b/modules/generic/src/main/scala/genericmapping.scala
@@ -31,16 +31,13 @@ trait GenericMappingLike[F[_]] extends ScalaVersionSpecificGenericMappingLike[F]
     else
       DeferredCursor(path, (context, parent) => cb.build(context, t, Some(parent), env)).success
 
-  override def mkCursorForField(parent: Cursor, fieldName: String, resultName: Option[String]): Result[Cursor] = {
-    val context = parent.context
-    val fieldContext = context.forFieldOrAttribute(fieldName, resultName)
-    typeMappings.fieldMapping(context, fieldName) match {
-      case Some(GenericField(_, t, cb, _)) =>
+  override def mkCursorForMappedField(parent: Cursor, fieldContext: Context, fm: FieldMapping): Result[Cursor] =
+    fm match {
+      case GenericField(_, t, cb, _) =>
         cb().build(fieldContext, t, Some(parent), parent.env)
       case _ =>
-        super.mkCursorForField(parent, fieldName, resultName)
+        super.mkCursorForMappedField(parent, fieldContext, fm)
     }
-  }
 
   case class GenericField[T](val fieldName: String, t: T, cb: () => CursorBuilder[T], hidden: Boolean)(
     implicit val pos: SourcePos

--- a/modules/generic/src/main/scala/genericmapping.scala
+++ b/modules/generic/src/main/scala/genericmapping.scala
@@ -45,7 +45,7 @@ trait GenericMappingLike[F[_]] extends ScalaVersionSpecificGenericMappingLike[F]
     def subtree: Boolean = true
   }
 
-  def GenericField[T](fieldName: String, t: T, hidden: Boolean = true)(implicit cb: => CursorBuilder[T], pos: SourcePos): GenericField[T] =
+  def GenericField[T](fieldName: String, t: T, hidden: Boolean = false)(implicit cb: => CursorBuilder[T], pos: SourcePos): GenericField[T] =
     new GenericField(fieldName, t, () => cb, hidden)
 
   object semiauto {

--- a/modules/sql/shared/src/test/scala/SqlMappingValidatorInvalidMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlMappingValidatorInvalidMapping.scala
@@ -133,7 +133,7 @@ trait SqlMappingValidatorInvalidMapping[F[_]] extends SqlTestMapping[F] {
   val SubObj3Type = schema.ref("SubObj3")
 
   override val typeMappings =
-    TypeMappings.unsafe(
+    TypeMappings.unchecked(
       List(
         ObjectMapping(
           tpe = QueryType,

--- a/modules/sql/shared/src/test/scala/SqlMappingValidatorInvalidSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlMappingValidatorInvalidSuite.scala
@@ -168,6 +168,15 @@ trait SqlMappingValidatorInvalidSuite extends CatsEffectSuite {
       }
   }
 
+  object UFM {
+    def unapply(vf: ValidationFailure): Option[(String, String)] =
+      vf match {
+        case M.UnusedFieldMapping(om, fm) =>
+          Some((om.tpe.name, fm.fieldName))
+        case _ => None
+      }
+  }
+
   object TypeNames {
     val BooleanTypeName = typeName[Boolean]
     val IntTypeName = typeName[Int]
@@ -212,7 +221,8 @@ trait SqlMappingValidatorInvalidSuite extends CatsEffectSuite {
           NHUFM("Union", "id"),
           SUM("Union", List("Obj1", "Obj2"), List("obj1", "obj2")),
           ND("Union"),
-          NK("Union")
+          NK("Union"),
+          UFM("Intrf", "id")
         ) =>
     }
   }

--- a/modules/sql/shared/src/test/scala/SqlMappingValidatorValidMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlMappingValidatorValidMapping.scala
@@ -207,7 +207,7 @@ trait SqlMappingValidatorValidMapping[F[_]] extends SqlTestMapping[F] {
   val SubObj2Type = schema.ref("SubObj2")
 
   override val typeMappings =
-    TypeMappings.unsafe(
+    TypeMappings.unchecked(
       List(
         ObjectMapping(
           tpe = QueryType,

--- a/modules/sql/shared/src/test/scala/SqlSiblingListsMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlSiblingListsMapping.scala
@@ -86,7 +86,7 @@ trait SqlSiblingListsData[F[_]] extends SqlTestMapping[F] {
         tpe = AType,
         fieldMappings =
           List(
-            SqlField("id", aTable.id, key = true, hidden = true),
+            SqlField("id", aTable.id, key = true),
             SqlObject("bs", Join(aTable.id, bTable.aId))
           )
       ),
@@ -94,7 +94,7 @@ trait SqlSiblingListsData[F[_]] extends SqlTestMapping[F] {
         tpe = BType,
         fieldMappings =
           List(
-            SqlField("id", bTable.id, key = true, hidden = true),
+            SqlField("id", bTable.id, key = true),
             SqlObject("cs", Join(bTable.id, cTable.bId)),
             SqlObject("ds", Join(bTable.id, dTable.bId))
           )
@@ -103,7 +103,7 @@ trait SqlSiblingListsData[F[_]] extends SqlTestMapping[F] {
         tpe = CType,
         fieldMappings =
           List(
-            SqlField("id", cTable.id, key = true, hidden = true),
+            SqlField("id", cTable.id, key = true),
             SqlField("nameC", cTable.nameC)
           )
       ),
@@ -111,7 +111,7 @@ trait SqlSiblingListsData[F[_]] extends SqlTestMapping[F] {
         tpe = DType,
         fieldMappings =
           List(
-            SqlField("id", dTable.id, key = true, hidden = true),
+            SqlField("id", dTable.id, key = true),
             SqlField("nameD", dTable.nameD)
           )
       )


### PR DESCRIPTION
+ Object type fields mapped at the interface level and interface type fields which are implemented or overridden at the object type level are now explicitly represented internally. This allows both more efficient lookup of inherited field mappings and correct lookup of overriden field mappings.
+ Field mapping lookup is now more effectively indexed in `TypeMappings`. This might give a noticeable performance improvement for `ValueMapping`. Now that this indexing in centralised in `TypeMappings`, the per-`ObjectMapping` field indices have been removed. If this proves problematic for applications it could be reinstated.
+ Schema validation now enforces the uniqueness of interfaces in `implements` clauses.
+ Schema validation now enforces that object and interface types must directly implement all transitively implemented interfaces. The `allInterfaces` method on `InterfaceType` has been deprecated because with the preceding validation change it is equivalent to `interfaces`.
+ The `Mapping`-specific logic of `mkCursorForField` has been extracted to `mkCursorForMappedField` allowing simpler mapping-specific implementations.
+ Previously introspection did not report interfaces implemented by interfaces.
+ Added `Schema#implementations` which returns the implementing object types of an interface.
+ The `unsafe` `TypeMappings` constructor has been deprecated and renamed to `unchecked`.
+ `TypeMappings#unsafe` has been renamed to `unchecked` and hidden
+ The implementations of `hasField`, `nullableHasField`, `hasPath` and `hasListPath` in `Cursor` had incorrect semantics and appear to be unused, so rather than fix them, they have been removed.
+ Various tests have been updated to conform to the newly implemented validation rules and changes to field mapping lookup.