### PR TITLE
Fix for polymorphic fields in SqlMapping

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ ThisBuild / scalaVersion        := Scala2
 ThisBuild / crossScalaVersions  := Seq(Scala2, Scala3)
 ThisBuild / tlJdkRelease        := Some(11)
 
-ThisBuild / tlBaseVersion    := "0.21"
+ThisBuild / tlBaseVersion    := "0.22"
 ThisBuild / startYear        := Some(2019)
 ThisBuild / licenses         := Seq(License.Apache2)
 ThisBuild / developers       := List(

--- a/modules/core/src/main/scala/cursor.scala
+++ b/modules/core/src/main/scala/cursor.scala
@@ -128,7 +128,7 @@ trait Cursor {
   def isDefined: Result[Boolean]
 
   /** Is the value at this `Cursor` narrowable to `subtpe`? */
-  def narrowsTo(subtpe: TypeRef): Boolean
+  def narrowsTo(subtpe: TypeRef): Result[Boolean]
 
   /**
    * Yield a `Cursor` corresponding to the value at this `Cursor` narrowed to
@@ -251,7 +251,7 @@ object Cursor {
     def isDefined: Result[Boolean] =
       Result.internalError(s"Expected Nullable type, found $focus for $tpe")
 
-    def narrowsTo(subtpe: TypeRef): Boolean = false
+    def narrowsTo(subtpe: TypeRef): Result[Boolean] = false.success
 
     def narrow(subtpe: TypeRef): Result[Cursor] =
       Result.internalError(s"Focus ${focus} of static type $tpe cannot be narrowed to $subtpe")
@@ -290,7 +290,7 @@ object Cursor {
 
     def isDefined: Result[Boolean] = underlying.isDefined
 
-    def narrowsTo(subtpe: TypeRef): Boolean = underlying.narrowsTo(subtpe)
+    def narrowsTo(subtpe: TypeRef): Result[Boolean] = underlying.narrowsTo(subtpe)
 
     def narrow(subtpe: TypeRef): Result[Cursor] = underlying.narrow(subtpe)
 

--- a/modules/core/src/main/scala/query.scala
+++ b/modules/core/src/main/scala/query.scala
@@ -456,35 +456,6 @@ object Query {
     }
   }
 
-  /** Extractor for grouped Narrow patterns in the query algebra */
-  object TypeCase {
-    def unapply(q: Query): Option[(Query, List[Narrow])] = {
-      def branch(q: Query): Option[TypeRef] =
-        q match {
-          case Narrow(subtpe, _) => Some(subtpe)
-          case _ => None
-        }
-
-      val grouped = ungroup(q).groupBy(branch).toList
-      val (default0, narrows0) = grouped.partition(_._1.isEmpty)
-      if (narrows0.isEmpty) None
-      else {
-        val default = default0.flatMap(_._2) match {
-          case Nil => Empty
-          case children => Group(children)
-        }
-        val narrows = narrows0.collect {
-          case (Some(subtpe), narrows) =>
-            narrows.collect { case Narrow(_, child) => child } match {
-              case List(child) => Narrow(subtpe, child)
-              case children => Narrow(subtpe, Group(children))
-            }
-        }
-        Some((default, narrows))
-      }
-    }
-  }
-
   /** Construct a query which yields all the supplied paths */
   def mkPathQuery(paths: List[List[String]]): List[Query] =
     paths match {

--- a/modules/generic/src/main/scala-2/genericmapping2.scala
+++ b/modules/generic/src/main/scala-2/genericmapping2.scala
@@ -137,12 +137,14 @@ trait ScalaVersionSpecificGenericMappingLike[F[_]] extends Mapping[F] { self: Ge
       override def field(fieldName: String, resultName: Option[String]): Result[Cursor] =
         cursor.field(fieldName, resultName) orElse mkCursorForField(this, fieldName, resultName)
 
-      override def narrowsTo(subtpe: TypeRef): Boolean =
-        subtpe <:< tpe && rtpe <:< subtpe
+      override def narrowsTo(subtpe: TypeRef): Result[Boolean] =
+        (subtpe <:< tpe && rtpe <:< subtpe).success
 
       override def narrow(subtpe: TypeRef): Result[Cursor] =
-        if (narrowsTo(subtpe)) copy(tpe0 = subtpe).success
-        else Result.internalError(s"Focus ${focus} of static type $tpe cannot be narrowed to $subtpe")
+        narrowsTo(subtpe).flatMap { n =>
+          if (n) copy(tpe0 = subtpe).success
+          else Result.internalError(s"Focus ${focus} of static type $tpe cannot be narrowed to $subtpe")
+        }
     }
   }
 }

--- a/modules/sql/shared/src/test/resources/db/interfaces.sql
+++ b/modules/sql/shared/src/test/resources/db/interfaces.sql
@@ -7,7 +7,9 @@ CREATE TABLE entities (
     film_rating TEXT,
     film_label INTEGER,
     series_number_of_episodes INTEGER,
-    series_label TEXT
+    series_label TEXT,
+    image_url TEXT,
+    hidden_image_url TEXT
 );
 
 CREATE TABLE episodes (
@@ -18,13 +20,13 @@ CREATE TABLE episodes (
     synopsis_long TEXT
 );
 
-COPY entities (id, entity_type, title, synopsis_short, synopsis_long, film_rating, film_label, series_number_of_episodes, series_label) FROM STDIN WITH DELIMITER '|' NULL AS '';
-1|1|Film 1|Short film 1|Long film 1|PG|1||
-2|1|Film 2|Short film 2|Long film 2|U|2||
-3|1|Film 3|Short film 3|Long film 3|15|3||
-4|2|Series 1|Short series 1|Long series 1|||5|One
-5|2|Series 2|Short series 2|Long series 2|||6|Two
-6|2|Series 3|Short series 3|Long series 3|||7|Three
+COPY entities (id, entity_type, title, synopsis_short, synopsis_long, film_rating, film_label, series_number_of_episodes, series_label, image_url, hidden_image_url) FROM STDIN WITH DELIMITER '|' NULL AS '';
+1|1|Film 1|Short film 1|Long film 1|PG|1|||http://www.example.com/film1.jpg|
+2|1|Film 2|Short film 2|Long film 2|U|2|||http://www.example.com/film2.jpg|
+3|1|Film 3|Short film 3|Long film 3|15|3|||http://www.example.com/film3.jpg|
+4|2|Series 1|Short series 1|Long series 1|||5|One||hidden_series1.jpg
+5|2|Series 2|Short series 2|Long series 2|||6|Two||hidden_series2.jpg
+6|2|Series 3|Short series 3|Long series 3|||7|Three||hidden_series3.jpg
 \.
 
 COPY episodes (id, series_id, title, synopsis_short, synopsis_long) FROM STDIN WITH DELIMITER '|' NULL AS '';

--- a/modules/sql/shared/src/test/scala/SqlInterfacesMapping2.scala
+++ b/modules/sql/shared/src/test/scala/SqlInterfacesMapping2.scala
@@ -16,6 +16,7 @@
 package grackle.sql.test
 
 import grackle._
+import grackle.syntax._
 import Predicate._
 
 trait SqlInterfacesMapping2[F[_]] extends SqlInterfacesMapping[F] { self =>
@@ -24,19 +25,18 @@ trait SqlInterfacesMapping2[F[_]] extends SqlInterfacesMapping[F] { self =>
 
     // discriminator always fails
     def discriminate(c: Cursor): Result[Type] =
-      Result.failure("no")
+      Result.internalError("Boom!!!")
 
     // same as in SqlInterfacesMapping
-    def narrowPredicate(subtpe: Type): Option[Predicate] = {
-      def mkPredicate(tpe: EntityType): Option[Predicate] =
-        Some(Eql(EType / "entityType", Const(tpe)))
+    def narrowPredicate(subtpe: Type): Result[Predicate] = {
+      def mkPredicate(tpe: EntityType): Result[Predicate] =
+        Eql(EType / "entityType", Const(tpe)).success
 
       subtpe match {
         case FilmType => mkPredicate(EntityType.Film)
         case SeriesType => mkPredicate(EntityType.Series)
-        case _ => None
+        case _ => Result.internalError(s"Invalid discriminator: $subtpe")
       }
     }
   }
-
 }

--- a/modules/sql/shared/src/test/scala/SqlInterfacesSuite.scala
+++ b/modules/sql/shared/src/test/scala/SqlInterfacesSuite.scala
@@ -805,4 +805,553 @@ trait SqlInterfacesSuite extends CatsEffectSuite {
 
     assertWeaklyEqualIO(res, expected)
   }
+
+  test("interface query with polymorphic cursor field (1)") {
+    val query = """
+      query {
+        entities {
+          id
+          ... on Film {
+            imageUrl
+          }
+          ... on Series {
+            imageUrl
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "entities" : [
+            {
+              "id" : "4",
+              "imageUrl" : "http://example.com/series/hidden_series1.jpg"
+            },
+            {
+              "id" : "5",
+              "imageUrl" : "http://example.com/series/hidden_series2.jpg"
+            },
+            {
+              "id" : "2",
+              "imageUrl" : "http://www.example.com/film2.jpg"
+            },
+            {
+              "id" : "3",
+              "imageUrl" : "http://www.example.com/film3.jpg"
+            },
+            {
+              "id" : "6",
+              "imageUrl" : "http://example.com/series/hidden_series3.jpg"
+            },
+            {
+              "id" : "1",
+              "imageUrl" : "http://www.example.com/film1.jpg"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query)
+
+    assertWeaklyEqualIO(res, expected)
+  }
+
+  test("interface query with polymorphic cursor field (2)") {
+    val query = """
+      query {
+        entities {
+          id
+          imageUrl
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "entities" : [
+            {
+              "id" : "4",
+              "imageUrl" : "http://example.com/series/hidden_series1.jpg"
+            },
+            {
+              "id" : "5",
+              "imageUrl" : "http://example.com/series/hidden_series2.jpg"
+            },
+            {
+              "id" : "2",
+              "imageUrl" : "http://www.example.com/film2.jpg"
+            },
+            {
+              "id" : "3",
+              "imageUrl" : "http://www.example.com/film3.jpg"
+            },
+            {
+              "id" : "6",
+              "imageUrl" : "http://example.com/series/hidden_series3.jpg"
+            },
+            {
+              "id" : "1",
+              "imageUrl" : "http://www.example.com/film1.jpg"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query)
+
+    assertWeaklyEqualIO(res, expected)
+  }
+
+  test("interface query with polymorphic cursor field (3)") {
+    val query = """
+      query {
+        entities {
+          id
+          imageUrl
+          ... on Film {
+            rating
+            imageUrl
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "entities" : [
+            {
+              "id" : "4",
+              "imageUrl" : "http://example.com/series/hidden_series1.jpg"
+            },
+            {
+              "id" : "5",
+              "imageUrl" : "http://example.com/series/hidden_series2.jpg"
+            },
+            {
+              "id" : "2",
+              "imageUrl" : "http://www.example.com/film2.jpg",
+              "rating" : "U"
+            },
+            {
+              "id" : "3",
+              "imageUrl" : "http://www.example.com/film3.jpg",
+              "rating" : "15"
+            },
+            {
+              "id" : "6",
+              "imageUrl" : "http://example.com/series/hidden_series3.jpg"
+            },
+            {
+              "id" : "1",
+              "imageUrl" : "http://www.example.com/film1.jpg",
+              "rating" : "PG"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query)
+
+    assertWeaklyEqualIO(res, expected)
+  }
+
+  test("interface query with polymorphic cursor field (4)") {
+    val query = """
+      query {
+        entities {
+          id
+          imageUrl
+          ... FilmFields
+        }
+      }
+
+      fragment FilmFields on Film {
+        rating
+        imageUrl
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "entities" : [
+            {
+              "id" : "4",
+              "imageUrl" : "http://example.com/series/hidden_series1.jpg"
+            },
+            {
+              "id" : "5",
+              "imageUrl" : "http://example.com/series/hidden_series2.jpg"
+            },
+            {
+              "id" : "2",
+              "imageUrl" : "http://www.example.com/film2.jpg",
+              "rating" : "U"
+            },
+            {
+              "id" : "3",
+              "imageUrl" : "http://www.example.com/film3.jpg",
+              "rating" : "15"
+            },
+            {
+              "id" : "6",
+              "imageUrl" : "http://example.com/series/hidden_series3.jpg"
+            },
+            {
+              "id" : "1",
+              "imageUrl" : "http://www.example.com/film1.jpg",
+              "rating" : "PG"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query)
+
+    assertWeaklyEqualIO(res, expected)
+  }
+
+  test("interface query with polymorphic cursor field (5)") {
+    val query = """
+      query {
+        entities {
+          id
+          ... on Film {
+            rating
+            imageUrl
+          }
+          imageUrl
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "entities" : [
+            {
+              "id" : "4",
+              "imageUrl" : "http://example.com/series/hidden_series1.jpg"
+            },
+            {
+              "id" : "5",
+              "imageUrl" : "http://example.com/series/hidden_series2.jpg"
+            },
+            {
+              "id" : "2",
+              "rating" : "U",
+              "imageUrl" : "http://www.example.com/film2.jpg"
+            },
+            {
+              "id" : "3",
+              "rating" : "15",
+              "imageUrl" : "http://www.example.com/film3.jpg"
+            },
+            {
+              "id" : "6",
+              "imageUrl" : "http://example.com/series/hidden_series3.jpg"
+            },
+            {
+              "id" : "1",
+              "rating" : "PG",
+              "imageUrl" : "http://www.example.com/film1.jpg"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query)
+
+    assertWeaklyEqualIO(res, expected)
+  }
+
+  test("interface query with polymorphic cursor field (6)") {
+    val query = """
+      query {
+        entities {
+          id
+          ... FilmFields
+          imageUrl
+        }
+      }
+
+      fragment FilmFields on Film {
+        rating
+        imageUrl
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "entities" : [
+            {
+              "id" : "4",
+              "imageUrl" : "http://example.com/series/hidden_series1.jpg"
+            },
+            {
+              "id" : "5",
+              "imageUrl" : "http://example.com/series/hidden_series2.jpg"
+            },
+            {
+              "id" : "2",
+              "rating" : "U",
+              "imageUrl" : "http://www.example.com/film2.jpg"
+            },
+            {
+              "id" : "3",
+              "rating" : "15",
+              "imageUrl" : "http://www.example.com/film3.jpg"
+            },
+            {
+              "id" : "6",
+              "imageUrl" : "http://example.com/series/hidden_series3.jpg"
+            },
+            {
+              "id" : "1",
+              "rating" : "PG",
+              "imageUrl" : "http://www.example.com/film1.jpg"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query)
+
+    assertWeaklyEqualIO(res, expected)
+  }
+
+  test("interface query with polymorphic cursor field (7)") {
+    val query = """
+      query {
+        entities {
+          id
+          imageUrl
+          ... on Series {
+            label
+            imageUrl
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "entities" : [
+            {
+              "id" : "4",
+              "imageUrl" : "http://example.com/series/hidden_series1.jpg",
+              "label" : "One"
+            },
+            {
+              "id" : "5",
+              "imageUrl" : "http://example.com/series/hidden_series2.jpg",
+              "label" : "Two"
+            },
+            {
+              "id" : "2",
+              "imageUrl" : "http://www.example.com/film2.jpg"
+            },
+            {
+              "id" : "3",
+              "imageUrl" : "http://www.example.com/film3.jpg"
+            },
+            {
+              "id" : "6",
+              "imageUrl" : "http://example.com/series/hidden_series3.jpg",
+              "label" : "Three"
+            },
+            {
+              "id" : "1",
+              "imageUrl" : "http://www.example.com/film1.jpg"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query)
+
+    assertWeaklyEqualIO(res, expected)
+  }
+
+  test("interface query with polymorphic cursor field (8)") {
+    val query = """
+      query {
+        entities {
+          id
+          imageUrl
+          ... SeriesFields
+        }
+      }
+
+      fragment SeriesFields on Series {
+        label
+        imageUrl
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "entities" : [
+            {
+              "id" : "4",
+              "imageUrl" : "http://example.com/series/hidden_series1.jpg",
+              "label" : "One"
+            },
+            {
+              "id" : "5",
+              "imageUrl" : "http://example.com/series/hidden_series2.jpg",
+              "label" : "Two"
+            },
+            {
+              "id" : "2",
+              "imageUrl" : "http://www.example.com/film2.jpg"
+            },
+            {
+              "id" : "3",
+              "imageUrl" : "http://www.example.com/film3.jpg"
+            },
+            {
+              "id" : "6",
+              "imageUrl" : "http://example.com/series/hidden_series3.jpg",
+              "label" : "Three"
+            },
+            {
+              "id" : "1",
+              "imageUrl" : "http://www.example.com/film1.jpg"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query)
+
+    assertWeaklyEqualIO(res, expected)
+  }
+
+  test("interface query with polymorphic cursor field (9)") {
+    val query = """
+      query {
+        entities {
+          id
+          ... on Series {
+            label
+            imageUrl
+          }
+          imageUrl
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "entities" : [
+            {
+              "id" : "4",
+              "label" : "One",
+              "imageUrl" : "http://example.com/series/hidden_series1.jpg"
+            },
+            {
+              "id" : "5",
+              "label" : "Two",
+              "imageUrl" : "http://example.com/series/hidden_series2.jpg"
+            },
+            {
+              "id" : "2",
+              "imageUrl" : "http://www.example.com/film2.jpg"
+            },
+            {
+              "id" : "3",
+              "imageUrl" : "http://www.example.com/film3.jpg"
+            },
+            {
+              "id" : "6",
+              "label" : "Three",
+              "imageUrl" : "http://example.com/series/hidden_series3.jpg"
+            },
+            {
+              "id" : "1",
+              "imageUrl" : "http://www.example.com/film1.jpg"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query)
+
+    assertWeaklyEqualIO(res, expected)
+  }
+
+  test("interface query with polymorphic cursor field (10)") {
+    val query = """
+      query {
+        entities {
+          id
+          ... SeriesFields
+          imageUrl
+        }
+      }
+
+      fragment SeriesFields on Series {
+        label
+        imageUrl
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "entities" : [
+            {
+              "id" : "4",
+              "label" : "One",
+              "imageUrl" : "http://example.com/series/hidden_series1.jpg"
+            },
+            {
+              "id" : "5",
+              "label" : "Two",
+              "imageUrl" : "http://example.com/series/hidden_series2.jpg"
+            },
+            {
+              "id" : "2",
+              "imageUrl" : "http://www.example.com/film2.jpg"
+            },
+            {
+              "id" : "3",
+              "imageUrl" : "http://www.example.com/film3.jpg"
+            },
+            {
+              "id" : "6",
+              "label" : "Three",
+              "imageUrl" : "http://example.com/series/hidden_series3.jpg"
+            },
+            {
+              "id" : "1",
+              "imageUrl" : "http://www.example.com/film1.jpg"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query)
+
+    assertWeaklyEqualIO(res, expected)
+  }
 }

--- a/modules/sql/shared/src/test/scala/SqlInterfacesSuite2.scala
+++ b/modules/sql/shared/src/test/scala/SqlInterfacesSuite2.scala
@@ -16,17 +16,14 @@
 package grackle.sql.test
 
 import cats.effect.IO
-import io.circe.literal._
 import munit.CatsEffectSuite
 
 import grackle._
 
-import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
-
 trait SqlInterfacesSuite2 extends CatsEffectSuite {
   def mapping: Mapping[IO]
 
-  test("when discriminator fails the fragments should be ignored") {
+  test("when discriminator fails the entire query should fail") {
     val query = """
       query {
         entities {
@@ -43,47 +40,10 @@ trait SqlInterfacesSuite2 extends CatsEffectSuite {
       }
     """
 
-    val expected = json"""
-      {
-        "data" : {
-          "entities" : [
-            {
-              "id" : "1",
-              "entityType" : "FILM",
-              "title" : "Film 1"
-            },
-            {
-              "id" : "2",
-              "entityType" : "FILM",
-              "title" : "Film 2"
-            },
-            {
-              "id" : "3",
-              "entityType" : "FILM",
-              "title" : "Film 3"
-            },
-            {
-              "id" : "4",
-              "entityType" : "SERIES",
-              "title" : "Series 1"
-            },
-            {
-              "id" : "5",
-              "entityType" : "SERIES",
-              "title" : "Series 2"
-            },
-            {
-              "id" : "6",
-              "entityType" : "SERIES",
-              "title" : "Series 3"
-            }
-          ]
-        }
-      }
-    """
+    val expected = Left("Boom!!!")
 
-    val res = mapping.compileAndRun(query)
+    val res = mapping.compileAndRun(query).attempt
 
-    assertWeaklyEqualIO(res, expected)
+    assertIO(res.map(_.left.map(_.getMessage)), expected)
   }
 }

--- a/modules/sql/shared/src/test/scala/SqlMappingValidatorInvalidMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlMappingValidatorInvalidMapping.scala
@@ -234,8 +234,9 @@ trait SqlMappingValidatorInvalidMapping[F[_]] extends SqlTestMapping[F] {
 
   lazy val objectTypeDiscriminator = new SqlDiscriminator {
     def discriminate(c: Cursor): Result[Type] =
-      Result.failure("discriminator not implemented")
+      Result.internalError("discriminator not implemented")
 
-    def narrowPredicate(subtpe: Type): Option[Predicate] = None
+    def narrowPredicate(subtpe: Type): Result[Predicate] =
+      Result.internalError("discriminator not implemented")
   }
 }

--- a/modules/sql/shared/src/test/scala/SqlMappingValidatorValidMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlMappingValidatorValidMapping.scala
@@ -326,9 +326,10 @@ trait SqlMappingValidatorValidMapping[F[_]] extends SqlTestMapping[F] {
 
   lazy val objectTypeDiscriminator = new SqlDiscriminator {
     def discriminate(c: Cursor): Result[Type] =
-      Result.failure("discriminator not implemented")
+      Result.internalError("discriminator not implemented")
 
-    def narrowPredicate(subtpe: Type): Option[Predicate] = None
+    def narrowPredicate(subtpe: Type): Result[Predicate] =
+      Result.internalError("discriminator not implemented")
   }
 
   sealed trait Genre extends Product with Serializable

--- a/modules/sql/shared/src/test/scala/SqlRecursiveInterfacesMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlRecursiveInterfacesMapping.scala
@@ -111,14 +111,14 @@ trait SqlRecursiveInterfacesMapping[F[_]] extends SqlTestMapping[F] { self =>
       }
     }
 
-    def narrowPredicate(subtpe: Type): Option[Predicate] = {
-      def mkPredicate(tpe: ItemType): Option[Predicate] =
-        Some(Eql(IType / "itemType", Const(tpe)))
+    def narrowPredicate(subtpe: Type): Result[Predicate] = {
+      def mkPredicate(tpe: ItemType): Result[Predicate] =
+        Eql(IType / "itemType", Const(tpe)).success
 
       subtpe match {
         case ItemAType => mkPredicate(ItemType.ItemA)
         case ItemBType => mkPredicate(ItemType.ItemB)
-        case _ => None
+        case _ => Result.internalError(s"Invalid discriminator: $subtpe")
       }
     }
   }

--- a/modules/sql/shared/src/test/scala/SqlUnionsMapping.scala
+++ b/modules/sql/shared/src/test/scala/SqlUnionsMapping.scala
@@ -92,14 +92,14 @@ trait SqlUnionsMapping[F[_]] extends SqlTestMapping[F] {
         case "ItemB" => ItemBType
       }
 
-    def narrowPredicate(subtpe: Type): Option[Predicate] = {
-      def mkPredicate(tpe: String): Option[Predicate] =
-        Some(Eql(ItemType / "itemType", Const(tpe)))
+    def narrowPredicate(subtpe: Type): Result[Predicate] = {
+      def mkPredicate(tpe: String): Result[Predicate] =
+        Eql(ItemType / "itemType", Const(tpe)).success
 
       subtpe match {
         case ItemAType => mkPredicate("ItemA")
         case ItemBType => mkPredicate("ItemB")
-        case _ => None
+        case _ => Result.internalError(s"Invalid discriminator: $subtpe")
       }
     }
   }


### PR DESCRIPTION
+ The resolution of polymorphic field mappings now takes the runtime context into account properly.
+ All narrowing operations on cursors yield a value in `Result` allowing mappings to report internal errors for failed discriminators.
+ In SQL mappings, failed discriminators now fail the entire query with an internal error.
+ The `TypeCase` extractor has been removed because it can't take the context into account.