### PR TITLE
preserve internal error

### DIFF
--- a/modules/core/src/main/scala/result.scala
+++ b/modules/core/src/main/scala/result.scala
@@ -145,6 +145,12 @@ sealed trait Result[+T] {
       case _ => false
     }
 
+  def isFailure: Boolean =
+    this match {
+      case Result.Failure(_) => true
+      case _ => false
+    }
+
   def hasProblems: Boolean =
     this match {
       case Result.Warning(_, _) => true

--- a/modules/sql/shared/src/main/scala/SqlMapping.scala
+++ b/modules/sql/shared/src/main/scala/SqlMapping.scala
@@ -3557,7 +3557,13 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
             Result.failure(s"No field '$fieldName' for type ${context.tpe}")
         }
 
-      localField orElse mkCursorForField(this, fieldName, resultName)
+      // Fall back to the general implementation if it's a logic failure, 
+      // but retain success and internal errors.
+      if (localField.isFailure) 
+        mkCursorForField(this, fieldName, resultName) 
+      else
+        localField
+
     }
   }
 


### PR DESCRIPTION
We ran into an issue where an internal error in `SqlCursor.field` "expected exactly one row (or something like that)" was masked by `orElse` selecting the generic `mkCursorForField`, which then failed with "Unhandled mapping of type grackle.sql.SqlMappingLike$SqlField", which is misleading. This PR fixes the specific issue, but I think in general we may want a combinator like `r1 onFailure r2` that only selects `r2` in the case of logical failure, preserving `r1` as-is in case of `InternalError`.