### PR TITLE
make effect elaborator respect predicated mappings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ ThisBuild / scalaVersion        := Scala2
 ThisBuild / crossScalaVersions  := Seq(Scala2, Scala3)
 ThisBuild / tlJdkRelease        := Some(11)
 
-ThisBuild / tlBaseVersion    := "0.20"
+ThisBuild / tlBaseVersion    := "0.21"
 ThisBuild / startYear        := Some(2019)
 ThisBuild / licenses         := Seq(License.Apache2)
 ThisBuild / developers       := List(

--- a/modules/core/src/main/scala/mapping.scala
+++ b/modules/core/src/main/scala/mapping.scala
@@ -1188,19 +1188,12 @@ abstract class Mapping[F[_]] {
     ComponentElaborator(componentMappings)
   }
 
-  lazy val effectElaborator = {
-    val effectMappings =
-      typeMappings.mappings.flatMap {
-        case om: ObjectMapping =>
-          om.fieldMappings.collect {
-            case EffectField(fieldName, handler, _, _) =>
-              EffectElaborator.EffectMapping(schema.uncheckedRef(om.tpe), fieldName, handler)
-          }
-        case _ => Seq.empty
+  lazy val effectElaborator: EffectElaborator[F] =
+    EffectElaborator { (ctx, fieldName) =>
+      typeMappings.fieldMapping(ctx, fieldName).collect {
+        case e: EffectField => e.handler
       }
-
-    EffectElaborator(effectMappings)
-  }
+    }
 
   def compilerPhases: List[QueryCompiler.Phase] = List(selectElaborator, componentElaborator, effectElaborator)
 


### PR DESCRIPTION
This changes `EffectElaborator` to accept an arbitrary function that maps context+field to effect handler, allowing users to delegate to `typeMappings.fieldMapping` (which understands predicated mappings).