### PR TITLE
allow fetch to fail cleanly

### DIFF
--- a/modules/doobie-core/src/main/scala/DoobieMapping.scala
+++ b/modules/doobie-core/src/main/scala/DoobieMapping.scala
@@ -147,7 +147,7 @@ trait DoobieMappingLike[F[_]] extends Mapping[F] with SqlMappingLike[F] {
       }
     }
 
-  def fetch(fragment: Fragment, codecs: List[(Boolean, Codec)]): F[Vector[Array[Any]]] = {
+  def fetch(fragment: Fragment, codecs: List[(Boolean, Codec)]): F[Result[Vector[Array[Any]]]] = {
     import cats.syntax.all._
     
     val reads: Array[Read[Any]] = codecs.toArray.map {
@@ -161,6 +161,6 @@ trait DoobieMappingLike[F[_]] extends Mapping[F] with SqlMappingLike[F] {
     }
     
     implicit val read: Read[Array[Any]] = new Read.CompositeOfInstances[Any](reads)
-    fragment.query[Array[Any]].to[Vector].transact(transactor)
+    fragment.query[Array[Any]].to[Vector].transact(transactor).map(Result.success)
   }
 }

--- a/modules/sql-core/src/main/scala/SqlMapping.scala
+++ b/modules/sql-core/src/main/scala/SqlMapping.scala
@@ -3308,7 +3308,7 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
       def fetch: F[Result[Table]] = {
         (for {
           frag <- ResultT(fragment.pure[F])
-          rows <- ResultT(self.fetch(frag, query.codecs).map(_.success))
+          rows <- ResultT(self.fetch(frag, query.codecs))
         } yield Table(rows)).value
       }
 

--- a/modules/sql-core/src/main/scala/SqlModule.scala
+++ b/modules/sql-core/src/main/scala/SqlModule.scala
@@ -77,5 +77,5 @@ trait SqlModule[F[_]] {
 
   def intCodec: Codec
 
-  def fetch(fragment: Fragment, codecs: List[(Boolean, Codec)]): F[Vector[Array[Any]]]
+  def fetch(fragment: Fragment, codecs: List[(Boolean, Codec)]): F[Result[Vector[Array[Any]]]]
 }


### PR DESCRIPTION
This changes `SqlModule.fetch` to yield a `Result`, which allows `fetch` to fail with cleanly (we are overriding `fetch` to fail on excessively large rowsets and prefer not to use an exception for this).

This also pulls out `rowDecoder` in `SkunkMapping` to allow access by overridden `fetch` implementations.