### PR TITLE
fix: avoid BigDecimal.equals exception cost in FailedJoin/Table checks

### DIFF
--- a/modules/sql-core/src/main/scala/FailedJoin.scala
+++ b/modules/sql-core/src/main/scala/FailedJoin.scala
@@ -16,6 +16,18 @@
 package grackle.sql
 
 /**
- * A sentinal value representing the empty column values from a failed join.
+ * A sentinel value representing the empty column values from a failed join.
  */
-case object FailedJoin
+case object FailedJoin {
+
+  /**
+   * Cheap equality check for the `FailedJoin` sentinel.
+   *
+   * Column values are `Any` and may be a `scala.math.BigDecimal`, whose `equals` throws and
+   * catches an `ArithmeticException` whenever compared to a value of another type (see
+   * `BigDecimal.isValidLong`). `a == b` calls `a.equals(b)`, so keeping `FailedJoin` on the
+   * left runs the singleton's own cheap `equals` instead of the column value's -- do not swap
+   * the operands here.
+   */
+  def isFailedJoin(v: Any): Boolean = FailedJoin == v
+}

--- a/modules/sql-core/src/main/scala/SqlMapping.scala
+++ b/modules/sql-core/src/main/scala/SqlMapping.scala
@@ -31,6 +31,7 @@ import grackle.Predicate._
 import grackle.Query._
 import grackle.ValidationFailure.Severity
 import grackle.circe.CirceMappingLike
+import grackle.sql.FailedJoin.isFailedJoin
 import grackle.syntax._
 
 abstract class SqlMapping[F[_]](implicit val M: MonadThrow[F])
@@ -4267,6 +4268,10 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
   }
 
   object Table {
+    // Same rationale as `FailedJoin.isFailedJoin`: keeps `None` on the left of `==` so its
+    // cheap equals runs instead of a possibly-`BigDecimal` column value's.
+    private def isNone(v: Any): Boolean = None == v
+
     def apply(rows: Vector[Array[Any]]): Table = {
       if (rows.sizeCompare(1) == 0) OneRowTable(rows.head)
       else if (rows.isEmpty) EmptyTable
@@ -4304,7 +4309,7 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
 
       def definesAll(cols: List[Int]): Boolean = {
         val cs = cols
-        cs.forall(c => row(c) != FailedJoin)
+        cs.forall(c => !isFailedJoin(row(c)))
       }
 
       def group(cols: List[Int]): Iterator[Table] = {
@@ -4337,10 +4342,10 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
         while (ir.hasNext) {
           ir.next()(c) match {
             case FailedJoin =>
-            case v if value == FailedJoin => value = v
+            case v if isFailedJoin(value) => value = v
             case v if value == v =>
             case None =>
-            case v @ Some(_) if value == None => value = v
+            case v @ Some(_) if isNone(value) => value = v
             case _ => return None
           }
         }
@@ -4349,12 +4354,12 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
 
       def filterDefined(cols: List[Int]): Table = {
         val cs = cols
-        Table(rows.filter(r => cs.forall(c => r(c) != FailedJoin)))
+        Table(rows.filter(r => cs.forall(c => !isFailedJoin(r(c)))))
       }
 
       def definesAll(cols: List[Int]): Boolean = {
         val cs = cols
-        rows.exists(r => cs.forall(c => r(c) != FailedJoin))
+        rows.exists(r => cs.forall(c => !isFailedJoin(r(c))))
       }
 
       def group(cols: List[Int]): Iterator[Table] = {
@@ -4369,7 +4374,7 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
                 case cs => row => cs.map(c => row(c))
               }
 
-            val nonNull = rows.filter(r => cs.forall(c => r(c) != FailedJoin))
+            val nonNull = rows.filter(r => cs.forall(c => !isFailedJoin(r(c))))
             val grouped = nonNull.groupBy(discrim)
             grouped.iterator.map { case (_, rows) => Table(rows) }
         }
@@ -4387,7 +4392,7 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
                 case cs => row => cs.map(c => row(c))
               }
 
-            val nonNull = rows.filter(r => cs.forall(c => r(c) != FailedJoin))
+            val nonNull = rows.filter(r => cs.forall(c => !isFailedJoin(r(c))))
             nonNull.map(discrim).distinct.size
         }
       }
@@ -4532,7 +4537,7 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
                   case Some(f) if tpe.variantField(fieldName) && !fieldTpe.isNullable => f
                   case other => other
                 }
-                assert(leafFocus != FailedJoin)
+                assert(!isFailedJoin(leafFocus))
                 LeafCursor(fieldContext, leafFocus, Some(np), Env.empty)
               })
 


### PR DESCRIPTION
Fixes #884.

Fun fact: This is a `scala.math.BigDecimal`-specific problem, not a JVM one. `java.math.BigDecimal.equals` doesn't do this, only Scala's wrapper does.

## Fix

Swapped the `FailedJoin`/`None` sentinel checks in `Table.select`/`definesAll`/`filterDefined`/`group`/`count` and the `SqlCursor.field` assert for reference-equality checks instead (`FailedJoin.isFailedJoin`, `Table.isNone`, both just `v.asInstanceOf[AnyRef] eq <sentinel>`). Should be exact since both `FailedJoin` and `None` are singletons, and it means `BigDecimal`'s overridden `equals` never gets called for these checks. Went through each changed line by hand to make sure nothing's behaving differently.

An alternative fix would be to use a BigDecimal-specific type check (`case _: BigDecimal => eq check; case _ => ==`). One might argue that, after all, this is just a workaround for a specific Scala limitation in `BigDecimal`.
Or one might argue that in the end it all boils down to reference equality anyway since we are comparing sentinel values. Treating it as such also makes the check more robust. The next weird `equals` of a mapped column will no longer impact performance in this way. Also, there is a minor performance aspect to this: Making this into a BigDecimal-workaround would introduce additional type checks at runtime (and while fast, they would run often).
So, I went with the universal reference equality + a comment explaining where it all started.

I also didn't limit the fix to `SqlCursor.field`'s assert, even though that's the one that showed up in the profiler. `Table.select`/`definesAll`/`filterDefined`/`group`/`count` all had the exact same pattern, all on the same row-assembly hot path, and this is shared core code used by every SQL backend (Postgres, MySQL, MSSQL, H2, ...). Scoping the fix to just the one line the profiler happened to flag would've left the rest of the bug in place.

I used async-profiler to discover the issue and to verify it was gone after applying the fix. As the test data set, I used Microsoft's AdventureWorks data set. This was all found as part of a benchmark I am writing, and the data set was chosen specifically for that benchmark. To avoid relying solely on the profiler output, I also added instrumentation (I might file that as a separate PR if that seems useful), which reliably showed that the "un-flattening", or row-assembly, phase dropped by about 50%, from ~900ms down to ~450ms.