### PR TITLE
Raise munit timeout for database-backed test suites

### DIFF
--- a/modules/doobie-core/src/test/scala/DoobieDatabaseSuite.scala
+++ b/modules/doobie-core/src/test/scala/DoobieDatabaseSuite.scala
@@ -18,13 +18,12 @@ package grackle.doobie.test
 import java.time.Duration
 
 import io.circe.{Decoder => CDecoder, Encoder => CEncoder}
-import munit.CatsEffectSuite
 import org.typelevel.doobie.Meta
 
 import grackle.doobie.DoobieMappingLike
 import grackle.sql.test._
 
-trait DoobieDatabaseSuite extends CatsEffectSuite {
+trait DoobieDatabaseSuite extends SqlDatabaseSuite {
   trait DoobieTestMapping[F[_]] extends DoobieMappingLike[F] with SqlTestMapping[F] {
 
     type TestCodec[T] = (Meta[T], Boolean)

--- a/modules/sql-core/src/test/scala/SqlDatabaseSuite.scala
+++ b/modules/sql-core/src/test/scala/SqlDatabaseSuite.scala
@@ -13,23 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package grackle.sqlpg.test
+package grackle.sql.test
 
-import grackle.sql.test.SqlDatabaseSuite
+import scala.concurrent.duration._
 
-trait SqlPgDatabaseSuite extends SqlDatabaseSuite {
-  case class PostgresConnectionInfo(host: String, port: Int) {
+import munit.CatsEffectSuite
 
-    val driverClassName = "org.postgresql.Driver"
-    val databaseName = "test"
-    val jdbcUrl = s"jdbc:postgresql://$host:$port/$databaseName"
-    val username = "test"
-    val password = "test"
-  }
-  object PostgresConnectionInfo {
-    val DefaultPort = 5432
-  }
-
-  val postgresConnectionInfo: PostgresConnectionInfo =
-    PostgresConnectionInfo("localhost", PostgresConnectionInfo.DefaultPort)
+/**
+ * Common base for the per-backend database suite traits, raising munit-cats-effect's 30s
+ * default timeout: database-backed tests can exceed it for reasons that have nothing to do with
+ * the test itself, e.g. several forked backend test JVMs contending for one docker daemon on a
+ * constrained machine, showing up as spurious timeouts rather than failures.
+ */
+trait SqlDatabaseSuite extends CatsEffectSuite {
+  override def munitIOTimeout: Duration = 2.minutes
 }


### PR DESCRIPTION
munit-cats-effect times a test out after 30 seconds, which isn't much headroom for the database-backed suites on a constrained machine. sbt runs each backend's tests in its own forked JVM and several of those contend for a single docker daemon, so a test can exceed 30s for reasons that have nothing to do with what it asserts. It surfaces as a `TimeoutException` in whichever suite happens to run first after the containers come up. I've seen it on `Embedding2Suite.paging`, `Paging3Suite.paging (initial)` and skunk's `TreeSuite.root query`, each of which passes on a rerun of the identical commit.

This raises the timeout to two minutes for the backend suites. It's a single shared `SqlDatabaseSuite` base in sql-core's test scope rather than an override on each of the per-backend traits, because `DoobiePgDatabaseSuite` mixes in both `DoobieDatabaseSuite` and `SqlPgDatabaseSuite` and two separate overrides of `munitIOTimeout` would conflict.

The commit has been riding along in my four open backend PRs (#864, #866, #872, #873), which each carry a copy of it. It stands on its own and is useful to anyone running the suites locally, so it seemed better raised separately; those PRs can drop their copy at their next rebase.
