### PR TITLE
Don't drop rows for a non-null field under a nullable parent

### DIFF
--- a/modules/doobie-mssql/src/test/scala/DoobieMSSqlSuites.scala
+++ b/modules/doobie-mssql/src/test/scala/DoobieMSSqlSuites.scala
@@ -191,6 +191,10 @@ final class NestedEffectsSuite extends DoobieMSSqlDatabaseSuite with SqlNestedEf
     }
 }
 
+final class NullableParentSuite extends DoobieMSSqlDatabaseSuite with SqlNullableParentSuite {
+  lazy val mapping = new DoobieMSSqlTestMapping(transactor) with SqlNullableParentMapping[IO]
+}
+
 final class NullOrderingSuite extends DoobieMSSqlDatabaseSuite with SqlNullOrderingSuite {
   lazy val mapping = new DoobieMSSqlTestMapping(transactor) with SqlNullOrderingMapping[IO]
 }

--- a/modules/doobie-oracle/src/test/scala/DoobieOracleSuites.scala
+++ b/modules/doobie-oracle/src/test/scala/DoobieOracleSuites.scala
@@ -197,6 +197,10 @@ final class NestedEffectsSuite extends DoobieOracleDatabaseSuite with SqlNestedE
     }
 }
 
+final class NullableParentSuite extends DoobieOracleDatabaseSuite with SqlNullableParentSuite {
+  lazy val mapping = new DoobieOracleTestMapping(transactor) with SqlNullableParentMapping[IO]
+}
+
 final class NullOrderingSuite extends DoobieOracleDatabaseSuite with SqlNullOrderingSuite {
   lazy val mapping = new DoobieOracleTestMapping(transactor) with SqlNullOrderingMapping[IO]
 }

--- a/modules/doobie-pg/src/test/scala/DoobiePgSuites.scala
+++ b/modules/doobie-pg/src/test/scala/DoobiePgSuites.scala
@@ -193,6 +193,10 @@ final class NestedEffectsSuite extends DoobiePgDatabaseSuite with SqlNestedEffec
     }
 }
 
+final class NullableParentSuite extends DoobiePgDatabaseSuite with SqlNullableParentSuite {
+  lazy val mapping = new DoobiePgTestMapping(transactor) with SqlNullableParentMapping[IO]
+}
+
 final class NullOrderingSuite extends DoobiePgDatabaseSuite with SqlNullOrderingSuite {
   lazy val mapping = new DoobiePgTestMapping(transactor) with SqlNullOrderingMapping[IO]
 }

--- a/modules/skunk/js-jvm/src/test/scala/SkunkSuites.scala
+++ b/modules/skunk/js-jvm/src/test/scala/SkunkSuites.scala
@@ -198,6 +198,10 @@ final class NestedEffectsSuite extends SkunkDatabaseSuite with SqlNestedEffectsS
     }
 }
 
+final class NullableParentSuite extends SkunkDatabaseSuite with SqlNullableParentSuite {
+  lazy val mapping = new SkunkTestMapping(pool) with SqlNullableParentMapping[IO]
+}
+
 final class NullOrderingSuite extends SkunkDatabaseSuite with SqlNullOrderingSuite {
   lazy val mapping = new SkunkTestMapping(pool) with SqlNullOrderingMapping[IO]
 }

--- a/modules/sql-core/src/main/scala/SqlMapping.scala
+++ b/modules/sql-core/src/main/scala/SqlMapping.scala
@@ -1442,7 +1442,19 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
     trait Laterality {
       def toFragment: Fragment
       def joinToFragment(join: SqlJoin, subquery: SubqueryRef): Aliased[Fragment]
-      def joinPredicates(join: SqlJoin): List[Predicate]
+
+      /**
+       * Distribute the conditions of `join` between the join itself and the enclosing select.
+       *
+       * Yields a possibly rewritten join, together with the predicates which must be added to
+       * the enclosing select's WHERE clause for the join to have its intended semantics.
+       *
+       * Lateralities which render the join with an `ON` clause need neither, and so yield the
+       * join unchanged and no predicates.
+       */
+      def distributeJoinConditions(
+          join: SqlJoin,
+          subquery: SubqueryRef): (SqlJoin, List[Predicate])
     }
     object Laterality {
       def apply(lateral: Boolean, inner: Boolean): Laterality =
@@ -1452,21 +1464,94 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
         def toFragment: Fragment = Fragments.empty
         def joinToFragment(join: SqlJoin, subquery: SubqueryRef): Aliased[Fragment] =
           join.toFragmentWithoutLaterality
-        def joinPredicates(join: SqlJoin): List[Predicate] = Nil
+        def distributeJoinConditions(
+            join: SqlJoin,
+            subquery: SubqueryRef): (SqlJoin, List[Predicate]) = (join, Nil)
       }
       case object Lateral extends Laterality {
         def toFragment: Fragment = Fragments.const("LATERAL ")
         def joinToFragment(join: SqlJoin, subquery: SubqueryRef): Aliased[Fragment] =
           join.toFragmentWithoutLaterality
-        def joinPredicates(join: SqlJoin): List[Predicate] = Nil
+        def distributeJoinConditions(
+            join: SqlJoin,
+            subquery: SubqueryRef): (SqlJoin, List[Predicate]) = (join, Nil)
       }
       case class Apply(inner: Boolean) extends Laterality {
         def toFragment: Fragment =
           Fragments.const(if (inner) "CROSS " else "OUTER ") |+| Fragments.const("APPLY ")
         def joinToFragment(join: SqlJoin, subquery: SubqueryRef): Aliased[Fragment] =
           subquery.toDefFragment
-        def joinPredicates(join: SqlJoin): List[Predicate] =
+
+        /**
+         * An `APPLY` join is rendered without an `ON` clause, so its conditions have to be
+         * expressed elsewhere.
+         *
+         * For `CROSS APPLY` they are lifted into the enclosing select's WHERE clause, which for
+         * an inner join is equivalent to an `ON` clause.
+         *
+         * For `OUTER APPLY` that would be wrong: the WHERE clause is applied after the join and
+         * would discard precisely the null padded rows the outer join produced. Instead the
+         * subquery is wrapped in a correlating select which applies the conditions to its
+         * result, referring to the enclosing select's tables. That is legal because `APPLY` is
+         * lateral, and is what makes `OUTER APPLY` equivalent to `LEFT JOIN LATERAL`.
+         *
+         * Only a subquery of the right shape can be correlated, and the conditions are lifted
+         * as a last resort otherwise. For an `OUTER APPLY` that reinstates the semantics
+         * described above, so it has to stay unreachable: the shapes `correlate` declines are
+         * those `addFilterOrderByOffsetLimit` builds, and those join on a predicate, which is
+         * short circuited before it.
+         */
+        def distributeJoinConditions(
+            join: SqlJoin,
+            subquery: SubqueryRef): (SqlJoin, List[Predicate]) =
+          if (inner || join.isPredicate) (join, liftedPredicates(join))
+          else
+            correlate(join, subquery).fold((join, liftedPredicates(join)))(join0 =>
+              (join0, Nil))
+
+        /**
+         * The join's conditions expressed as predicates of the enclosing select.
+         */
+        private def liftedPredicates(join: SqlJoin): List[Predicate] =
           if (!join.isPredicate) join.on.map { case (p, c) => Eql(p.toTerm, c.toTerm) } else Nil
+
+        /**
+         * Yields a copy of `join` with its conditions moved inside its subquery.
+         *
+         * The subquery is wrapped in a select which applies the conditions to the subquery's
+         * result, so that any LIMIT, OFFSET, DISTINCT or window function in the subquery is
+         * evaluated first, exactly as it would be were the conditions in the ON clause of a
+         * `LEFT JOIN LATERAL`. Wrapping also ensures that only the subquery's exposed columns
+         * are in scope where the conditions are applied, so that a table of the enclosing
+         * select can't be shadowed by a same named table within the subquery.
+         *
+         * The subquery side of each condition names a column exposed by the subquery, which has
+         * to be mapped to the corresponding column of the wrapper. Yields `None` if that isn't
+         * possible, in which case the caller falls back to lifting the conditions into the
+         * enclosing select.
+         */
+        private def correlate(join: SqlJoin, subquery: SubqueryRef): Option[SqlJoin] =
+          subquery.subquery match {
+            case sel: SqlSelect if sel.withs.isEmpty =>
+              sel.table match {
+                case table: TableRef =>
+                  val exposed =
+                    join.on.traverse {
+                      case (p, c) => sel.cols.find(_ == c.subst(subquery, table)).map((p, _))
+                    }
+                  exposed.map { exposed0 =>
+                    val wrapper =
+                      sel.toSubquery(subquery.name + "_corr", NotLateral, correlated = true)
+                    val wheres =
+                      exposed0.map {
+                        case (p, c) => Eql(p.toTerm, c.derive(wrapper.table).toTerm)
+                      }
+                    join.copy(child = subquery.copy(subquery = wrapper.copy(wheres = wheres)))
+                  }
+                case _ => None
+              }
+            case _ => None
+          }
       }
     }
 
@@ -1477,7 +1562,8 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
         context: Context,
         name: String,
         subquery: SqlQuery,
-        laterality: Laterality)
+        laterality: Laterality,
+        correlated: Boolean = false)
         extends TableExpr {
       def owns(col: SqlColumn): Boolean = col.owner.isSameOwner(this) || subquery.owns(col)
       def contains(other: ColumnOwner): Boolean = isSameOwner(other) || subquery.contains(other)
@@ -2484,22 +2570,23 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
                 cols: List[SqlColumn],
                 wheres: List[Predicate],
                 joins: List[SqlJoin]): SqlSelect = {
-              val extraWheres =
-                if (!outer) Nil
-                else
-                  joins.flatMap { join =>
-                    join.child match {
-                      case sq: SubqueryRef => sq.laterality.joinPredicates(join)
-                      case _ => Nil
-                    }
+              val distributed =
+                joins.map { join =>
+                  join.child match {
+                    case sq: SubqueryRef if outer =>
+                      sq.laterality.distributeJoinConditions(join, sq)
+                    case _ => (join, Nil)
                   }
+                }
+              val joins0 = distributed.map(_._1)
+              val extraWheres = distributed.flatMap(_._2)
 
               SqlSelect(
                 context = parentContext,
                 withs = withs,
                 table = table,
                 cols = cols,
-                joins = joins,
+                joins = joins0,
                 wheres = wheres ++ extraWheres,
                 orders = Nil,
                 offset = None,
@@ -2534,6 +2621,10 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
                   true)
                 val assocJoin = lastJoin.toSqlJoin(lastJoinParentTable, assocTable, inner)
 
+                // This join is on the key between a table and itself, so it always matches and
+                // an outer join is as good as an inner one. `assocJoin` carries the join's real
+                // innerness, and it's that which decides how a subquery beneath it distributes
+                // its conditions.
                 val finalJoin =
                   SqlJoin(
                     assocTable,
@@ -3219,8 +3310,11 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
       def toSubquery(name: String): Result[SqlSelect] =
         toSubquery(name, Laterality.NotLateral).success
 
-      def toSubquery(name: String, lateral: Laterality): SqlSelect = {
-        val ref = SubqueryRef(context, name, this, lateral)
+      def toSubquery(
+          name: String,
+          lateral: Laterality,
+          correlated: Boolean = false): SqlSelect = {
+        val ref = SubqueryRef(context, name, this, lateral, correlated)
         SqlSelect(
           context,
           Nil,
@@ -3241,7 +3335,7 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
        */
       def subqueryToWithQuery: SqlSelect = {
         table match {
-          case SubqueryRef(_, name, sq, _) =>
+          case SubqueryRef(_, name, sq, _, _) =>
             // A common table expression name is rendered verbatim rather than through the
             // alias machinery, so it has to be folded here (issue #342). The derived table
             // keeps the unfolded name, which carries the subquery's identity.
@@ -3549,7 +3643,7 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
        */
       def isPredicate: Boolean =
         child match {
-          case SubqueryRef(_, _, sq: SqlSelect, _) => sq.predicate
+          case SubqueryRef(_, _, sq: SqlSelect, _, _) => sq.predicate
           case _ => false
         }
 

--- a/modules/sql-core/src/main/scala/SqlMapping.scala
+++ b/modules/sql-core/src/main/scala/SqlMapping.scala
@@ -2689,7 +2689,10 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
                 )
 
               case Some(SqlObject(_, joins)) =>
-                mkJoins(joins).success
+                // `mkJoins` can throw: an OUTER APPLY which declines to correlate is a bug, and
+                // `distributeJoinConditions` raises rather than render incorrect SQL. Lift that into
+                // the Result channel here rather than let it escape `nest`.
+                Result.catchNonFatal(mkJoins(joins))
 
               case _ =>
                 Result.internalError(

--- a/modules/sql-core/src/main/scala/SqlMapping.scala
+++ b/modules/sql-core/src/main/scala/SqlMapping.scala
@@ -1489,8 +1489,8 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
          * inner join. `OUTER APPLY` can't: WHERE applies after the join and would discard its
          * null-padded rows. Its subquery is instead wrapped in a correlating select, legal
          * because `APPLY` is lateral — which is what makes `OUTER APPLY` equivalent to a
-         * `LEFT JOIN LATERAL`. A subquery that can't be correlated has no correct rendering,
-         * so a decline is a bug.
+         * `LEFT JOIN LATERAL`. A subquery that can't be correlated has no correct rendering, so
+         * a decline is a bug.
          */
         def distributeJoinConditions(
             join: SqlJoin,

--- a/modules/sql-core/src/main/scala/SqlMapping.scala
+++ b/modules/sql-core/src/main/scala/SqlMapping.scala
@@ -1483,31 +1483,25 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
           subquery.toDefFragment
 
         /**
-         * An `APPLY` join is rendered without an `ON` clause, so its conditions have to be
-         * expressed elsewhere.
+         * Distributes an `APPLY` join's conditions, which it renders without an `ON` clause.
          *
-         * For `CROSS APPLY` they are lifted into the enclosing select's WHERE clause, which for
-         * an inner join is equivalent to an `ON` clause.
-         *
-         * For `OUTER APPLY` that would be wrong: the WHERE clause is applied after the join and
-         * would discard precisely the null padded rows the outer join produced. Instead the
-         * subquery is wrapped in a correlating select which applies the conditions to its
-         * result, referring to the enclosing select's tables. That is legal because `APPLY` is
-         * lateral, and is what makes `OUTER APPLY` equivalent to `LEFT JOIN LATERAL`.
-         *
-         * Only a subquery of the right shape can be correlated, and the conditions are lifted
-         * as a last resort otherwise. For an `OUTER APPLY` that reinstates the semantics
-         * described above, so it has to stay unreachable: the shapes `correlate` declines are
-         * those `addFilterOrderByOffsetLimit` builds, and those join on a predicate, which is
-         * short circuited before it.
+         * `CROSS APPLY` lifts them into the enclosing WHERE, an `ON` clause's equivalent for an
+         * inner join. `OUTER APPLY` can't: WHERE applies after the join and would discard its
+         * null-padded rows. Its subquery is instead wrapped in a correlating select, legal
+         * because `APPLY` is lateral — which is what makes `OUTER APPLY` equivalent to a
+         * `LEFT JOIN LATERAL`. A subquery that can't be correlated has no correct rendering,
+         * so a decline is a bug.
          */
         def distributeJoinConditions(
             join: SqlJoin,
             subquery: SubqueryRef): (SqlJoin, List[Predicate]) =
           if (inner || join.isPredicate) (join, liftedPredicates(join))
           else
-            correlate(join, subquery).fold((join, liftedPredicates(join)))(join0 =>
-              (join0, Nil))
+            // Every OUTER APPLY reachable here can be correlated; a None is a bug, not a query.
+            correlate(join, subquery)
+              .map((_, Nil))
+              .getOrElse(throw new SqlMappingException(
+                s"OUTER APPLY subquery '${subquery.name}' could not be correlated"))
 
         /**
          * The join's conditions expressed as predicates of the enclosing select.
@@ -1518,22 +1512,20 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
         /**
          * Yields a copy of `join` with its conditions moved inside its subquery.
          *
-         * The subquery is wrapped in a select which applies the conditions to the subquery's
-         * result, so that any LIMIT, OFFSET, DISTINCT or window function in the subquery is
-         * evaluated first, exactly as it would be were the conditions in the ON clause of a
-         * `LEFT JOIN LATERAL`. Wrapping also ensures that only the subquery's exposed columns
-         * are in scope where the conditions are applied, so that a table of the enclosing
-         * select can't be shadowed by a same named table within the subquery.
+         * The subquery is wrapped in a select so any LIMIT, OFFSET or DISTINCT is evaluated
+         * first — as under a `LEFT JOIN LATERAL` ON clause — and so only the subquery's exposed
+         * columns are in scope, not a same-named table of the enclosing select.
          *
-         * The subquery side of each condition names a column exposed by the subquery, which has
-         * to be mapped to the corresponding column of the wrapper. Yields `None` if that isn't
-         * possible, in which case the caller falls back to lifting the conditions into the
-         * enclosing select.
+         * `None` means a subquery shape it doesn't handle; no `OUTER APPLY` produces one, so
+         * the caller treats it as a bug rather than lifting. An existing wrapper is returned
+         * unchanged, so re-nesting won't correlate it twice.
          */
         private def correlate(join: SqlJoin, subquery: SubqueryRef): Option[SqlJoin] =
           subquery.subquery match {
             case sel: SqlSelect if sel.withs.isEmpty =>
               sel.table match {
+                case wrapped: SubqueryRef if wrapped.correlated && sel.wheres.nonEmpty =>
+                  Some(join)
                 case table: TableRef =>
                   val exposed =
                     join.on.traverse {
@@ -1541,7 +1533,7 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
                     }
                   exposed.map { exposed0 =>
                     val wrapper =
-                      sel.toSubquery(subquery.name + "_corr", NotLateral, correlated = true)
+                      sel.toSubquery(correlationName(subquery), NotLateral, correlated = true)
                     val wheres =
                       exposed0.map {
                         case (p, c) => Eql(p.toTerm, c.derive(wrapper.table).toTerm)
@@ -1552,6 +1544,12 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
               }
             case _ => None
           }
+
+        /**
+         * The alias given to the correlating select `correlate` wraps around `subquery`. Only
+         * cosmetic: the wrapper is recognised by its `correlated` flag, not by this name.
+         */
+        private def correlationName(subquery: SubqueryRef): String = subquery.name + "_corr"
       }
     }
 

--- a/modules/sql-core/src/main/scala/SqlMapping.scala
+++ b/modules/sql-core/src/main/scala/SqlMapping.scala
@@ -2446,11 +2446,13 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
                 joinCols: List[SqlColumn],
                 suffix: String): SqlSelect = {
               def isMergeable: Boolean =
-                !multiTable && !nested.joins.exists(_.isPredicate) && nested
-                  .wheres
-                  .isEmpty && nested.orders.isEmpty && nested.offset.isEmpty && nested
-                  .limit
-                  .isEmpty && !nested.isDistinct
+                !multiTable &&
+                  !nested.joins.exists(_.isPredicate) &&
+                  nested.wheres.isEmpty &&
+                  nested.orders.isEmpty &&
+                  nested.offset.isEmpty &&
+                  nested.limit.isEmpty &&
+                  !nested.isDistinct
 
               if (isMergeable) nested
               else {

--- a/modules/sql-core/src/main/scala/SqlMapping.scala
+++ b/modules/sql-core/src/main/scala/SqlMapping.scala
@@ -2439,6 +2439,15 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
         parentTableForType(parentContext).flatMap { parentTable =>
           val inner = !context.tpe.isNullable && !context.tpe.isList
 
+          // Flattening moves the nested select's joins below the join that attaches it. If that
+          // join is LEFT and unmatched it yields a NULL-padded row an INNER join below would
+          // discard, losing a row that should return with the field null or empty. Every join
+          // in `nested.joins` is rooted at that select's table, so all land below the attaching
+          // join and see its padding, directly or transitively — safe, then, only if this join
+          // is INNER or the nested select has no INNER joins.
+          def mergePreservesRows(nested: SqlSelect): Boolean =
+            inner || !nested.joins.exists(_.inner)
+
           def mkJoins(joins: List[Join]): SqlSelect = {
             def mkSubquery(
                 multiTable: Boolean,
@@ -2446,7 +2455,8 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
                 joinCols: List[SqlColumn],
                 suffix: String): SqlSelect = {
               def isMergeable: Boolean =
-                !multiTable &&
+                mergePreservesRows(nested) &&
+                  !multiTable &&
                   !nested.joins.exists(_.isPredicate) &&
                   nested.wheres.isEmpty &&
                   nested.orders.isEmpty &&

--- a/modules/sql-core/src/test/scala/SqlNullableParentMapping.scala
+++ b/modules/sql-core/src/test/scala/SqlNullableParentMapping.scala
@@ -1,0 +1,84 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2025 Grackle Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grackle.sql.test
+
+import grackle.syntax._
+
+trait SqlNullableParentMapping[F[_]] extends SqlTestMapping[F] {
+
+  object aTable extends TableDef("nullable_parent_a") {
+    val id = col("id", int4)
+    val bId = col("b_id", nullable(int4))
+    val name = col("name", text)
+  }
+
+  object bTable extends TableDef("nullable_parent_b") {
+    val id = col("id", int4)
+    val cId = col("c_id", int4)
+    val name = col("name", text)
+  }
+
+  object cTable extends TableDef("nullable_parent_c") {
+    val id = col("id", int4)
+    val name = col("name", text)
+  }
+
+  val schema =
+    schema"""
+      type Query {
+        as: [A!]!
+      }
+      type A {
+        name: String!
+        b: B
+      }
+      type B {
+        name: String!
+        c: C!
+      }
+      type C {
+        name: String!
+      }
+    """
+
+  val QueryType = schema.ref("Query")
+  val AType = schema.ref("A")
+  val BType = schema.ref("B")
+  val CType = schema.ref("C")
+
+  val typeMappings =
+    TypeMappings(
+      ObjectMapping(QueryType)(
+        SqlObject("as")
+      ),
+      ObjectMapping(AType)(
+        SqlField("id", aTable.id, key = true, hidden = true),
+        SqlField("bId", aTable.bId, hidden = true),
+        SqlField("name", aTable.name),
+        SqlObject("b", Join(aTable.bId, bTable.id))
+      ),
+      ObjectMapping(BType)(
+        SqlField("id", bTable.id, key = true, hidden = true),
+        SqlField("cId", bTable.cId, hidden = true),
+        SqlField("name", bTable.name),
+        SqlObject("c", Join(bTable.cId, cTable.id))
+      ),
+      ObjectMapping(CType)(
+        SqlField("id", cTable.id, key = true, hidden = true),
+        SqlField("name", cTable.name)
+      )
+    )
+}

--- a/modules/sql-core/src/test/scala/SqlNullableParentMapping.scala
+++ b/modules/sql-core/src/test/scala/SqlNullableParentMapping.scala
@@ -36,10 +36,28 @@ trait SqlNullableParentMapping[F[_]] extends SqlTestMapping[F] {
     val name = col("name", text)
   }
 
+  object dTable extends TableDef("nullable_parent_d") {
+    val id = col("id", int4)
+    val name = col("name", text)
+  }
+
+  object eTable extends TableDef("nullable_parent_e") {
+    val id = col("id", int4)
+    val dId = col("d_id", int4)
+    val fId = col("f_id", int4)
+    val name = col("name", text)
+  }
+
+  object fTable extends TableDef("nullable_parent_f") {
+    val id = col("id", int4)
+    val name = col("name", text)
+  }
+
   val schema =
     schema"""
       type Query {
         as: [A!]!
+        ds: [D!]!
       }
       type A {
         name: String!
@@ -52,17 +70,32 @@ trait SqlNullableParentMapping[F[_]] extends SqlTestMapping[F] {
       type C {
         name: String!
       }
+      type D {
+        name: String!
+        es: [E!]!
+      }
+      type E {
+        name: String!
+        f: F!
+      }
+      type F {
+        name: String!
+      }
     """
 
   val QueryType = schema.ref("Query")
   val AType = schema.ref("A")
   val BType = schema.ref("B")
   val CType = schema.ref("C")
+  val DType = schema.ref("D")
+  val EType = schema.ref("E")
+  val FType = schema.ref("F")
 
   val typeMappings =
     TypeMappings(
       ObjectMapping(QueryType)(
-        SqlObject("as")
+        SqlObject("as"),
+        SqlObject("ds")
       ),
       ObjectMapping(AType)(
         SqlField("id", aTable.id, key = true, hidden = true),
@@ -79,6 +112,22 @@ trait SqlNullableParentMapping[F[_]] extends SqlTestMapping[F] {
       ObjectMapping(CType)(
         SqlField("id", cTable.id, key = true, hidden = true),
         SqlField("name", cTable.name)
+      ),
+      ObjectMapping(DType)(
+        SqlField("id", dTable.id, key = true, hidden = true),
+        SqlField("name", dTable.name),
+        SqlObject("es", Join(dTable.id, eTable.dId))
+      ),
+      ObjectMapping(EType)(
+        SqlField("id", eTable.id, key = true, hidden = true),
+        SqlField("dId", eTable.dId, hidden = true),
+        SqlField("fId", eTable.fId, hidden = true),
+        SqlField("name", eTable.name),
+        SqlObject("f", Join(eTable.fId, fTable.id))
+      ),
+      ObjectMapping(FType)(
+        SqlField("id", fTable.id, key = true, hidden = true),
+        SqlField("name", fTable.name)
       )
     )
 }

--- a/modules/sql-core/src/test/scala/SqlNullableParentMapping.scala
+++ b/modules/sql-core/src/test/scala/SqlNullableParentMapping.scala
@@ -45,6 +45,7 @@ trait SqlNullableParentMapping[F[_]] extends SqlTestMapping[F] {
     val id = col("id", int4)
     val dId = col("d_id", int4)
     val fId = col("f_id", int4)
+    val otherDId = col("other_d_id", int4)
     val name = col("name", text)
   }
 
@@ -77,6 +78,7 @@ trait SqlNullableParentMapping[F[_]] extends SqlTestMapping[F] {
       type E {
         name: String!
         f: F!
+        otherD: D!
       }
       type F {
         name: String!
@@ -122,8 +124,10 @@ trait SqlNullableParentMapping[F[_]] extends SqlTestMapping[F] {
         SqlField("id", eTable.id, key = true, hidden = true),
         SqlField("dId", eTable.dId, hidden = true),
         SqlField("fId", eTable.fId, hidden = true),
+        SqlField("otherDId", eTable.otherDId, hidden = true),
         SqlField("name", eTable.name),
-        SqlObject("f", Join(eTable.fId, fTable.id))
+        SqlObject("f", Join(eTable.fId, fTable.id)),
+        SqlObject("otherD", Join(eTable.otherDId, dTable.id))
       ),
       ObjectMapping(FType)(
         SqlField("id", fTable.id, key = true, hidden = true),

--- a/modules/sql-core/src/test/scala/SqlNullableParentSuite.scala
+++ b/modules/sql-core/src/test/scala/SqlNullableParentSuite.scala
@@ -23,13 +23,13 @@ import grackle._
 import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
 
 /**
- * A non-null field beneath a nullable one must not remove rows whose nullable field is absent.
+ * A non-null field beneath a nullable one, or beneath a list, must not remove rows whose parent
+ * is absent or empty.
  *
- * Both joins are individually correct — the nullable field's is a LEFT JOIN, the non-null
- * field's an INNER JOIN — but flattening them into one chain lets the INNER JOIN eliminate the
- * rows the LEFT JOIN null-padded. The non-null-ness of `c` only constrains anything when a `B`
- * exists at all: per the GraphQL spec, completing a nullable field with a null result returns
- * null without executing its sub-selections.
+ * The non-null-ness of such a field only constrains anything where its parent exists at all:
+ * per the GraphQL spec, completing a nullable field with a null result returns null without
+ * executing its sub-selections, and a `D` with no `E`s must still be returned with `es` as
+ * `[]`.
  */
 trait SqlNullableParentSuite extends CatsEffectSuite {
   def mapping: Mapping[IO]
@@ -115,6 +115,56 @@ trait SqlNullableParentSuite extends CatsEffectSuite {
             {
               "name" : "a-without-b",
               "b" : null
+            }
+          ]
+        }
+      }
+    """
+
+    assertWeaklyEqualIO(mapping.compileAndRun(query), expected)
+  }
+
+  test("a list field that is empty does not remove its row") {
+    val query = """
+      query {
+        ds {
+          name
+          es {
+            name
+            f {
+              name
+            }
+          }
+        }
+      }
+    """
+
+    // `d-without-es` is the row at issue: it has no `E`s, so nothing beneath `es` is selected at
+    // all, and the non-null-ness of `f` cannot bear on whether the `D` itself is returned.
+    val expected = json"""
+      {
+        "data" : {
+          "ds" : [
+            {
+              "name" : "d-with-es",
+              "es" : [
+                {
+                  "name" : "e-with-f",
+                  "f" : {
+                    "name" : "fish-1"
+                  }
+                },
+                {
+                  "name" : "e-with-another-f",
+                  "f" : {
+                    "name" : "fish-2"
+                  }
+                }
+              ]
+            },
+            {
+              "name" : "d-without-es",
+              "es" : []
             }
           ]
         }

--- a/modules/sql-core/src/test/scala/SqlNullableParentSuite.scala
+++ b/modules/sql-core/src/test/scala/SqlNullableParentSuite.scala
@@ -1,0 +1,126 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2025 Grackle Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grackle.sql.test
+
+import cats.effect.IO
+import io.circe.literal._
+import munit.CatsEffectSuite
+
+import grackle._
+import grackle.test.GraphQLResponseTests.assertWeaklyEqualIO
+
+/**
+ * A non-null field beneath a nullable one must not remove rows whose nullable field is absent.
+ *
+ * Both joins are individually correct — the nullable field's is a LEFT JOIN, the non-null
+ * field's an INNER JOIN — but flattening them into one chain lets the INNER JOIN eliminate the
+ * rows the LEFT JOIN null-padded. The non-null-ness of `c` only constrains anything when a `B`
+ * exists at all: per the GraphQL spec, completing a nullable field with a null result returns
+ * null without executing its sub-selections.
+ */
+trait SqlNullableParentSuite extends CatsEffectSuite {
+  def mapping: Mapping[IO]
+
+  test("a nullable field that is absent does not remove its row") {
+    val query = """
+      query {
+        as {
+          name
+          b {
+            name
+            c {
+              name
+            }
+          }
+        }
+      }
+    """
+
+    // `a-with-dangling-b` names a `B` which doesn't exist, so its row is reported with a null
+    // `b` rather than as an error. That isn't what the spec asks for — a non-null field with no
+    // row should raise an execution error propagated to the nearest nullable ancestor — but it
+    // is a separate defect from the one under test here, and returning the row is already an
+    // improvement on dropping it. Note that expecting `data` alone also expects no `errors`
+    // entry, so this has to be revisited when that defect is addressed.
+    val expected = json"""
+      {
+        "data" : {
+          "as" : [
+            {
+              "name" : "a-with-good-b",
+              "b" : {
+                "name" : "b-with-c",
+                "c" : {
+                  "name" : "cat-1"
+                }
+              }
+            },
+            {
+              "name" : "a-with-dangling-b",
+              "b" : null
+            },
+            {
+              "name" : "a-without-b",
+              "b" : null
+            }
+          ]
+        }
+      }
+    """
+
+    assertWeaklyEqualIO(mapping.compileAndRun(query), expected)
+  }
+
+  test("the same query stopping above the non-null field is unaffected") {
+    val query = """
+      query {
+        as {
+          name
+          b {
+            name
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "as" : [
+            {
+              "name" : "a-with-good-b",
+              "b" : {
+                "name" : "b-with-c"
+              }
+            },
+            {
+              "name" : "a-with-dangling-b",
+              "b" : {
+                "name" : "b-with-dangling-c"
+              }
+            },
+            {
+              "name" : "a-without-b",
+              "b" : null
+            }
+          ]
+        }
+      }
+    """
+
+    assertWeaklyEqualIO(mapping.compileAndRun(query), expected)
+  }
+}

--- a/modules/sql-core/src/test/scala/SqlNullableParentSuite.scala
+++ b/modules/sql-core/src/test/scala/SqlNullableParentSuite.scala
@@ -173,4 +173,73 @@ trait SqlNullableParentSuite extends CatsEffectSuite {
 
     assertWeaklyEqualIO(mapping.compileAndRun(query), expected)
   }
+
+  // Reaching a second list through a non-null field nests the same shape twice, which on a
+  // backend joining by `APPLY` presents the inner join to correlation a second time, once the
+  // first has already rewritten it. `e-with-f` is the row at issue: its `otherD` is the `D`
+  // with no `E`s, so only a query which descends that far has a row to lose.
+  test("an empty list reached through a back reference does not remove its row") {
+    val query = """
+      query {
+        ds {
+          name
+          es {
+            name
+            otherD {
+              name
+              es {
+                name
+                f {
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "ds" : [
+            {
+              "name" : "d-with-es",
+              "es" : [
+                {
+                  "name" : "e-with-f",
+                  "otherD" : {
+                    "name" : "d-without-es",
+                    "es" : []
+                  }
+                },
+                {
+                  "name" : "e-with-another-f",
+                  "otherD" : {
+                    "name" : "d-with-es",
+                    "es" : [
+                      {
+                        "name" : "e-with-f",
+                        "f" : { "name" : "fish-1" }
+                      },
+                      {
+                        "name" : "e-with-another-f",
+                        "f" : { "name" : "fish-2" }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name" : "d-without-es",
+              "es" : []
+            }
+          ]
+        }
+      }
+    """
+
+    assertWeaklyEqualIO(mapping.compileAndRun(query), expected)
+  }
 }

--- a/testdata/mssql/nullable-parent.sql
+++ b/testdata/mssql/nullable-parent.sql
@@ -27,4 +27,33 @@ INSERT INTO nullable_parent_a (id, b_id, name) VALUES
 (200, 20, 'a-with-dangling-b'),
 (300, NULL, 'a-without-b');
 
+CREATE TABLE nullable_parent_f (
+  id INTEGER PRIMARY KEY,
+  name VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE nullable_parent_e (
+  id INTEGER PRIMARY KEY,
+  d_id INTEGER NOT NULL,
+  f_id INTEGER NOT NULL,
+  name VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE nullable_parent_d (
+  id INTEGER PRIMARY KEY,
+  name VARCHAR(64) NOT NULL
+);
+
+INSERT INTO nullable_parent_f (id, name) VALUES
+(1, 'fish-1'),
+(2, 'fish-2');
+
+INSERT INTO nullable_parent_e (id, d_id, f_id, name) VALUES
+(10, 100, 1, 'e-with-f'),
+(11, 100, 2, 'e-with-another-f');
+
+INSERT INTO nullable_parent_d (id, name) VALUES
+(100, 'd-with-es'),
+(200, 'd-without-es');
+
 GO

--- a/testdata/mssql/nullable-parent.sql
+++ b/testdata/mssql/nullable-parent.sql
@@ -1,0 +1,30 @@
+CREATE TABLE nullable_parent_c (
+  id INTEGER PRIMARY KEY,
+  name VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE nullable_parent_b (
+  id INTEGER PRIMARY KEY,
+  c_id INTEGER NOT NULL,
+  name VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE nullable_parent_a (
+  id INTEGER PRIMARY KEY,
+  b_id INTEGER,
+  name VARCHAR(64) NOT NULL
+);
+
+INSERT INTO nullable_parent_c (id, name) VALUES
+(1, 'cat-1');
+
+INSERT INTO nullable_parent_b (id, c_id, name) VALUES
+(10, 1, 'b-with-c'),
+(20, 999, 'b-with-dangling-c');
+
+INSERT INTO nullable_parent_a (id, b_id, name) VALUES
+(100, 10, 'a-with-good-b'),
+(200, 20, 'a-with-dangling-b'),
+(300, NULL, 'a-without-b');
+
+GO

--- a/testdata/mssql/nullable-parent.sql
+++ b/testdata/mssql/nullable-parent.sql
@@ -36,6 +36,7 @@ CREATE TABLE nullable_parent_e (
   id INTEGER PRIMARY KEY,
   d_id INTEGER NOT NULL,
   f_id INTEGER NOT NULL,
+  other_d_id INTEGER NOT NULL,
   name VARCHAR(64) NOT NULL
 );
 
@@ -48,9 +49,9 @@ INSERT INTO nullable_parent_f (id, name) VALUES
 (1, 'fish-1'),
 (2, 'fish-2');
 
-INSERT INTO nullable_parent_e (id, d_id, f_id, name) VALUES
-(10, 100, 1, 'e-with-f'),
-(11, 100, 2, 'e-with-another-f');
+INSERT INTO nullable_parent_e (id, d_id, f_id, other_d_id, name) VALUES
+(10, 100, 1, 200, 'e-with-f'),
+(11, 100, 2, 100, 'e-with-another-f');
 
 INSERT INTO nullable_parent_d (id, name) VALUES
 (100, 'd-with-es'),

--- a/testdata/oracle/nullable-parent.sql
+++ b/testdata/oracle/nullable-parent.sql
@@ -1,0 +1,28 @@
+CREATE TABLE nullable_parent_c (
+  id INTEGER PRIMARY KEY,
+  name VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE nullable_parent_b (
+  id INTEGER PRIMARY KEY,
+  c_id INTEGER NOT NULL,
+  name VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE nullable_parent_a (
+  id INTEGER PRIMARY KEY,
+  b_id INTEGER,
+  name VARCHAR(64) NOT NULL
+);
+
+INSERT INTO nullable_parent_c (id, name) VALUES
+(1, 'cat-1');
+
+INSERT INTO nullable_parent_b (id, c_id, name) VALUES
+(10, 1, 'b-with-c'),
+(20, 999, 'b-with-dangling-c');
+
+INSERT INTO nullable_parent_a (id, b_id, name) VALUES
+(100, 10, 'a-with-good-b'),
+(200, 20, 'a-with-dangling-b'),
+(300, NULL, 'a-without-b');

--- a/testdata/oracle/nullable-parent.sql
+++ b/testdata/oracle/nullable-parent.sql
@@ -26,3 +26,32 @@ INSERT INTO nullable_parent_a (id, b_id, name) VALUES
 (100, 10, 'a-with-good-b'),
 (200, 20, 'a-with-dangling-b'),
 (300, NULL, 'a-without-b');
+
+CREATE TABLE nullable_parent_f (
+  id INTEGER PRIMARY KEY,
+  name VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE nullable_parent_e (
+  id INTEGER PRIMARY KEY,
+  d_id INTEGER NOT NULL,
+  f_id INTEGER NOT NULL,
+  name VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE nullable_parent_d (
+  id INTEGER PRIMARY KEY,
+  name VARCHAR(64) NOT NULL
+);
+
+INSERT INTO nullable_parent_f (id, name) VALUES
+(1, 'fish-1'),
+(2, 'fish-2');
+
+INSERT INTO nullable_parent_e (id, d_id, f_id, name) VALUES
+(10, 100, 1, 'e-with-f'),
+(11, 100, 2, 'e-with-another-f');
+
+INSERT INTO nullable_parent_d (id, name) VALUES
+(100, 'd-with-es'),
+(200, 'd-without-es');

--- a/testdata/oracle/nullable-parent.sql
+++ b/testdata/oracle/nullable-parent.sql
@@ -36,6 +36,7 @@ CREATE TABLE nullable_parent_e (
   id INTEGER PRIMARY KEY,
   d_id INTEGER NOT NULL,
   f_id INTEGER NOT NULL,
+  other_d_id INTEGER NOT NULL,
   name VARCHAR(64) NOT NULL
 );
 
@@ -48,9 +49,9 @@ INSERT INTO nullable_parent_f (id, name) VALUES
 (1, 'fish-1'),
 (2, 'fish-2');
 
-INSERT INTO nullable_parent_e (id, d_id, f_id, name) VALUES
-(10, 100, 1, 'e-with-f'),
-(11, 100, 2, 'e-with-another-f');
+INSERT INTO nullable_parent_e (id, d_id, f_id, other_d_id, name) VALUES
+(10, 100, 1, 200, 'e-with-f'),
+(11, 100, 2, 100, 'e-with-another-f');
 
 INSERT INTO nullable_parent_d (id, name) VALUES
 (100, 'd-with-es'),

--- a/testdata/pg/nullable-parent.sql
+++ b/testdata/pg/nullable-parent.sql
@@ -29,3 +29,35 @@ COPY nullable_parent_a (id, b_id, name) FROM STDIN WITH DELIMITER '|';
 200|20|a-with-dangling-b
 300|\N|a-without-b
 \.
+
+CREATE TABLE nullable_parent_f (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE nullable_parent_e (
+  id INTEGER PRIMARY KEY,
+  d_id INTEGER NOT NULL,
+  f_id INTEGER NOT NULL,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE nullable_parent_d (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+COPY nullable_parent_f (id, name) FROM STDIN WITH DELIMITER '|';
+1|fish-1
+2|fish-2
+\.
+
+COPY nullable_parent_e (id, d_id, f_id, name) FROM STDIN WITH DELIMITER '|';
+10|100|1|e-with-f
+11|100|2|e-with-another-f
+\.
+
+COPY nullable_parent_d (id, name) FROM STDIN WITH DELIMITER '|';
+100|d-with-es
+200|d-without-es
+\.

--- a/testdata/pg/nullable-parent.sql
+++ b/testdata/pg/nullable-parent.sql
@@ -39,6 +39,7 @@ CREATE TABLE nullable_parent_e (
   id INTEGER PRIMARY KEY,
   d_id INTEGER NOT NULL,
   f_id INTEGER NOT NULL,
+  other_d_id INTEGER NOT NULL,
   name TEXT NOT NULL
 );
 
@@ -52,9 +53,9 @@ COPY nullable_parent_f (id, name) FROM STDIN WITH DELIMITER '|';
 2|fish-2
 \.
 
-COPY nullable_parent_e (id, d_id, f_id, name) FROM STDIN WITH DELIMITER '|';
-10|100|1|e-with-f
-11|100|2|e-with-another-f
+COPY nullable_parent_e (id, d_id, f_id, other_d_id, name) FROM STDIN WITH DELIMITER '|';
+10|100|1|200|e-with-f
+11|100|2|100|e-with-another-f
 \.
 
 COPY nullable_parent_d (id, name) FROM STDIN WITH DELIMITER '|';

--- a/testdata/pg/nullable-parent.sql
+++ b/testdata/pg/nullable-parent.sql
@@ -1,0 +1,31 @@
+CREATE TABLE nullable_parent_c (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE nullable_parent_b (
+  id INTEGER PRIMARY KEY,
+  c_id INTEGER NOT NULL,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE nullable_parent_a (
+  id INTEGER PRIMARY KEY,
+  b_id INTEGER,
+  name TEXT NOT NULL
+);
+
+COPY nullable_parent_c (id, name) FROM STDIN WITH DELIMITER '|';
+1|cat-1
+\.
+
+COPY nullable_parent_b (id, c_id, name) FROM STDIN WITH DELIMITER '|';
+10|1|b-with-c
+20|999|b-with-dangling-c
+\.
+
+COPY nullable_parent_a (id, b_id, name) FROM STDIN WITH DELIMITER '|';
+100|10|a-with-good-b
+200|20|a-with-dangling-b
+300|\N|a-without-b
+\.


### PR DESCRIPTION
This PR was mostly done by an LLM. I have poked and prodded at it, encouraged it to verify rather than assume, enforced a proper software engineering workflow including TDD and reviews on top of which I did a manual review. It was an iterative process. The PR is now at a stage where I can't find anything obviously wrong with it but I will admit that the SQL generation is a bit arcane and things might have slipped past me.

And now, without further ado, the detailed LLM analysis:

---

Fixes #888. Also fixes #892, which #888 turned out to depend on.

Three defects, one observable symptom. The first is the one #888 describes: a nested select carrying an `INNER` join was flattened into the enclosing select's join chain even when it attached via a `LEFT` join, so the inner join sat below the outer one and eliminated the rows the outer join had null padded. `SqlSelect.nest` now declines to flatten in that case and builds a subquery instead, which keeps the inner join scoped where it's genuinely valid rather than discarding the optimisation.

Fixing that alone had no effect on MSSQL, which turned out to have a second and older defect, described in #892: an `OUTER APPLY` was never correlated to its enclosing select, so it behaved as an inner join and discarded the same rows again for an unrelated reason. `Laterality.joinPredicates` is replaced by `distributeJoinConditions`, which can rewrite the join as well as yield predicates for the enclosing select, and `Apply` uses that to wrap the subquery of an `OUTER APPLY` in a correlating select. Applying the conditions to the subquery's result rather than pushing them into it preserves any `LIMIT`, `OFFSET` or `DISTINCT`, and keeps a same named table inside the subquery from shadowing one of the enclosing select — both of which regressed when tried the other way round.

Correlating once isn't enough, which is the third fix. Nesting a select re-examines joins an earlier nesting already correlated, and `correlate` didn't recognise the wrapper it had itself built — so it declined, the conditions were lifted a second time, and the correlation was undone. It now recognises that wrapper and leaves the join alone. With that, no query in any of the four backends' suites reaches a decline at all.

None of the three is observable without the others, which is why they're here together: without the first no `APPLY` is emitted for these queries at all, without the second the first is a no-op on MSSQL, and without the third the second only holds to a depth of one.

Replacing `joinPredicates` isn't binary compatible, so the last commit bumps `tlBaseVersion` to 0.30. It's kept separate in case you'd rather own that yourself or take it in a different release.

Worth noting that the issue understates the reach. The join is chosen by `!context.tpe.isNullable && !context.tpe.isList`, so a list is attached the same way a nullable field is, and a parent with no children at all was being dropped for the same reason: `[B!]!` with a non-null field beneath `B` lost every parent whose list was empty. That needs no nullable field anywhere in the schema, so it's the easier of the two to hit by accident. There's a test for each shape.

The tests are a shared mapping and suite run on all four SQL backends, with fixture data including a row whose non-null reference dangles — the case that distinguishes a row being absent from a row being dropped — and a parent with an empty list. A third test descends two lists through a non-null field, which is what reaches the repeated correlation; it needs a second reference back to the parent type, so that the inner list can be empty where the outer one isn't.

One thing deliberately out of scope. A genuinely dangling non-null reference is still not reported as an error: before this change the row vanished from the result entirely, and after it the parent row is returned with the offending field as `null`. Both are wrong under §6.4.3 step 1, which asks for an execution error propagated to the nearest nullable ancestor. That's a separate defect with a separate remedy — the object field path at `SqlCursor` narrows without checking, where the interface and union path checks first via `narrowsTo` — and I'd rather raise it on its own than widen this. The tests assert the post-fix behaviour as it stands, so they'll need updating when it's addressed.

Verified on all four backends: `doobiepg`, `doobieoracle` and `skunkJVM` are green, and `doobiemssql` is green apart from three pre-existing `MovieSuite` failures which fail identically at the base commit. Those are a local artifact rather than anything in this change — the container runs in the host's timezone, so `moviesShownBetween` resolves its range boundary an hour out and returns a fourth film — and they're what #862 pins to UTC.
