### PR TITLE
Bump tlBaseVersion to 0.30

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ ThisBuild / scalaVersion := Scala2
 ThisBuild / crossScalaVersions := Seq(Scala2, Scala3)
 ThisBuild / tlJdkRelease := Some(11)
 
-ThisBuild / tlBaseVersion := "0.29"
+ThisBuild / tlBaseVersion := "0.30"
 ThisBuild / startYear := Some(2019)
 ThisBuild / licenses := Seq(License.Apache2)
 ThisBuild / developers := List(


### PR DESCRIPTION
Co-authored by an LLM. Reviewed by me. And now without further ado:

---

`v0.30.0` is tagged, but `tlBaseVersion` on main is still `0.29`. sbt-typelevel treats that as an error as soon as a branch has any commit on top of the tag:

```
[error] Your tlBaseVersion 0.29 is behind the latest tag 0.30.0
```

Main itself builds, because main *is* the tagged commit and the version comes from the tag. Every branch off it does not, so this currently blocks any PR that does not carry a bump of its own.

Same change as #863 did for 0.29.
