### PR TITLE
Accept a comment at the end of a file

### DIFF
--- a/modules/core/src/main/scala/parser.scala
+++ b/modules/core/src/main/scala/parser.scala
@@ -505,11 +505,13 @@ object GraphQLParser {
 
     /**
      * Parser that consumes a comment
+     *
+     * A comment ends at a line terminator or at the end of the file.
      */
     val comment: Parser[Unit] =
-      (char('#') *> charWhere(c => c != '\n' && c != '\r').rep0 <* charIn(
+      (char('#') *> charWhere(c => c != '\n' && c != '\r').rep0 <* (charIn(
         '\n',
-        '\r') <* skipWhitespace).void
+        '\r').void | Parser.end) <* skipWhitespace).void
 
     /**
      * Turns a parser into one that skips trailing whitespace and comments

--- a/modules/core/src/test/scala/parser/ParserSuite.scala
+++ b/modules/core/src/test/scala/parser/ParserSuite.scala
@@ -971,6 +971,15 @@ final class ParserSuite extends CatsEffectSuite {
     assertEquals(resFail, Result.failure(expectedFail))
   }
 
+  test("comment at end of file without a line terminator") {
+    val expected =
+      List(Operation(Query, None, Nil, Nil, List(Field(None, Name("x"), Nil, Nil, Nil))))
+
+    assertEquals(parser.parseText("query { x } # done"), Result(expected))
+    assertEquals(parser.parseText("query { x } #"), Result(expected))
+    assertEquals(parser.parseText("query { # inner\n x } # a\n# b"), Result(expected))
+  }
+
   def mkParser(
       maxSelectionDepth: Int = GraphQLParser.defaultConfig.maxSelectionDepth,
       maxSelectionWidth: Int = GraphQLParser.defaultConfig.maxSelectionWidth,


### PR DESCRIPTION
The comment parser required a line terminator after the comment text. A comment at the end of the file has none, so the whole document failed to parse.

The terminator is now `charIn('\n', '\r') | Parser.end`.
