### PR TITLE
Allow `@skip` and `@include` on the same selection

### DIFF
--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -1269,15 +1269,13 @@ object QueryCompiler {
       Elab.liftR(Value.elaborateValue(b.value, vars).map(ev => b.copy(value = ev)))
 
     def isSkipped(dirs: List[Directive]): Elab[Boolean] =
-      dirs.filter(d => d.name == "skip" || d.name == "include") match {
-        case Nil => Elab.pure(false)
-        case List(Directive(nme, List(Binding("if", value)))) =>
-          for {
-            c <- extractCond(value)
-          } yield (nme == "skip" && c) || (nme == "include" && !c)
-        case List(Directive(nme, _)) =>
+      dirs.filter(d => d.name == "skip" || d.name == "include").foldLeftM(false) {
+        case (skipped, Directive(nme, List(Binding("if", value)))) =>
+          extractCond(value).map { c =>
+            skipped || (nme == "skip" && c) || (nme == "include" && !c)
+          }
+        case (_, Directive(nme, _)) =>
           Elab.failure(s"Directive '$nme' must have a single Boolean 'if' argument")
-        case _ => Elab.failure("skip/include directives must be unique")
       }
 
     def extractCond(value: Value): Elab[Boolean] =

--- a/modules/core/src/test/scala/compiler/SkipIncludeSuite.scala
+++ b/modules/core/src/test/scala/compiler/SkipIncludeSuite.scala
@@ -260,6 +260,51 @@ final class SkipIncludeSuite extends CatsEffectSuite {
 
     assertEquals(compiled.map(_.query), Result.Success(expected))
   }
+
+  test("skip and include on the same selection") {
+    val query = """
+      query {
+        a: field @skip(if: false) @include(if: true) { subfieldA }
+        b: field @skip(if: true) @include(if: true) { subfieldA }
+        c: field @skip(if: false) @include(if: false) { subfieldA }
+        d: field @skip(if: true) @include(if: false) { subfieldA }
+      }
+    """
+
+    val expected = Select("field", Some("a"), Select("subfieldA"))
+
+    val compiled = SkipIncludeMapping.compiler.compile(query)
+
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+  }
+
+  test("repeated skip on the same selection is rejected") {
+    val query = """
+      query {
+        field @skip(if: false) @skip(if: false) { subfieldA }
+      }
+    """
+
+    val compiled = SkipIncludeMapping.compiler.compile(query)
+
+    assertEquals(
+      compiled.map(_.query),
+      Result.failure("Directive 'skip' may not occur more than once"))
+  }
+
+  test("repeated include on the same selection is rejected") {
+    val query = """
+      query {
+        field @include(if: true) @include(if: true) { subfieldA }
+      }
+    """
+
+    val compiled = SkipIncludeMapping.compiler.compile(query)
+
+    assertEquals(
+      compiled.map(_.query),
+      Result.failure("Directive 'include' may not occur more than once"))
+  }
 }
 
 object SkipIncludeMapping extends TestMapping {


### PR DESCRIPTION
The specification allows both `@skip` and `@include` on one selection. `isSkipped` matched on the full directive list and failed with "skip/include directives must be unique" for the combination.

https://spec.graphql.org/September2025/#sec-Directives-Are-Unique-per-Location
