### PR TITLE
Show keys for "Expected single value" SQL error

### DIFF
--- a/modules/doobie-pg/src/test/scala/DoobiePgSuites.scala
+++ b/modules/doobie-pg/src/test/scala/DoobiePgSuites.scala
@@ -68,6 +68,10 @@ final class Embedding3Suite extends DoobiePgDatabaseSuite with SqlEmbedding3Suit
   lazy val mapping = new DoobiePgTestMapping(transactor) with SqlEmbedding3Mapping[IO]
 }
 
+final class ErrorKeysSuite extends DoobiePgDatabaseSuite with SqlErrorKeysSuite {
+  lazy val mapping = new DoobiePgTestMapping(transactor) with SqlCompositeKeyMapping[IO]
+}
+
 final class FilterJoinAliasSuite extends DoobiePgDatabaseSuite with SqlFilterJoinAliasSuite {
   lazy val mapping = new DoobiePgTestMapping(transactor) with SqlFilterJoinAliasMapping[IO]
 }

--- a/modules/skunk/js-jvm/src/test/scala/SkunkSuites.scala
+++ b/modules/skunk/js-jvm/src/test/scala/SkunkSuites.scala
@@ -71,6 +71,10 @@ final class Embedding3Suite extends SkunkDatabaseSuite with SqlEmbedding3Suite {
   lazy val mapping = new SkunkTestMapping(pool) with SqlEmbedding3Mapping[IO]
 }
 
+final class ErrorKeysSuite extends SkunkDatabaseSuite with SqlErrorKeysSuite {
+  lazy val mapping = new SkunkTestMapping(pool) with SqlCompositeKeyMapping[IO]
+}
+
 final class FilterJoinAliasSuite extends SkunkDatabaseSuite with SqlFilterJoinAliasSuite {
   lazy val mapping = new SkunkTestMapping(pool) with SqlFilterJoinAliasMapping[IO]
 }

--- a/modules/sql-core/src/main/scala/SqlMapping.scala
+++ b/modules/sql-core/src/main/scala/SqlMapping.scala
@@ -4310,11 +4310,34 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
             Result.internalError(s"Expected mapping for field '$fieldName' of type $obj")
 
           case col =>
-            table
-              .select(col)
-              .toResultOrError(
-                s"Expected single value for field '$fieldName' of type ${context.tpe.dealias} at ${context.path}, found many"
-              )
+            table.select(col).toResultOrError {
+              def renderLeaf(keyCol: SqlColumn, v: Any): String =
+                keyCol
+                  .resultPath
+                  .headOption
+                  .flatMap(fn => encoderForLeaf(context.forFieldOrAttribute(fn, None)))
+                  .map(enc => enc(v).noSpaces)
+                  .getOrElse(v.toString)
+
+              val keys = for {
+                keyCol <- self.keyColumnsForType(context)
+                col <- index.get(keyCol).toList
+                rendered = table.select(col) match {
+                  // `select` yields `None` only if the column holds more than one distinct value.
+                  case None => "<many>"
+                  case Some(value) =>
+                    value match {
+                      case None => "null"
+                      case Some(v) => renderLeaf(keyCol, v)
+                      case v if isFailedJoin(v) => "<no value>"
+                      case v => renderLeaf(keyCol, v)
+                    }
+                }
+              } yield s"$keyCol = $rendered"
+
+              val keyInfo = if (keys.isEmpty) "" else keys.mkString(" (keys: ", ", ", ")")
+              s"Expected single value for field '$fieldName' of type ${context.tpe.dealias} at ${context.path}, found many$keyInfo"
+            }
 
         }
 

--- a/modules/sql-core/src/test/scala/SqlErrorKeysSuite.scala
+++ b/modules/sql-core/src/test/scala/SqlErrorKeysSuite.scala
@@ -1,0 +1,98 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2025 Grackle Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grackle.sql.test
+
+import cats.effect.IO
+import munit.{CatsEffectSuite, Location}
+
+import grackle._
+import grackle.sql.FailedJoin
+
+trait SqlErrorKeysSuite extends CatsEffectSuite {
+  def mapping: SqlCompositeKeyMapping[IO]
+
+  final lazy val M = mapping
+
+  val query = "{ parents { key1 key2 children { id parent1 parent2 } } }"
+
+  lazy val (mapped, rootContext) =
+    (for {
+      op <- M.compiler.compile(query)
+      context = Context(op.rootTpe)
+      mq <- M.MappedQuery(op.query, context)
+      // The compiled query is never empty here, so the cast is safe.
+    } yield (mq.asInstanceOf[M.MappedQuery.NonEmptyMappedQuery], context)) match {
+      case Result.Success(res) => res
+      case other => fail(s"Expected a non-empty mapped query, got: $other")
+    }
+
+  lazy val parentContext = itemContext(rootContext, "parents")
+  lazy val childContext = itemContext(parentContext, "children")
+
+  def itemContext(context: Context, fieldName: String): Context = {
+    val fieldContext = context.forFieldOrAttribute(fieldName, None)
+    val itemTpe =
+      fieldContext.tpe.item.map(_.dealias).getOrElse(fail(s"Not a list: $fieldName"))
+    fieldContext.asType(itemTpe)
+  }
+
+  def colIndex(context: Context, fieldName: String): Int =
+    mapped.colsByResultPath(fieldName :: context.resultPath).head._2
+
+  def mkRow(cells: (Int, Any)*): Array[Any] = {
+    val row = Array.fill[Any](mapped.index.values.max + 1)(FailedJoin)
+    cells.foreach { case (i, v) => row(i) = v }
+    row
+  }
+
+  def mkTable(rows: Array[Any]*): M.Table = M.Table(rows.toVector)
+
+  def errorMessage(res: Result[Any])(implicit loc: Location): String =
+    res match {
+      case Result.InternalError(err) => err.getMessage
+      case other => fail(s"Expected an internal error, got: $other")
+    }
+
+  test("single value selects") {
+    val id = colIndex(childContext, "id")
+    val parent1 = colIndex(childContext, "parent1")
+    val table = mkTable(mkRow(id -> 1, parent1 -> 10), mkRow(id -> 1, parent1 -> 10))
+    val res: Result[Any] = mapped.selectAtomicField(childContext, "parent1", table)
+    assertEquals(res, Result.Success[Any](10))
+  }
+
+  test("many values name the key") {
+    val id = colIndex(childContext, "id")
+    val parent1 = colIndex(childContext, "parent1")
+    val table = mkTable(mkRow(id -> 1, parent1 -> 10), mkRow(id -> 1, parent1 -> 20))
+    val msg = errorMessage(mapped.selectAtomicField(childContext, "parent1", table))
+    assertNoDiff(
+      msg,
+      "Expected single value for field 'parent1' of type Child at List(children, parents), found many (keys: composite_key_child.id = 1)"
+    )
+  }
+
+  test("string key renders quoted, and a key with many values renders as <many>") {
+    val key1 = colIndex(parentContext, "key1")
+    val key2 = colIndex(parentContext, "key2")
+    val table = mkTable(mkRow(key1 -> 1, key2 -> "GBR"), mkRow(key1 -> 2, key2 -> "GBR"))
+    val msg = errorMessage(mapped.selectAtomicField(parentContext, "key1", table))
+    assertNoDiff(
+      msg,
+      "Expected single value for field 'key1' of type Parent at List(parents), found many (keys: composite_key_parent.key_1 = <many>, composite_key_parent.key_2 = \"GBR\")"
+    )
+  }
+}


### PR DESCRIPTION
Instead of:

```
Expected single value for field 'key1' of type Parent at List(parents), found many
```

Now shows:

```
Expected single value for field 'key1' of type Parent at List(parents), found many (keys: composite_key_parent.key_1 = <many>, composite_key_parent.key_2 = "GBR")
```