### PR TITLE
Correct two values in the shared test data

### DIFF
--- a/testdata/projection/level2.csv
+++ b/testdata/projection/level2.csv
@@ -1,4 +1,4 @@
-id|level1_id|attr
+id|level1_id|attr:boolean
 20|10|false
 21|10|false
 22|11|false

--- a/testdata/unions/collections.csv
+++ b/testdata/unions/collections.csv
@@ -1,3 +1,3 @@
 id|item_type|itema|itemb
-1|ItemA|A|null
-2|ItemB|null|B
+1|ItemA|A|\N
+2|ItemB|\N|B


### PR DESCRIPTION
As a follow-up to #912 I noticed two issues.

First, there is a boolean column which is currently not explicitly tagged as such but would benefit from it: `testdata/projection/level2.csv`'s `attr`. So every dialect gets the string literal `'false'`, where before #912 Oracle had `'FALSE'` and SQL Server had `0`. All three databases are fine with that and parse the boolean correctly. So far, that is. With the advent of SQLite this is no longer good enough: SQLite gives such a column INTEGER affinity and keeps `'true'` as text, reading it back as false. MySQL's `BOOLEAN` is a `TINYINT(1)`, where `'true'` is an error under strict mode. Also, `coalesce/cb.csv` already tags its boolean column. `projection` was the only one that did not.

Second, before #912 the `unions` dataset held slightly different data on SQL Server and Oracle than on Postgres. Those two wrote a real `NULL` into `collections.itema`/`itemb`, while Postgres's `COPY` block set `NULL AS ''`, so only an empty field became NULL there and the word `null` was stored as a four-character string. #912 shared the Postgres spelling, which changed the value on the other two. Writing `\N` gives all three a real NULL, which is what the fixture means: the row is not that variant of the union.

This PR corrects both.

One more difference from before #912 turned up on the way: San Marino's `headofstate` was `''` on SQL Server, and NULL on Postgres and Oracle. It is NULL everywhere now.
