### PR TITLE
Support DBs without LATERAL JOINS

### DIFF
--- a/modules/doobie-mssql/src/main/scala/DoobieMSSqlMapping.scala
+++ b/modules/doobie-mssql/src/main/scala/DoobieMSSqlMapping.scala
@@ -93,14 +93,17 @@ trait DoobieMSSqlMappingLike[F[_]] extends DoobieMappingLike[F] with SqlMappingL
       // folded to a bare identifier first (issue #342).
       s.toSubquery(s.table.identifier + "_encaps", Laterality.NotLateral)
 
+  def unionBranchToFragment(branch: Fragment): Fragment = Fragments.parentheses(branch)
+
   def mkLateral(inner: Boolean): Laterality =
     Laterality.Apply(inner)
 
-  def defaultOffsetForSubquery(subquery: SqlQuery): SqlQuery =
-    subquery match {
-      case s: SqlSelect if s.orders.nonEmpty && s.offset.isEmpty => s.copy(offset = 0.some)
-      case _ => subquery
-    }
+  // MSSQL's grammar requires an ORDER BY inside a derived table to be paired with an
+  // OFFSET/FETCH clause; at the query root the pairing is optional and OFFSET 0 ROWS is a
+  // harmless no-op, so the default can be supplied unconditionally.
+  def normalizeOffsetLimit(query: SqlSelect): SqlSelect =
+    if (query.orders.nonEmpty && query.offset.isEmpty) query.copy(offset = 0.some)
+    else query
 
   def defaultOffsetForLimit(limit: Option[Int]): Option[Int] =
     limit.as(0)

--- a/modules/doobie-oracle/src/main/scala/DoobieOracleMapping.scala
+++ b/modules/doobie-oracle/src/main/scala/DoobieOracleMapping.scala
@@ -89,8 +89,9 @@ trait DoobieOracleMappingLike[F[_]] extends DoobieMappingLike[F] with SqlMapping
     ) // TODO: check that passing orders works with Oracle
 
   def encapsulateUnionBranch(s: SqlSelect): SqlSelect = s
+  def unionBranchToFragment(branch: Fragment): Fragment = Fragments.parentheses(branch)
   def mkLateral(inner: Boolean): Laterality = Laterality.Lateral
-  def defaultOffsetForSubquery(subquery: SqlQuery): SqlQuery = subquery
+  def normalizeOffsetLimit(query: SqlSelect): SqlSelect = query
   def defaultOffsetForLimit(limit: Option[Int]): Option[Int] = None
 
   def orderToFragment(col: Fragment, ascending: Boolean, nullsLast: Boolean): Fragment = {

--- a/modules/sql-core/src/main/scala/SqlMapping.scala
+++ b/modules/sql-core/src/main/scala/SqlMapping.scala
@@ -59,8 +59,63 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
       predCols: List[SqlColumn],
       orders: List[OrderSelection[_]]): SqlColumn
   def encapsulateUnionBranch(s: SqlSelect): SqlSelect
+
+  /**
+   * Renders one branch of a `UNION ALL` compound select.
+   *
+   * Typically the branch is wrapped in parentheses: `(branch1) UNION ALL (branch2)`. Dialects
+   * whose compound-select grammar forbids parenthesized branches (e.g. SQLite) return the
+   * fragment unmodified instead. That is safe for any dialect: grackle only ever combines
+   * branches with `UNION ALL` (never plain `UNION`), which is associative, so grouping never
+   * affects results. A branch that carries its own `ORDER BY`/`OFFSET`/`LIMIT` is wrapped in a
+   * derived-table subquery by `encapsulateUnionBranch` before this is applied.
+   */
+  def unionBranchToFragment(branch: Fragment): Fragment
+
   def mkLateral(inner: Boolean): Laterality
-  def defaultOffsetForSubquery(subquery: SqlQuery): SqlQuery
+
+  /**
+   * Whether this dialect can correlate a FROM-clause subquery with a sibling table, by
+   * `LATERAL`, `CROSS`/`OUTER APPLY`, or an equivalent.
+   *
+   * Derived from `mkLateral`: a dialect with no such mechanism at all (e.g. SQLite) has no
+   * lateral form for `mkLateral` to render and answers `Laterality.NotLateral` there, which is
+   * what this test detects. The probe passes `inner = false`, which assumes no dialect offers a
+   * lateral form only in the inner position.
+   *
+   * Two parts of `addFilterOrderByOffsetLimit` depend on it:
+   *
+   *   - When `false`, the parent-constraint equality predicate normally embedded in a nested
+   *     field's own `WHERE` clause is omitted. That predicate is redundant - the correlation it
+   *     expresses is supplied independently, via an ordinary `JOIN ... ON` clause, by
+   *     `SqlQuery.SqlSelect.nest` - so omitting it doesn't change results, it only removes a
+   *     reference to a column that isn't in scope inside a non-lateral subquery. The trade-off
+   *     is performance, not correctness: a genuinely lateral-evaluated subquery lets the
+   *     database restrict window-function/ordering work to just the current parent row, whereas
+   *     without it the same window function (e.g. `PARTITION BY <foreign key>`) runs across the
+   *     whole child table and the outer join selects out the relevant partition.
+   *   - The "Case 1" fast paths apply `OFFSET`/`LIMIT` directly to a query built from
+   *     pre-existing `joins`, trusting `oneToOne && predIsOneToOne` to mean the result is
+   *     already one row per key. That only holds when a lateral-evaluated correlated subquery
+   *     produced those joins (guaranteeing at most one contribution per outer row); without
+   *     one, `joins` can itself contain a nested one-to-many hop (e.g. a further
+   *     windowed/limited grandchild list) whose LEFT JOIN "no match" rows and real match rows
+   *     both carry this level's own key, so a physical-row-counting `LIMIT` applied on top
+   *     keeps an arbitrary one of the two. When `false`, the fast paths are therefore only
+   *     taken when no joins (or no offset/limit) are present to introduce that fan-out.
+   */
+  lazy val supportsLateralJoin: Boolean = mkLateral(false) != Laterality.NotLateral
+
+  /**
+   * Supplies any offset/limit defaults the dialect's rendering requires.
+   *
+   * Applied to every `SqlSelect` just before it is rendered, root query and subqueries alike.
+   * MSSQL uses it to pair an `ORDER BY` with the `OFFSET` its grammar demands; SQLite to pair
+   * an explicit offset with the `LIMIT` its comma-form clause is anchored on. Must return its
+   * argument unchanged when no defaults are needed - what it returns is rendered directly,
+   * without a second normalization pass.
+   */
+  def normalizeOffsetLimit(query: SqlSelect): SqlSelect
   def defaultOffsetForLimit(limit: Option[Int]): Option[Int]
   def orderToFragment(col: Fragment, ascending: Boolean, nullsLast: Boolean): Fragment
   def nullsHigh: Boolean
@@ -1580,7 +1635,7 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
       def toDefFragment: Aliased[Fragment] =
         for {
           alias <- Aliased.tableDef(this)
-          sub <- defaultOffsetForSubquery(subquery).toFragment
+          sub <- subquery.toFragment
         } yield laterality.toFragment |+| Fragments.parentheses(sub) |+| aliasDefToFragment(
           alias)
 
@@ -2755,9 +2810,13 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
 
         val (pred, filterJoins) =
           filter.map { case (pred, joins) => (pred :: Nil, joins) }.getOrElse((Nil, Nil))
-        val pred0 = parentConstraints.flatMap(_.map {
-          case (p, c) => Eql(p.toTerm, c.toTerm)
-        }) ++ pred
+        // The parent-constraint equality is only meaningful (and only in scope) inside a
+        // lateral-evaluated subquery; the correlation it expresses is supplied independently by
+        // SqlSelect.nest's JOIN ... ON. See supportsLateralJoin.
+        val pred0 =
+          (if (supportsLateralJoin)
+             parentConstraints.flatMap(_.map { case (p, c) => Eql(p.toTerm, c.toTerm) })
+           else Nil) ++ pred
 
         val (oss, orderJoins) =
           orderBy.map { case (oss, joins) => (oss, joins) }.getOrElse((Nil, Nil))
@@ -2779,7 +2838,12 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
 
             val partitionBy = parentConstraints.head.map(_._2)
 
-            if (oneToOne && predIsOneToOne) {
+            // Without a lateral-evaluated subquery, oneToOne && predIsOneToOne doesn't guarantee
+            // one physical row per key if joins contains a one-to-many hop; see
+            // supportsLateralJoin.
+            val fastPathSafe = supportsLateralJoin || joins.isEmpty
+
+            if (oneToOne && predIsOneToOne && fastPathSafe) {
               // Case 1) one row is one object in this context
               pred0.traverse(p => contextualiseWhereTerms(context, table, p)).flatMap { pred1 =>
                 oss.traverse(os => contextualiseOrderTerms(context, table, os)).flatMap {
@@ -3158,7 +3222,12 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
           } else {
             // No parent constraint so nothing to be gained from using window functions
 
-            if ((oneToOne && predIsOneToOne) || (offset0.isEmpty && limit0.isEmpty && filterJoins.isEmpty && orderJoins.isEmpty)) {
+            // As in the useWindow branch above, except that with no offset/limit there's
+            // nothing for join-introduced fan-out to corrupt; see supportsLateralJoin.
+            val fastPathSafe =
+              supportsLateralJoin || (offset0.isEmpty && limit0.isEmpty) || joins.isEmpty
+
+            if ((oneToOne && predIsOneToOne && fastPathSafe) || (offset0.isEmpty && limit0.isEmpty && filterJoins.isEmpty && orderJoins.isEmpty)) {
               // Case 1) one row is one object or query is simple enough to not require subqueries
 
               pred0.traverse(p => contextualiseWhereTerms(context, table, p)).flatMap { pred1 =>
@@ -3349,9 +3418,12 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
       }
 
       /**
-       * Render this `SqlSelect` as a `Fragment`
+       * Render this `SqlSelect` as a `Fragment`, first giving the dialect a chance to supply
+       * any offset/limit defaults its rendering requires (see `normalizeOffsetLimit`).
        */
-      def toFragment: Aliased[Fragment] = {
+      def toFragment: Aliased[Fragment] = normalizeOffsetLimit(this).toFragment0
+
+      private def toFragment0: Aliased[Fragment] = {
         for {
           _ <- Aliased.pushOwner(this)
           withs0 <-
@@ -3576,8 +3648,8 @@ trait SqlMappingLike[F[_]] extends CirceMappingLike[F] with SqlModule[F] { self 
           frags <- alignedElems.traverse(_.toFragment)
         } yield {
           frags.reduce((x, y) =>
-            Fragments.parentheses(x) |+| Fragments.const(" UNION ALL ") |+| Fragments
-              .parentheses(y))
+            unionBranchToFragment(x) |+| Fragments.const(
+              " UNION ALL ") |+| unionBranchToFragment(y))
         }
       }
     }

--- a/modules/sql-core/src/test/scala/SqlFilterOrderOffsetLimitSuite.scala
+++ b/modules/sql-core/src/test/scala/SqlFilterOrderOffsetLimitSuite.scala
@@ -1039,6 +1039,35 @@ trait SqlFilterOrderOffsetLimitSuite extends CatsEffectSuite {
     assertWeaklyEqualIO(res, expected)
   }
 
+  // Unlike "root offset" above, no child lists are selected, so the offset isn't pushed into a
+  // planner-wrapped subquery but stays on the top-level select - the only query shape that
+  // reaches rendering with an offset and no limit, exercising normalizeOffsetLimit at the root.
+  test("root offset with no nested lists") {
+    val query = """
+      query {
+        root(offset: 1) {
+          id
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "root" : [
+            {
+              "id" : "r1"
+            }
+          ]
+        }
+      }
+    """
+
+    val res = mapping.compileAndRun(query)
+
+    assertWeaklyEqualIO(res, expected)
+  }
+
   test("order on one side") {
     val query = """
       query {

--- a/modules/sql-pg/shared/src/main/scala/SqlPgMapping.scala
+++ b/modules/sql-pg/shared/src/main/scala/SqlPgMapping.scala
@@ -66,8 +66,9 @@ trait SqlPgMappingLike[F[_]] extends SqlMappingLike[F] {
       orders: List[OrderSelection[_]]): SqlColumn = col
 
   def encapsulateUnionBranch(s: SqlSelect): SqlSelect = s
+  def unionBranchToFragment(branch: Fragment): Fragment = Fragments.parentheses(branch)
   def mkLateral(inner: Boolean): Laterality = Laterality.Lateral
-  def defaultOffsetForSubquery(subquery: SqlQuery): SqlQuery = subquery
+  def normalizeOffsetLimit(query: SqlSelect): SqlSelect = query
   def defaultOffsetForLimit(limit: Option[Int]): Option[Int] = None
 
   def orderToFragment(col: Fragment, ascending: Boolean, nullsLast: Boolean): Fragment = {


### PR DESCRIPTION
This PR makes support for LATERAL JOINS optional. This has been extracted out of the SQLite branch since it can stand on its own. This way it might be easier to review. It moves the two decisions a backend _without lateral joins_ has to make out of `sql-core` and behind abstract hooks.

## Two abstract members on `SqlMappingLike`

`normalizeOffsetLimit` says how a select's `OFFSET`/`LIMIT` is fixed up before it is rendered, and `unionBranchToFragment` how one branch of a union is rendered. `defaultOffsetForSubquery` is gone, since the first of those covers what it did.

I decided to leave those two abstract and not provide a default implementation. I am not aware of any implementation of `SqlMappingLike` outside of this repo. And if there is, all it has to do is implement two small methods.

Every backend in this repo still has lateral joins, so `supportsLateralJoin` is true everywhere and the branches that do without one are not exercised until #864 adds SQLite and #866 adds H2.

## SQL Server's generated SQL changes

SQL Server now emits `OFFSET 0 ROWS` after an `ORDER BY` at the root of a query, where before it did so only in subqueries. The rows and their order are unchanged; only the text is. Keeping the old text would have meant passing a "subquery or root?" boolean through the new hook, so I took the text change.

