### PR TITLE
Encode error locations with `column` instead of `col`

### DIFF
--- a/modules/core/src/main/scala/problem.scala
+++ b/modules/core/src/main/scala/problem.scala
@@ -64,10 +64,10 @@ object Problem {
           "locations" ->
             p.locations
               .map {
-                case (line, col) =>
+                case (line, column) =>
                   Json.obj(
                     "line" -> line.asJson,
-                    "col" -> col.asJson
+                    "column" -> column.asJson
                   )
               }
               .asJson

--- a/modules/core/src/test/scala/compiler/ProblemSuite.scala
+++ b/modules/core/src/test/scala/compiler/ProblemSuite.scala
@@ -33,11 +33,11 @@ final class ProblemSuite extends CatsEffectSuite {
           "locations" : [
             {
               "line" : 1,
-              "col" : 2
+              "column" : 2
             },
             {
               "line" : 5,
-              "col" : 6
+              "column" : 6
             }
           ],
           "path" : [
@@ -58,11 +58,11 @@ final class ProblemSuite extends CatsEffectSuite {
           "locations" : [
             {
               "line" : 1,
-              "col" : 2
+              "column" : 2
             },
             {
               "line" : 5,
-              "col" : 6
+              "column" : 6
             }
           ]
         }

--- a/modules/core/src/test/scala/conformance/ResponseSuite.scala
+++ b/modules/core/src/test/scala/conformance/ResponseSuite.scala
@@ -162,9 +162,8 @@ final class ResponseSuite extends ConformanceSuite {
     }
   """)
 
-  // Section 7.1.6 states that each location is a map with the keys `line` and `column`. Grackle
-  // writes the key `col`. This test case isolates that difference from the two above.
-  test("an error location uses the keys line and column".fail) {
+  // Section 7.1.6 states that each location is a map with the keys `line` and `column`.
+  test("an error location uses the keys line and column") {
     assertEquals(
       Problem(
         "Name for character with ID 1002 could not be fetched.",


### PR DESCRIPTION
Spec: https://spec.graphql.org/September2025/#sec-Errors.Error-Result-Format

Problems should be encoded with the key `column` instead of `col` to conform to the GraphQL specification. This is a breaking change, but should also bring better error reporting for clients that rely on the GraphQL specification.
