### PR TITLE
Apply the default `@deprecated`` reason when reason is not provided

### DIFF
--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -842,10 +842,10 @@ protected trait Deprecatable {
     directives.find(_.name == "deprecated")
   def isDeprecated: Boolean = deprecatedDirective.isDefined
   def deprecationReason: Option[String] =
-    for {
-      dir <- deprecatedDirective
-      reason <- dir.args.collectFirst { case Binding("reason", StringValue(reason)) => reason }
-    } yield reason
+    deprecatedDirective.map(
+      _.args
+        .collectFirst { case Binding("reason", StringValue(reason)) => reason }
+        .getOrElse(DirectiveDef.DefaultDeprecationReason))
 }
 
 /**
@@ -1342,6 +1342,15 @@ case class DirectiveDef(
 )
 
 object DirectiveDef {
+
+  /**
+   * The default value of the `reason` argument of the built-in `@deprecated` directive.
+   *
+   * @see
+   *   https://spec.graphql.org/draft/#sec--deprecated
+   */
+  val DefaultDeprecationReason: String = "No longer supported"
+
   val Skip: DirectiveDef =
     DirectiveDef(
       "skip",
@@ -1391,7 +1400,7 @@ object DirectiveDef {
           Some(
             "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/)."),
           StringType,
-          Some(StringValue("No longer supported")),
+          Some(StringValue(DefaultDeprecationReason)),
           Nil
         )),
       false,

--- a/modules/core/src/test/scala/introspection/IntrospectionSuite.scala
+++ b/modules/core/src/test/scala/introspection/IntrospectionSuite.scala
@@ -1047,6 +1047,67 @@ final class IntrospectionSuite extends CatsEffectSuite {
     assertIO(res, expected)
   }
 
+  test("bare @deprecated query") {
+    val query = """
+      {
+        __type(name: "User") {
+          fields(includeDeprecated: true) {
+            name
+            isDeprecated
+            deprecationReason
+          }
+        }
+        queryType: __type(name: "Query") {
+          fields(includeDeprecated: true) {
+            args(includeDeprecated: true) {
+              name
+              isDeprecated
+              deprecationReason
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "__type" : {
+            "fields" : [
+              {
+                "name" : "id",
+                "isDeprecated" : false,
+                "deprecationReason" : null
+              },
+              {
+                "name" : "name",
+                "isDeprecated" : true,
+                "deprecationReason" : "No longer supported"
+              }
+            ]
+          },
+          "queryType" : {
+            "fields" : [
+              {
+                "args" : [
+                  {
+                    "name" : "dep",
+                    "isDeprecated" : true,
+                    "deprecationReason" : "No longer supported"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    """
+
+    val res = BareDeprecationMapping.compileAndRun(query)
+
+    assertIO(res, expected)
+  }
+
   test("simple schema query") {
     val query = """
       {
@@ -2082,6 +2143,41 @@ object InputMapping extends ValueMapping[IO] {
           ValueField("id", _.id),
           ValueField("name", _.name),
           ValueField("age", _.age)
+        )
+      )
+    )
+}
+
+object BareDeprecationMapping extends ValueMapping[IO] {
+  import SmallData._
+
+  val schema =
+    schema"""
+      type Query {
+        users(dep: Int @deprecated): [User!]!
+      }
+      type User {
+        id: String
+        name: String @deprecated
+      }
+    """
+
+  val QueryType = schema.queryType
+  val UserType = schema.ref("User")
+
+  val typeMappings =
+    List(
+      ValueObjectMapping[Unit](
+        tpe = QueryType,
+        fieldMappings = List(
+          ValueField("users", _ => users)
+        )
+      ),
+      ValueObjectMapping[User](
+        tpe = UserType,
+        fieldMappings = List(
+          ValueField("id", _.id),
+          ValueField("name", _.name)
         )
       )
     )

--- a/modules/core/src/test/scala/schema/SchemaSuite.scala
+++ b/modules/core/src/test/scala/schema/SchemaSuite.scala
@@ -18,7 +18,7 @@ package schema
 import cats.data.NonEmptyChain
 import munit.CatsEffectSuite
 
-import grackle.{Result, ScalarType, Schema}
+import grackle.{DirectiveDef, EnumType, Result, ScalarType, Schema}
 import grackle.syntax._
 
 final class SchemaSuite extends CatsEffectSuite {
@@ -859,6 +859,53 @@ final class SchemaSuite extends CatsEffectSuite {
             "oneOf input object type ExampleInput may not have non-nullable field(s): 'foo', 'baz'"))
       case unexpected => fail(s"This was unexpected: $unexpected")
     }
+  }
+
+  test("bare @deprecated yields the default reason") {
+    val schema = schema"""
+      type Query {
+        old(id: Int @deprecated): Int @deprecated
+      }
+
+      enum Status {
+        GONE @deprecated
+      }
+    """
+
+    val defaultReason = Some(DirectiveDef.DefaultDeprecationReason)
+
+    val field = schema.queryType.fieldInfo("old").get
+    assertEquals(field.isDeprecated, true)
+    assertEquals(field.deprecationReason, defaultReason)
+
+    val arg = field.args.find(_.name == "id").get
+    assertEquals(arg.deprecationReason, defaultReason)
+
+    val status = schema.definition("Status").collect { case e: EnumType => e }.get
+    assertEquals(status.valueDefinition("GONE").get.deprecationReason, defaultReason)
+  }
+
+  test("@deprecated with an explicit reason yields that reason") {
+    val schema = schema"""
+      type Query {
+        old: Int @deprecated(reason: "Use new instead")
+      }
+    """
+
+    val field = schema.queryType.fieldInfo("old").get
+    assertEquals(field.deprecationReason, Some("Use new instead"))
+  }
+
+  test("a field without @deprecated has no deprecation reason") {
+    val schema = schema"""
+      type Query {
+        current: Int
+      }
+    """
+
+    val field = schema.queryType.fieldInfo("current").get
+    assertEquals(field.isDeprecated, false)
+    assertEquals(field.deprecationReason, None)
   }
 
   test("operations on undefined types") {


### PR DESCRIPTION
Reason of `@deprecated` directive should have the default value "No longer supported".
