### PR TITLE
Allow additional optional arguments on interface implementations

### DIFF
--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -2185,6 +2185,10 @@ object SchemaValidator {
   }
 
   def validateImplementations(schema: Schema): List[Problem] = {
+    // https://spec.graphql.org/October2021/#sec-Required-Arguments
+    def isRequired(arg: InputValue): Boolean =
+      !arg.tpe.isNullable && arg.defaultValue.isEmpty
+
     def validateImplementor(impl: TypeWithFields): List[Problem] = {
       import impl.{name, fields, interfaces}
 
@@ -2238,18 +2242,31 @@ object SchemaValidator {
                         s"Field '${implField.name}' of type '$name' has type '${renderType(implTpe)}', however implemented interface '${iface.name}' requires it to be a subtype of '${renderType(ifTpe)}'"))
 
                   val argsMatch =
-                    implField.args.corresponds(ifField.args) {
-                      case (arg0, arg1) =>
-                        arg0.name == arg1.name && arg0.tpe == arg1.tpe
+                    ifField.args.forall { ifArg =>
+                      implField
+                        .args
+                        .exists(implArg =>
+                          implArg.name == ifArg.name && implArg.tpe == ifArg.tpe)
                     }
 
                   val ap =
                     if (argsMatch) Nil
                     else
                       List(Problem(
-                        s"Field '${implField.name}' of type '$name' has has an argument list that does not conform to that specified by implemented interface '${iface.name}'"))
+                        s"Field '${implField.name}' of type '$name' has an argument list that does not conform to that specified by implemented interface '${iface.name}'"))
 
-                  rp ++ ap
+                  // Additional arguments on the implementing field must not be required
+                  // https://spec.graphql.org/October2021/#IsValidImplementation()
+                  val ep =
+                    implField.args.collect {
+                      case implArg
+                          if isRequired(implArg) &&
+                            !ifField.args.exists(_.name == implArg.name) =>
+                        Problem(
+                          s"Field '${implField.name}' of type '$name' has a required argument '${implArg.name}' which is not defined by implemented interface '${iface.name}'")
+                    }
+
+                  rp ++ ap ++ ep
                 }
                 .getOrElse(List(Problem(
                   s"Field '${ifField.name}' from interface '${iface.name}' is not defined by implementing type '$name'")))

--- a/modules/core/src/test/scala/schema/SchemaSuite.scala
+++ b/modules/core/src/test/scala/schema/SchemaSuite.scala
@@ -334,10 +334,174 @@ final class SchemaSuite extends CatsEffectSuite {
         assertEquals(
           ps.map(_.message),
           NonEmptyChain(
-            "Field 'name' of type 'Human' has has an argument list that does not conform to that specified by implemented interface 'Character'"
+            "Field 'name' of type 'Human' has an argument list that does not conform to that specified by implemented interface 'Character'"
           )
         )
       case unexpected => fail(s"This was unexpected: ${unexpected.getClass.getSimpleName}")
+    }
+  }
+
+  test(
+    "schema validation: object implementing interface field with additional nullable argument") {
+    val schema = Schema(
+      """
+        type Query {
+          foo: Int
+        }
+
+        interface Character {
+          name(foo: Int!): String!
+        }
+
+        type Human implements Character {
+          name(foo: Int!, extra: String): String!
+        }
+      """
+    )
+
+    schema match {
+      case Result.Success(s) =>
+        assertEquals(s.types.map(_.name), List("Query", "Character", "Human"))
+      case unexpected => fail(s"This was unexpected: $unexpected")
+    }
+  }
+
+  test(
+    "schema validation: object implementing interface field with additional defaulted argument") {
+    val schema = Schema(
+      """
+        type Query {
+          foo: Int
+        }
+
+        interface Character {
+          name(foo: Int!): String!
+        }
+
+        type Human implements Character {
+          name(foo: Int!, extra: Int! = 3): String!
+        }
+      """
+    )
+
+    schema match {
+      case Result.Success(s) =>
+        assertEquals(s.types.map(_.name), List("Query", "Character", "Human"))
+      case unexpected => fail(s"This was unexpected: $unexpected")
+    }
+  }
+
+  test(
+    "schema validation: object implementing interface field with arguments in a different order") {
+    val schema = Schema(
+      """
+        type Query {
+          foo: Int
+        }
+
+        interface Character {
+          name(foo: Int!, bar: String): String!
+        }
+
+        type Human implements Character {
+          name(bar: String, foo: Int!): String!
+        }
+      """
+    )
+
+    schema match {
+      case Result.Success(s) =>
+        assertEquals(s.types.map(_.name), List("Query", "Character", "Human"))
+      case unexpected => fail(s"This was unexpected: $unexpected")
+    }
+  }
+
+  test(
+    "schema validation: object implementing interface field with additional required argument") {
+    val schema = Schema(
+      """
+        type Query {
+          foo: Int
+        }
+
+        interface Character {
+          name(foo: Int!): String!
+        }
+
+        type Human implements Character {
+          name(foo: Int!, extra: String!): String!
+        }
+      """
+    )
+
+    schema match {
+      case Result.Failure(ps) =>
+        assertEquals(
+          ps.map(_.message),
+          NonEmptyChain(
+            "Field 'name' of type 'Human' has a required argument 'extra' which is not defined by implemented interface 'Character'"
+          )
+        )
+      case unexpected => fail(s"This was unexpected: $unexpected")
+    }
+  }
+
+  test("schema validation: object implementing interface field with a renamed argument") {
+    val schema = Schema(
+      """
+        type Query {
+          foo: Int
+        }
+
+        interface Character {
+          name(foo: Int!): String!
+        }
+
+        type Human implements Character {
+          name(bar: Int!): String!
+        }
+      """
+    )
+
+    schema match {
+      case Result.Failure(ps) =>
+        assertEquals(
+          ps.map(_.message),
+          NonEmptyChain(
+            "Field 'name' of type 'Human' has an argument list that does not conform to that specified by implemented interface 'Character'",
+            "Field 'name' of type 'Human' has a required argument 'bar' which is not defined by implemented interface 'Character'"
+          )
+        )
+      case unexpected => fail(s"This was unexpected: $unexpected")
+    }
+  }
+
+  test("schema validation: object implementing interface field missing an interface argument") {
+    val schema = Schema(
+      """
+        type Query {
+          foo: Int
+        }
+
+        interface Character {
+          name(foo: Int!): String!
+        }
+
+        type Human implements Character {
+          name: String!
+        }
+      """
+    )
+
+    schema match {
+      case Result.Failure(ps) =>
+        assertEquals(
+          ps.map(_.message),
+          NonEmptyChain(
+            "Field 'name' of type 'Human' has an argument list that does not conform to that specified by implemented interface 'Character'"
+          )
+        )
+      case unexpected => fail(s"This was unexpected: $unexpected")
     }
   }
 


### PR DESCRIPTION
Fields on interface implementations can have more arguments, as long as they are default or nullable.
