### PR TITLE
Coerce Int literals to Float in input values

### DIFF
--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -1187,6 +1187,8 @@ object Value {
         value.success
       case (FloatType, Some(value: FloatValue)) =>
         value.success
+      case (FloatType, Some(IntValue(i))) =>
+        FloatValue(i.toDouble).success
       case (StringType, Some(value: StringValue)) =>
         value.success
       case (BooleanType, Some(value: BooleanValue)) =>

--- a/modules/core/src/test/scala/compiler/InputValuesSuite.scala
+++ b/modules/core/src/test/scala/compiler/InputValuesSuite.scala
@@ -221,6 +221,104 @@ final class InputValuesSuite extends CatsEffectSuite {
     assertEquals(compiled.map(_.query), Result.Failure(NonEmptyChain.one(expected)))
   }
 
+  test("an Int literal coerces to a Float") {
+    val query = """
+      query {
+        floatField(arg: 123) {
+          subfield
+        }
+      }
+    """
+
+    val expected =
+      UntypedSelect(
+        "floatField",
+        None,
+        List(Binding("arg", FloatValue(123.0))),
+        Nil,
+        UntypedSelect("subfield", None, Nil, Nil, Empty)
+      )
+
+    val compiled = InputValuesMapping.compiler.compile(query, None)
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+  }
+
+  test("an Int literal coerces to a Float inside a list") {
+    val query = """
+      query {
+        floatListField(arg: [1, 2.5]) {
+          subfield
+        }
+      }
+    """
+
+    val expected =
+      UntypedSelect(
+        "floatListField",
+        None,
+        List(Binding("arg", ListValue(List(FloatValue(1.0), FloatValue(2.5))))),
+        Nil,
+        UntypedSelect("subfield", None, Nil, Nil, Empty)
+      )
+
+    val compiled = InputValuesMapping.compiler.compile(query, None)
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+  }
+
+  test("an Int default coerces to a Float") {
+    val query = """
+      query {
+        defaultedFloatField {
+          subfield
+        }
+      }
+    """
+
+    val expected =
+      UntypedSelect(
+        "defaultedFloatField",
+        None,
+        List(Binding("arg", FloatValue(5.0))),
+        Nil,
+        UntypedSelect("subfield", None, Nil, Nil, Empty)
+      )
+
+    val compiled = InputValuesMapping.compiler.compile(query, None)
+    assertEquals(compiled.map(_.query), Result.Success(expected))
+  }
+
+  test("a Float literal at an Int location is rejected") {
+    val query = """
+      query {
+        field(arg: 1.5) {
+          subfield
+        }
+      }
+    """
+
+    val expected =
+      Problem("Expected Int found '1.5' for 'arg' in field 'field' of type 'Query'")
+
+    val compiled = InputValuesMapping.compiler.compile(query, None)
+    assertEquals(compiled.map(_.query), Result.Failure(NonEmptyChain.one(expected)))
+  }
+
+  test("a String literal at a Float location is rejected") {
+    val query = """
+      query {
+        floatField(arg: "foo") {
+          subfield
+        }
+      }
+    """
+
+    val expected =
+      Problem("Expected Float found '\"foo\"' for 'arg' in field 'floatField' of type 'Query'")
+
+    val compiled = InputValuesMapping.compiler.compile(query, None)
+    assertEquals(compiled.map(_.query), Result.Failure(NonEmptyChain.one(expected)))
+  }
+
   test("single variable value coerces to a list of size one") {
     val query = """
       query ($arg: [String]!) {
@@ -509,6 +607,9 @@ object InputValuesMapping extends TestMapping {
     schema"""
       type Query {
         field(arg: Int): Result!
+        floatField(arg: Float): Result!
+        floatListField(arg: [Float]): Result!
+        defaultedFloatField(arg: Float = 5): Result!
         listField(arg: [String!]!): Result!
         nullableListField(arg: [String]): Result!
         defaultedListField(arg: [String] = "foo"): Result!

--- a/modules/core/src/test/scala/conformance/ValidationValuesSuite.scala
+++ b/modules/core/src/test/scala/conformance/ValidationValuesSuite.scala
@@ -48,9 +48,7 @@ final class ValidationValuesSuite extends ValidationSuite {
     }
   """)
 
-  // Grackle rejects the Int literal `123` at a `Float` location. Section 3.5.2, Float, requires
-  // that coercion.
-  validQuery("an Int literal at a Float location".fail)("""
+  validQuery("an Int literal at a Float location")("""
     query driver {
       arguments { ...coercedIntIntoFloatArg }
     }


### PR DESCRIPTION
`Value.checkValue` matched only `FloatValue` for `FloatType`. Therefore a query such as `floatField(arg: 123)` failed to compile.

The variable path was correct already, because the JSON extractor matches every number. A Float literal at an Int location is still rejected.

Removes 1 `.fail` from the conformance tests.
