### PR TITLE
Run the NULL-ordering and nullable-parent suites on SQLite and H2

### DIFF
--- a/modules/doobie-h2/src/test/scala/DoobieH2Suites.scala
+++ b/modules/doobie-h2/src/test/scala/DoobieH2Suites.scala
@@ -55,6 +55,10 @@ final class CompositeKeySuite extends DoobieH2DatabaseSuite with SqlCompositeKey
   lazy val mapping = new DoobieH2TestMapping(transactor) with SqlCompositeKeyMapping[IO]
 }
 
+final class ErrorKeysSuite extends DoobieH2DatabaseSuite with SqlErrorKeysSuite {
+  lazy val mapping = new DoobieH2TestMapping(transactor) with SqlCompositeKeyMapping[IO]
+}
+
 final class CursorJsonSuite extends DoobieH2DatabaseSuite with SqlCursorJsonSuite {
   lazy val mapping = new DoobieH2TestMapping(transactor) with SqlCursorJsonMapping[IO]
 }
@@ -192,6 +196,14 @@ final class MutationSuite extends DoobieH2DatabaseSuite with SqlMutationSuite {
         } yield id).transact(transactor)
       }
     }
+}
+
+final class NullableParentSuite extends DoobieH2DatabaseSuite with SqlNullableParentSuite {
+  lazy val mapping = new DoobieH2TestMapping(transactor) with SqlNullableParentMapping[IO]
+}
+
+final class NullOrderingSuite extends DoobieH2DatabaseSuite with SqlNullOrderingSuite {
+  lazy val mapping = new DoobieH2TestMapping(transactor) with SqlNullOrderingMapping[IO]
 }
 
 final class NestedEffectsSuite extends DoobieH2DatabaseSuite with SqlNestedEffectsSuite {

--- a/modules/doobie-h2/src/test/scala/DoobieH2Suites.scala
+++ b/modules/doobie-h2/src/test/scala/DoobieH2Suites.scala
@@ -235,6 +235,14 @@ final class ProjectionSuite extends DoobieH2DatabaseSuite with SqlProjectionSuit
   lazy val mapping = new DoobieH2TestMapping(transactor) with SqlProjectionMapping[IO]
 }
 
+final class QualifiedNamesSuite extends DoobieH2DatabaseSuite with SqlQualifiedNamesSuite {
+  lazy val mapping = new DoobieH2TestMapping(transactor) with SqlQualifiedNamesMapping[IO]
+}
+
+final class TableNameSuite extends DoobieH2DatabaseSuite with SqlTableNameSuite {
+  lazy val mapping = new DoobieH2TestMapping(transactor) with SqlQualifiedNamesMapping[IO]
+}
+
 final class RecursiveInterfacesSuite
     extends DoobieH2DatabaseSuite
     with SqlRecursiveInterfacesSuite {
@@ -251,6 +259,10 @@ final class SiblingListsSuite extends DoobieH2DatabaseSuite with SqlSiblingLists
 
 final class TreeSuite extends DoobieH2DatabaseSuite with SqlTreeSuite {
   lazy val mapping = new DoobieH2TestMapping(transactor) with SqlTreeMapping[IO]
+}
+
+final class UnionOrderSuite extends DoobieH2DatabaseSuite with SqlUnionOrderSuite {
+  lazy val mapping = new DoobieH2TestMapping(transactor) with SqlUnionOrderMapping[IO]
 }
 
 final class UnionsSuite extends DoobieH2DatabaseSuite with SqlUnionSuite {

--- a/modules/doobie-sqlite/src/test/scala/DoobieSqliteSuites.scala
+++ b/modules/doobie-sqlite/src/test/scala/DoobieSqliteSuites.scala
@@ -61,6 +61,10 @@ final class CompositeKeySuite extends DoobieSqliteDatabaseSuite with SqlComposit
   lazy val mapping = new DoobieSqliteTestMapping(transactor) with SqlCompositeKeyMapping[IO]
 }
 
+final class ErrorKeysSuite extends DoobieSqliteDatabaseSuite with SqlErrorKeysSuite {
+  lazy val mapping = new DoobieSqliteTestMapping(transactor) with SqlCompositeKeyMapping[IO]
+}
+
 final class CursorJsonSuite extends DoobieSqliteDatabaseSuite with SqlCursorJsonSuite {
   lazy val mapping = new DoobieSqliteTestMapping(transactor) with SqlCursorJsonMapping[IO]
 }
@@ -193,6 +197,14 @@ final class MutationSuite extends DoobieSqliteDatabaseSuite with SqlMutationSuit
           RETURNING id
           """.query[Int].unique.transact(transactor)
     }
+}
+
+final class NullableParentSuite extends DoobieSqliteDatabaseSuite with SqlNullableParentSuite {
+  lazy val mapping = new DoobieSqliteTestMapping(transactor) with SqlNullableParentMapping[IO]
+}
+
+final class NullOrderingSuite extends DoobieSqliteDatabaseSuite with SqlNullOrderingSuite {
+  lazy val mapping = new DoobieSqliteTestMapping(transactor) with SqlNullOrderingMapping[IO]
 }
 
 final class NestedEffectsSuite extends DoobieSqliteDatabaseSuite with SqlNestedEffectsSuite {

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -57,5 +57,5 @@ only runs its init scripts on a first start, so an existing container will not p
 - `qualified-names` exists for Postgres only, because it tests schema-qualified names (`CREATE SCHEMA qualified;`).
   One dialect means no duplication to remove.
 
-`qualified-names` and `union-order` have neither a `sqlite.sql` nor an `h2.sql`, so those two skip them. Both put
-their tables in a schema, and SQLite has nothing to create one with.
+`qualified-names` and `union-order` have no `sqlite.sql`, so SQLite skips them. Both put their tables in a schema,
+and SQLite has nothing to create one with.

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -57,5 +57,5 @@ only runs its init scripts on a first start, so an existing container will not p
 - `qualified-names` exists for Postgres only, because it tests schema-qualified names (`CREATE SCHEMA qualified;`).
   One dialect means no duplication to remove.
 
-`null-ordering`, `nullable-parent`, `qualified-names` and `union-order` have neither a `sqlite.sql` nor an
-`h2.sql`, so those two skip them.
+`qualified-names` and `union-order` have neither a `sqlite.sql` nor an `h2.sql`, so those two skip them. Both put
+their tables in a schema, and SQLite has nothing to create one with.

--- a/testdata/null-ordering/h2.sql
+++ b/testdata/null-ordering/h2.sql
@@ -1,0 +1,4 @@
+CREATE TABLE null_ordering (
+  id INTEGER PRIMARY KEY,
+  v INTEGER
+);

--- a/testdata/null-ordering/sqlite.sql
+++ b/testdata/null-ordering/sqlite.sql
@@ -1,0 +1,4 @@
+CREATE TABLE null_ordering (
+  id INTEGER PRIMARY KEY,
+  v INTEGER
+);

--- a/testdata/nullable-parent/h2.sql
+++ b/testdata/nullable-parent/h2.sql
@@ -1,0 +1,34 @@
+CREATE TABLE nullable_parent_c (
+  id INTEGER PRIMARY KEY,
+  name VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE nullable_parent_b (
+  id INTEGER PRIMARY KEY,
+  c_id INTEGER NOT NULL,
+  name VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE nullable_parent_a (
+  id INTEGER PRIMARY KEY,
+  b_id INTEGER,
+  name VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE nullable_parent_f (
+  id INTEGER PRIMARY KEY,
+  name VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE nullable_parent_e (
+  id INTEGER PRIMARY KEY,
+  d_id INTEGER NOT NULL,
+  f_id INTEGER NOT NULL,
+  other_d_id INTEGER NOT NULL,
+  name VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE nullable_parent_d (
+  id INTEGER PRIMARY KEY,
+  name VARCHAR(64) NOT NULL
+);

--- a/testdata/nullable-parent/sqlite.sql
+++ b/testdata/nullable-parent/sqlite.sql
@@ -1,0 +1,34 @@
+CREATE TABLE nullable_parent_c (
+  id INTEGER PRIMARY KEY,
+  name VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE nullable_parent_b (
+  id INTEGER PRIMARY KEY,
+  c_id INTEGER NOT NULL,
+  name VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE nullable_parent_a (
+  id INTEGER PRIMARY KEY,
+  b_id INTEGER,
+  name VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE nullable_parent_f (
+  id INTEGER PRIMARY KEY,
+  name VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE nullable_parent_e (
+  id INTEGER PRIMARY KEY,
+  d_id INTEGER NOT NULL,
+  f_id INTEGER NOT NULL,
+  other_d_id INTEGER NOT NULL,
+  name VARCHAR(64) NOT NULL
+);
+
+CREATE TABLE nullable_parent_d (
+  id INTEGER PRIMARY KEY,
+  name VARCHAR(64) NOT NULL
+);

--- a/testdata/qualified-names/h2.sql
+++ b/testdata/qualified-names/h2.sql
@@ -1,0 +1,43 @@
+CREATE SCHEMA qualified;
+
+CREATE TABLE qualified.country (
+    code CHAR(3) NOT NULL PRIMARY KEY,
+    name VARCHAR NOT NULL
+);
+
+CREATE TABLE qualified.city (
+    id INTEGER NOT NULL PRIMARY KEY,
+    countrycode CHAR(3) NOT NULL,
+    name VARCHAR NOT NULL
+);
+
+CREATE TABLE qualified.speaks (
+    countrycode CHAR(3) NOT NULL,
+    lang VARCHAR NOT NULL,
+    PRIMARY KEY (countrycode, lang)
+);
+
+-- Deliberately named so that folding the qualifier of qualified.country with an underscore
+-- yields this table's name: pins that synthesized aliases and real tables can coexist.
+CREATE TABLE qualified_country (
+    code CHAR(3) NOT NULL PRIMARY KEY,
+    motto VARCHAR NOT NULL
+);
+
+INSERT INTO qualified.country (code, name) VALUES
+('CAN', 'Canada'),
+('DEU', 'Germany');
+
+INSERT INTO qualified.city (id, countrycode, name) VALUES
+(1, 'CAN', 'Toronto'),
+(2, 'CAN', 'Ottawa'),
+(3, 'DEU', 'Berlin');
+
+INSERT INTO qualified.speaks (countrycode, lang) VALUES
+('CAN', 'English'),
+('CAN', 'French'),
+('DEU', 'German');
+
+INSERT INTO qualified_country (code, motto) VALUES
+('CAN', 'A mari usque ad mare'),
+('DEU', 'Einigkeit und Recht und Freiheit');

--- a/testdata/union-order/h2.sql
+++ b/testdata/union-order/h2.sql
@@ -1,0 +1,6 @@
+-- schema `qualified` is created by qualified-names.sql, which loads first
+CREATE TABLE qualified.union_order_entities (
+    id VARCHAR NOT NULL PRIMARY KEY,
+    entity_type VARCHAR NOT NULL,
+    name VARCHAR NOT NULL
+);


### PR DESCRIPTION
Runs the shared suites that SQLite and H2 were not running. SQLite goes from 245 to 256 tests, H2 from 245 to 270, which is parity with Postgres. All green.

## How the gap happened

Each backend once had its own `Doobie<Db>NullOrderingSuite`. In July all of them were deleted as "superseded by the shared SqlNullOrderingMapping/SqlNullOrderingSuite ... This branch will pick that up once it rebases past #870's merge". #870 merged, and the branches did rebase, but that alone wires nothing: the suite has to be named in each backend's `Doobie*Suites.scala`, and `testdata/null-ordering/` needs a schema for the dialect. Neither happened, so NULL ordering has been untested on exactly the backends that hand-roll a `CASE WHEN ... IS NULL` sort prefix to emulate it.

The suites pass unchanged, so no dialect bug was hiding behind this.

## What each one gets

Both get `SqlNullOrderingSuite`, `SqlNullableParentSuite` and `SqlErrorKeysSuite`. The first two need a schema file per dialect; the third reuses the composite-keys dataset and only ever needed wiring.

H2 additionally gets `SqlQualifiedNamesSuite`, `SqlTableNameSuite` and `SqlUnionOrderSuite`, which put their tables in a schema. H2 has `CREATE SCHEMA`; SQLite has nothing to create one with, so it still skips those two datasets.

MySQL (#872) and MariaDB (#873) have the same gap and pick this up when they rebase.
