### PR TITLE
Add description support for operations, fragments, variables and schemas

### DIFF
--- a/modules/core/src/main/scala/ast.scala
+++ b/modules/core/src/main/scala/ast.scala
@@ -48,7 +48,8 @@ object Ast {
         name: Option[Name],
         variables: List[VariableDefinition],
         directives: List[Directive],
-        selectionSet: List[Selection]
+        selectionSet: List[Selection],
+        description: Option[String] = None
     ) extends OperationDefinition
 
   }
@@ -85,14 +86,16 @@ object Ast {
       name: Name,
       typeCondition: Type,
       directives: List[Directive],
-      selectionSet: List[Selection]
+      selectionSet: List[Selection],
+      description: Option[String] = None
   ) extends ExecutableDefinition
 
   case class VariableDefinition(
       name: Name,
       tpe: Type,
       defaultValue: Option[Value],
-      directives: List[Directive]
+      directives: List[Directive],
+      description: Option[String] = None
   )
 
   sealed trait Value
@@ -116,6 +119,7 @@ object Ast {
   }
 
   case class SchemaDefinition(
+      description: Option[String],
       rootOperationTypes: List[RootOperationTypeDefinition],
       directives: List[Directive]
   ) extends TypeSystemDefinition

--- a/modules/core/src/main/scala/compiler.scala
+++ b/modules/core/src/main/scala/compiler.scala
@@ -103,7 +103,7 @@ object QueryParser {
      * GraphQL errors and warnings are accumulated in the result.
      */
     def parseOperation(op: Operation): Result[UntypedOperation] = {
-      val Operation(opType, name, vds, dirs0, sels) = op
+      val Operation(opType, name, vds, dirs0, sels, _) = op
       for {
         vs <- parseVariableDefinitions(vds)
         q <- parseSelections(sels)
@@ -125,7 +125,7 @@ object QueryParser {
      */
     def parseVariableDefinitions(vds: List[VariableDefinition]): Result[List[UntypedVarDef]] =
       vds.traverse {
-        case VariableDefinition(Name(nme), tpe, dv0, dirs0) =>
+        case VariableDefinition(Name(nme), tpe, dv0, dirs0, _) =>
           for {
             dv <- dv0.traverse(Value.fromAst)
             dirs <- parseDirectives(dirs0)

--- a/modules/core/src/main/scala/introspection.scala
+++ b/modules/core/src/main/scala/introspection.scala
@@ -30,6 +30,7 @@ object Introspection {
         }
 
         type __Schema {
+          description: String
           types: [__Type!]!
           queryType: __Type!
           mutationType: __Type
@@ -203,6 +204,7 @@ object Introspection {
           ValueField("__type", _ => allTypes.map(_.nullable))
         ),
         ValueObjectMapping(__SchemaType).on[Schema](
+          ValueField("description", _.description),
           ValueField("types", _ => allTypes.map(_.nullable)),
           ValueField("queryType", _.queryType.dealias.nullable),
           ValueField("mutationType", _.mutationType.map(_.dealias.nullable)),

--- a/modules/core/src/main/scala/minimizer.scala
+++ b/modules/core/src/main/scala/minimizer.scala
@@ -35,6 +35,7 @@ object QueryMinimizer {
     def minimizeDocument(doc: Document): String = {
       import OperationDefinition._
       import OperationType._
+      import SchemaRenderer.renderDescription
       import Selection._
       import Value._
 
@@ -57,7 +58,8 @@ object QueryMinimizer {
         }
 
       def renderOperation(op: Operation): String =
-        renderOperationType(op.operationType) +
+        renderDescription(op.description) +
+          renderOperationType(op.operationType) +
           op.name.map(nme => s" ${nme.value}").getOrElse("") +
           renderVariableDefns(op.variables) +
           renderDirectives(op.directives) +
@@ -81,8 +83,8 @@ object QueryMinimizer {
           case _ =>
             vars
               .map {
-                case VariableDefinition(name, tpe, default, dirs) =>
-                  s"$$${name.value}:${tpe.name}${default.map(v => s"=${renderValue(v)}").getOrElse("")}${renderDirectives(dirs)}"
+                case VariableDefinition(name, tpe, default, dirs, desc) =>
+                  s"${renderDescription(desc)}$$${name.value}:${tpe.name}${default.map(v => s"=${renderValue(v)}").getOrElse("")}${renderDirectives(dirs)}"
               }
               .mkString("(", ",", ")")
         }
@@ -126,7 +128,7 @@ object QueryMinimizer {
         s"on ${tpe.name}"
 
       def renderFragmentDefinition(frag: FragmentDefinition): String =
-        s"fragment ${frag.name.value} ${renderTypeCondition(frag.typeCondition)}${renderDirectives(frag.directives)}${renderSelectionSet(frag.selectionSet)}"
+        s"${renderDescription(frag.description)}fragment ${frag.name.value} ${renderTypeCondition(frag.typeCondition)}${renderDirectives(frag.directives)}${renderSelectionSet(frag.selectionSet)}"
 
       def renderFragmentSpread(spread: FragmentSpread): String =
         s"...${spread.name.value}${renderDirectives(spread.directives)}"

--- a/modules/core/src/main/scala/parser.scala
+++ b/modules/core/src/main/scala/parser.scala
@@ -76,99 +76,95 @@ object GraphQLParser {
       (whitespace.void | comment).rep0 *> Definition.rep0 <* Parser.end
 
     lazy val Definition: Parser[Ast.Definition] =
-      ExecutableDefinition | TypeSystemDefinition | TypeSystemExtension
-
-    lazy val TypeSystemDefinition: Parser[Ast.TypeSystemDefinition] = {
-      val SchemaDefinition: Parser[Ast.SchemaDefinition] =
-        ((keyword("schema") *> Directives.?) ~ braces(RootOperationTypeDefinition.rep0)).map {
-          case (dirs, rootdefs) => Ast.SchemaDefinition(rootdefs, dirs.getOrElse(Nil))
+      QueryShorthand | TypeSystemExtension |
+        (Description.?.with1 ~ DescribedDefinition).map {
+          case (desc, mk) => mk(desc.map(_.value))
         }
 
-      def typeDefinition(desc: Option[Ast.Value.StringValue]): Parser[Ast.TypeDefinition] = {
+    lazy val DescribedDefinition: Parser[Option[String] => Ast.Definition] =
+      operation | fragmentDefinition | typeSystemDefinition
 
-        def scalarTypeDefinition(
-            desc: Option[Ast.Value.StringValue]): Parser[Ast.ScalarTypeDefinition] =
+    lazy val typeSystemDefinition: Parser[Option[String] => Ast.TypeSystemDefinition] = {
+
+      val schemaDefinition: Parser[Option[String] => Ast.SchemaDefinition] =
+        ((keyword("schema") *> Directives.?) ~ braces(RootOperationTypeDefinition.rep0)).map {
+          case (dirs, rootdefs) =>
+            Ast.SchemaDefinition(_, rootdefs, dirs.getOrElse(Nil))
+        }
+
+      val typeDefinition: Parser[Option[String] => Ast.TypeDefinition] = {
+
+        val scalarTypeDefinition: Parser[Option[String] => Ast.ScalarTypeDefinition] =
           ((keyword("scalar") *> Name) ~ Directives.?).map {
             case (name, dirs) =>
-              Ast.ScalarTypeDefinition(name, desc.map(_.value), dirs.getOrElse(Nil))
+              Ast.ScalarTypeDefinition(name, _, dirs.getOrElse(Nil))
           }
 
-        def objectTypeDefinition(
-            desc: Option[Ast.Value.StringValue]): Parser[Ast.ObjectTypeDefinition] =
+        val objectTypeDefinition: Parser[Option[String] => Ast.ObjectTypeDefinition] =
           ((keyword("type") *> Name) ~ ImplementsInterfaces.? ~ Directives.? ~ FieldsDefinition)
             .map {
               case (((name, ifs), dirs), fields) =>
                 Ast.ObjectTypeDefinition(
                   name,
-                  desc.map(_.value),
+                  _,
                   fields,
                   ifs.getOrElse(Nil),
                   dirs.getOrElse(Nil))
             }
 
-        def interfaceTypeDefinition(
-            desc: Option[Ast.Value.StringValue]): Parser[Ast.InterfaceTypeDefinition] =
+        val interfaceTypeDefinition: Parser[Option[String] => Ast.InterfaceTypeDefinition] =
           ((keyword(
             "interface") *> Name) ~ ImplementsInterfaces.? ~ Directives.? ~ FieldsDefinition)
             .map {
               case (((name, ifs), dirs), fields) =>
                 Ast.InterfaceTypeDefinition(
                   name,
-                  desc.map(_.value),
+                  _,
                   fields,
                   ifs.getOrElse(Nil),
                   dirs.getOrElse(Nil))
             }
 
-        def unionTypeDefinition(
-            desc: Option[Ast.Value.StringValue]): Parser[Ast.UnionTypeDefinition] =
+        val unionTypeDefinition: Parser[Option[String] => Ast.UnionTypeDefinition] =
           ((keyword("union") *> Name) ~ Directives.? ~ UnionMemberTypes).map {
             case ((name, dirs), members) =>
-              Ast.UnionTypeDefinition(name, desc.map(_.value), dirs.getOrElse(Nil), members)
+              Ast.UnionTypeDefinition(name, _, dirs.getOrElse(Nil), members)
           }
 
-        def enumTypeDefinition(
-            desc: Option[Ast.Value.StringValue]): Parser[Ast.EnumTypeDefinition] =
+        val enumTypeDefinition: Parser[Option[String] => Ast.EnumTypeDefinition] =
           ((keyword("enum") *> Name) ~ Directives.? ~ EnumValuesDefinition).map {
             case ((name, dirs), values) =>
-              Ast.EnumTypeDefinition(name, desc.map(_.value), dirs.getOrElse(Nil), values)
+              Ast.EnumTypeDefinition(name, _, dirs.getOrElse(Nil), values)
           }
 
-        def inputObjectTypeDefinition(
-            desc: Option[Ast.Value.StringValue]): Parser[Ast.InputObjectTypeDefinition] =
+        val inputObjectTypeDefinition: Parser[Option[String] => Ast.InputObjectTypeDefinition] =
           ((keyword("input") *> Name) ~ Directives.? ~ InputFieldsDefinition).map {
             case ((name, dirs), fields) =>
               Ast.InputObjectTypeDefinition(
                 name,
-                desc.map(_.value),
+                _,
                 fields,
-                dirs.getOrElse(Nil))
+                dirs.getOrElse(Nil)
+              )
           }
 
-        scalarTypeDefinition(desc) |
-          objectTypeDefinition(desc) |
-          interfaceTypeDefinition(desc) |
-          unionTypeDefinition(desc) |
-          enumTypeDefinition(desc) |
-          inputObjectTypeDefinition(desc)
+        scalarTypeDefinition |
+          objectTypeDefinition |
+          interfaceTypeDefinition |
+          unionTypeDefinition |
+          enumTypeDefinition |
+          inputObjectTypeDefinition
       }
 
-      def directiveDefinition(
-          desc: Option[Ast.Value.StringValue]): Parser[Ast.DirectiveDefinition] =
+      val directiveDefinition: Parser[Option[String] => Ast.DirectiveDefinition] =
         ((keyword("directive") *> punctuation("@") *> Name) ~
           ArgumentsDefinition.? ~ (keyword("repeatable").? <* keyword(
             "on")) ~ DirectiveLocations).map {
           case (((name, args), rpt), locs) =>
-            Ast.DirectiveDefinition(
-              name,
-              desc.map(_.value),
-              args.getOrElse(Nil),
-              rpt.isDefined,
-              locs)
+            Ast.DirectiveDefinition(name, _, args.getOrElse(Nil), rpt.isDefined, locs)
         }
 
-      SchemaDefinition |
-        Description.?.with1.flatMap { desc => typeDefinition(desc) | directiveDefinition(desc) }
+      schemaDefinition | typeDefinition | directiveDefinition
     }
 
     lazy val TypeSystemExtension: Parser[Ast.TypeSystemExtension] = {
@@ -313,19 +309,13 @@ object GraphQLParser {
         keyword("INPUT_OBJECT").as(Ast.DirectiveLocation.INPUT_OBJECT) |
         keyword("INPUT_FIELD_DEFINITION").as(Ast.DirectiveLocation.INPUT_FIELD_DEFINITION)
 
-    lazy val ExecutableDefinition: Parser[Ast.ExecutableDefinition] =
-      OperationDefinition | FragmentDefinition
-
-    lazy val OperationDefinition: Parser[Ast.OperationDefinition] =
-      QueryShorthand | Operation
-
     lazy val QueryShorthand: Parser[Ast.OperationDefinition.QueryShorthand] =
       SelectionSet.map(Ast.OperationDefinition.QueryShorthand.apply)
 
-    lazy val Operation: Parser[Ast.OperationDefinition.Operation] =
+    lazy val operation: Parser[Option[String] => Ast.OperationDefinition.Operation] =
       (OperationType ~ Name.? ~ VariableDefinitions.? ~ Directives ~ SelectionSet).map {
         case ((((op, name), vars), dirs), sels) =>
-          Ast.OperationDefinition.Operation(op, name, vars.orEmpty, dirs, sels)
+          Ast.OperationDefinition.Operation(op, name, vars.orEmpty, dirs, sels, _)
       }
 
     lazy val OperationType: Parser[Ast.OperationType] =
@@ -373,9 +363,10 @@ object GraphQLParser {
     lazy val FragmentName: Parser[Ast.Name] =
       not(string("on") <* not(charIn(nameSubsequent))).with1 *> Name
 
-    lazy val FragmentDefinition: Parser[Ast.FragmentDefinition] =
+    lazy val fragmentDefinition: Parser[Option[String] => Ast.FragmentDefinition] =
       ((keyword("fragment") *> FragmentName) ~ TypeCondition ~ Directives ~ SelectionSet).map {
-        case (((name, cond), dirs), sel) => Ast.FragmentDefinition(name, cond, dirs, sel)
+        case (((name, cond), dirs), sel) =>
+          Ast.FragmentDefinition(name, cond, dirs, sel, _)
       }
 
     lazy val TypeCondition: Parser[Ast.Type.Named] =
@@ -444,9 +435,10 @@ object GraphQLParser {
       parens(VariableDefinition.rep0)
 
     lazy val VariableDefinition: Parser[Ast.VariableDefinition] =
-      ((Variable <* punctuation(":")) ~ Type ~ DefaultValue.? ~ Directives.?).map {
-        case (((v, tpe), dv), dirs) =>
-          Ast.VariableDefinition(v.name, tpe, dv, dirs.getOrElse(Nil))
+      (Description.?.with1 ~ (Variable <* punctuation(
+        ":")) ~ Type ~ DefaultValue.? ~ Directives.?).map {
+        case ((((desc, v), tpe), dv), dirs) =>
+          Ast.VariableDefinition(v.name, tpe, dv, dirs.getOrElse(Nil), desc.map(_.value))
       }
 
     lazy val Variable: Parser[Ast.Value.Variable] =

--- a/modules/core/src/main/scala/schema.scala
+++ b/modules/core/src/main/scala/schema.scala
@@ -175,6 +175,11 @@ trait Schema {
     else extendSchemaType(schemaExtensions, baseSchemaType)
 
   /**
+   * The description of this `Schema`, if any
+   */
+  def description: Option[String] = schemaType.description
+
+  /**
    * The type of queries defined by this `Schema`
    */
   def queryType: NamedType = schemaType.field("query").flatMap(_.nonNull.asNamed).get
@@ -1775,13 +1780,13 @@ object SchemaParser {
 
     // explicit Schema type, if any
     def mkSchemaType(schema: Schema, doc: Document): Result[Option[NamedType]] = {
-      def build(dirs: List[Directive], ops: List[Field]): NamedType = {
+      def build(desc: Option[String], dirs: List[Directive], ops: List[Field]): NamedType = {
         val query = ops
           .find(_.name == "query")
           .getOrElse(Field("query", None, Nil, defaultQueryType, Nil))
         ObjectType(
           name = "Schema",
-          description = None,
+          description = desc,
           fields = query :: List(
             ops.find(_.name == "mutation"),
             ops.find(_.name == "subscription")).flatten,
@@ -1795,11 +1800,11 @@ object SchemaParser {
       val defns = doc.collect { case schema: SchemaDefinition => schema }
       defns match {
         case Nil => None.success
-        case SchemaDefinition(rootOpTpes, dirs0) :: Nil =>
+        case SchemaDefinition(desc, rootOpTpes, dirs0) :: Nil =>
           for {
             ops <- rootOpTpes.traverse(mkRootOperation(schema))
             dirs <- dirs0.traverse(Directive.fromAst)
-          } yield Some(build(dirs, ops))
+          } yield Some(build(desc, dirs, ops))
 
         case _ => Result.failure("At most one schema definition permitted")
       }
@@ -2350,11 +2355,13 @@ object SchemaValidator {
 object SchemaRenderer {
   def renderSchema(schema: Schema): String = {
     val schemaDefn = {
+      val desc = schema.baseSchemaType.description
       val dirs0 = schema.baseSchemaType.directives
       if (schema.queryType.name == "Query" &&
         schema.mutationType.forall(_.name == "Mutation") &&
         schema.subscriptionType.forall(_.name == "Subscription") &&
-        dirs0.isEmpty) ""
+        dirs0.isEmpty &&
+        desc.forall(_.isEmpty)) ""
       else {
         val fields =
           schema.baseSchemaType match {
@@ -2363,7 +2370,7 @@ object SchemaRenderer {
           }
 
         val dirs = renderDirectives(dirs0)
-        s"schema$dirs {\n${renderMembers(fields)(renderField)}\n}\n"
+        s"${renderDescription(desc)}schema$dirs {\n${renderMembers(fields)(renderField)}\n}\n"
       }
     }
 

--- a/modules/core/src/test/scala/conformance/LanguageSuite.scala
+++ b/modules/core/src/test/scala/conformance/LanguageSuite.scala
@@ -52,7 +52,7 @@ final class LanguageSuite extends ConformanceSuite {
   // 2.2 Descriptions
   // https://spec.graphql.org/September2025/#sec-Descriptions
 
-  parses("an operation, a variable and a fragment can carry a description".fail)("""
+  parses("an operation, a variable and a fragment can carry a description")("""
     '''
     Request the current status of a time machine and its operator.
     You can also check the status for a particular year.
@@ -85,7 +85,7 @@ final class LanguageSuite extends ConformanceSuite {
   // 2.4 Operations
   // https://spec.graphql.org/September2025/#sec-Language.Operations
 
-  parses("a mutation operation can carry a description".fail)("""
+  parses("a mutation operation can carry a description")("""
     '''
     Mark story 12345 as "liked"
     and return the updated number of likes on the story
@@ -253,7 +253,7 @@ final class LanguageSuite extends ConformanceSuite {
     }
   """)
 
-  parses("a fragment factors out a repeated selection set".fail)("""
+  parses("a fragment factors out a repeated selection set")("""
     query withFragments {
       user(id: 4) {
         friends(first: 10) {
@@ -420,7 +420,7 @@ final class LanguageSuite extends ConformanceSuite {
   // 2.11 Variables
   // https://spec.graphql.org/September2025/#sec-Language.Variables
 
-  parses("a variable definition can carry a description".fail)("""
+  parses("a variable definition can carry a description")("""
     query getZuckProfile(
       "The size of the profile picture to fetch."
       $devicePicSize: Int
@@ -433,14 +433,14 @@ final class LanguageSuite extends ConformanceSuite {
     }
   """)
 
-  // The specification states the variable values `{"devicePicSize": 60}` for the example above.
-  // This test case supplies those values. It drops the description of the variable definition,
-  // because the parser rejects it, which the test case above records.
   yields(
     "a request supplies a value for the variable of an operation",
     Site,
     json"""{"devicePicSize": 60}""")("""
-    query getZuckProfile($devicePicSize: Int) {
+    query getZuckProfile(
+      "The size of the profile picture to fetch."
+      $devicePicSize: Int
+    ) {
       user(id: 4) {
         id
         name

--- a/modules/core/src/test/scala/conformance/TypeSystemSuite.scala
+++ b/modules/core/src/test/scala/conformance/TypeSystemSuite.scala
@@ -34,7 +34,7 @@ final class TypeSystemSuite extends ConformanceSuite {
   // 3.2 Type System Descriptions
   // https://spec.graphql.org/September2025/#sec-Descriptions
 
-  validSchema("every definition of a schema can carry a description".fail)("""
+  validSchema("every definition of a schema can carry a description")("""
     '''
     A simple GraphQL schema which is well described.
     '''
@@ -141,7 +141,7 @@ final class TypeSystemSuite extends ConformanceSuite {
     }
   """)
 
-  validSchema("a schema definition can carry a description".fail)("""
+  validSchema("a schema definition can carry a description")("""
     '''
     Example schema
     '''

--- a/modules/core/src/test/scala/introspection/IntrospectionSuite.scala
+++ b/modules/core/src/test/scala/introspection/IntrospectionSuite.scala
@@ -1201,6 +1201,54 @@ final class IntrospectionSuite extends CatsEffectSuite {
     assertIO(res, expected)
   }
 
+  test("schema description query") {
+    val query = """
+      {
+        __schema {
+          description
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "__schema" : {
+            "description" : "A schema which introspection can describe"
+          }
+        }
+      }
+    """
+
+    val res = DescribedMapping.compileAndRun(query)
+
+    assertIO(res, expected)
+  }
+
+  test("schema description query yields null without a description") {
+    val query = """
+      {
+        __schema {
+          description
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "data" : {
+          "__schema" : {
+            "description" : null
+          }
+        }
+      }
+    """
+
+    val res = TestMapping.compileAndRun(query)
+
+    assertIO(res, expected)
+  }
+
   test("standard introspection query") {
     val query = """
                   |query IntrospectionQuery {
@@ -2178,6 +2226,31 @@ object BareDeprecationMapping extends ValueMapping[IO] {
         fieldMappings = List(
           ValueField("id", _.id),
           ValueField("name", _.name)
+        )
+      )
+    )
+}
+
+object DescribedMapping extends ValueMapping[IO] {
+  val schema =
+    schema"""
+      "A schema which introspection can describe"
+      schema {
+        query: Query
+      }
+      type Query {
+        foo: Int
+      }
+    """
+
+  val QueryType = schema.queryType
+
+  val typeMappings =
+    List(
+      ObjectMapping(
+        tpe = QueryType,
+        fieldMappings = List(
+          ValueField.fromValue("foo", 0)
         )
       )
     )

--- a/modules/core/src/test/scala/minimizer/MinimizerSuite.scala
+++ b/modules/core/src/test/scala/minimizer/MinimizerSuite.scala
@@ -663,4 +663,38 @@ final class MinimizerSuite extends CatsEffectSuite {
 
     run(query, expected)
   }
+
+  test("minimize descriptions") {
+    val query = """
+      "Fetch a character"
+      query Character(
+        "the id to fetch"
+        $id: Int
+      ) {
+        character(id: $id) {
+          ...Name
+        }
+      }
+      "the name fields"
+      fragment Name on Character {
+        name
+      }
+    """
+
+    val expected =
+      """|"Fetch a character"
+         |query Character("the id to fetch"
+         |$id:Int){character(id:$id){...Name}},"the name fields"
+         |fragment Name on Character{name}""".stripMargin
+
+    run(query, expected)
+  }
+
+  test("minimize block string description") {
+    val query = "\"\"\"\nA \"character\".\n\nWith a \\ backslash.\n\"\"\" query Foo { x }"
+
+    val expected = "\"\"\"\nA \"character\".\n\nWith a \\ backslash.\n\"\"\"\nquery Foo{x}"
+
+    run(query, expected)
+  }
 }

--- a/modules/core/src/test/scala/parser/ParserSuite.scala
+++ b/modules/core/src/test/scala/parser/ParserSuite.scala
@@ -709,7 +709,7 @@ final class ParserSuite extends CatsEffectSuite {
 
     def assertParse(input: String, expected: Value) =
       parser.parseText(s"query { foo(bar: $input) }").toOption match {
-        case Some(List(Operation(_, _, _, _, List(Field(_, _, List((_, v)), _, _))))) =>
+        case Some(List(Operation(_, _, _, _, List(Field(_, _, List((_, v)), _, _)), _))) =>
           assertEquals(v, expected)
         case _ => assert(false)
       }
@@ -1057,6 +1057,88 @@ final class ParserSuite extends CatsEffectSuite {
             Nil)))
 
     assertEquals(parser.parseText(query), Result(List(expected)))
+  }
+
+  test("anonymous operation with block string description") {
+    val query = "\"\"\"Like a story\"\"\" mutation { likeStory }"
+
+    val expected =
+      Operation(
+        Mutation,
+        None,
+        Nil,
+        Nil,
+        List(Field(None, Name("likeStory"), Nil, Nil, Nil)),
+        Some("Like a story"))
+
+    assertEquals(parser.parseText(query), Result(List(expected)))
+  }
+
+  test("operation and variable definition with descriptions") {
+    val query = """
+      "Fetch x"
+      query Foo(
+        "the id to fetch"
+        $id: Int
+      ) {
+        x
+      }
+    """
+
+    val expected =
+      Operation(
+        Query,
+        Some(Name("Foo")),
+        List(
+          VariableDefinition(
+            Name("id"),
+            Named(Name("Int")),
+            None,
+            Nil,
+            Some("the id to fetch"))),
+        Nil,
+        List(Field(None, Name("x"), Nil, Nil, Nil)),
+        Some("Fetch x")
+      )
+
+    assertEquals(parser.parseText(query), Result(List(expected)))
+  }
+
+  test("fragment definition with description") {
+    val query = """
+      query { x { ...frag } }
+      "shared fields"
+      fragment frag on X { name }
+    """
+
+    val expected =
+      List(
+        Operation(
+          Query,
+          None,
+          Nil,
+          Nil,
+          List(Field(None, Name("x"), Nil, Nil, List(FragmentSpread(Name("frag"), Nil))))),
+        FragmentDefinition(
+          Name("frag"),
+          Named(Name("X")),
+          Nil,
+          List(Field(None, Name("name"), Nil, Nil, Nil)),
+          Some("shared fields"))
+      )
+
+    assertEquals(parser.parseText(query), Result(expected))
+  }
+
+  test("query shorthand cannot carry a description") {
+    assert(parser.parseText("\"desc\" { x }").hasValue == false)
+  }
+
+  test("description before a type definition still parses") {
+    val expected =
+      ScalarTypeDefinition(Name("Foo"), Some("A scalar"), Nil)
+
+    assertEquals(parser.parseText("\"A scalar\" scalar Foo"), Result(List(expected)))
   }
 
   def mkParser(

--- a/modules/core/src/test/scala/sdl/SDLSuite.scala
+++ b/modules/core/src/test/scala/sdl/SDLSuite.scala
@@ -41,11 +41,34 @@ final class SDLSuite extends CatsEffectSuite {
     val expected =
       List(
         SchemaDefinition(
+          None,
           List(
             RootOperationTypeDefinition(Query, Named(Name("MyQuery")), Nil),
             RootOperationTypeDefinition(Mutation, Named(Name("MyMutation")), Nil),
             RootOperationTypeDefinition(Subscription, Named(Name("MySubscription")), Nil)
           ),
+          Nil
+        )
+      )
+
+    val res = parser.parseText(schema)
+
+    assertEquals(res, expected.success)
+  }
+
+  test("parse schema definition with description") {
+    val schema = """
+      "A described schema"
+      schema {
+        query: MyQuery
+      }
+    """
+
+    val expected =
+      List(
+        SchemaDefinition(
+          Some("A described schema"),
+          List(RootOperationTypeDefinition(Query, Named(Name("MyQuery")), Nil)),
           Nil
         )
       )
@@ -508,6 +531,34 @@ final class SDLSuite extends CatsEffectSuite {
     val ser = res.map(_.toString)
 
     assertEquals(ser, schema.success)
+  }
+
+  test("deserialize schema with a schema description") {
+    val schema =
+      """|"The schema"
+         |schema {
+         |  query: Query
+         |}
+         |type Query {
+         |  foo: Int
+         |}""".stripMargin
+
+    val res = schemaParser.parseText(schema)
+
+    assertEquals(res.map(_.description), Some("The schema").success)
+    assertEquals(res.map(_.toString), schema.success)
+  }
+
+  test("a schema without a schema description has none") {
+    val schema =
+      """|type Query {
+         |  foo: Int
+         |}""".stripMargin
+
+    val res = schemaParser.parseText(schema)
+
+    assertEquals(res.map(_.description), Option.empty[String].success)
+    assertEquals(res.map(_.toString), schema.success)
   }
 
   test("deserialize schema with described directive arguments") {


### PR DESCRIPTION
The September 2025 GraphQL specification allows descriptions on every definition.

Adds description support on:

- operations
- fragment definitions
- variable definitions
- schema definitions (since September2025)

Also adds support for schema descriptions in the introspection system.

Six conformance test cases now pass.

Also rewrites the parser a little bit to only create `Parser` instances once, improving performance. Here is a _very_ approximate benchmark:

```
document                  main      branch    change
query x1               38.1 us      4.8 us      7.9x
query x2               42.0 us      8.6 us      4.9x
query x4               47.8 us     15.4 us      3.1x
query x8               61.0 us     28.6 us      2.1x
query + fragment       35.9 us      5.1 us      7.0x
sdl, 7 defns          261.8 us     13.7 us     19.1x
schema defn            65.6 us      4.3 us     15.2x
introspection          82.7 us     50.3 us      1.6x
```
