### PR TITLE
Make MappingValidator stack safe

### DIFF
--- a/modules/core/.jvm/src/test/scala/validator/ValidatorStackSafetySuite.scala
+++ b/modules/core/.jvm/src/test/scala/validator/ValidatorStackSafetySuite.scala
@@ -1,0 +1,69 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// Copyright (c) 2016-2025 Grackle Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import cats.effect.IO
+import compiler.TestMapping
+import munit.CatsEffectSuite
+
+import grackle.{Schema, ValidationFailure}
+
+/**
+ * JVM only: needs a thread with a fixed, small stack so the result does not depend on the
+ * stack size the test runner happens to give us.
+ */
+final class ValidatorStackSafetySuite extends CatsEffectSuite {
+  test("validation is stack safe for large mappings") {
+    val n = 5000
+    val names = (0 until n).map(i => s"Foo$i")
+
+    object M extends TestMapping {
+      val schema =
+        Schema(
+          s"""
+            type Query {
+              ${names.map(nm => s"${nm.toLowerCase}: $nm").mkString("\n")}
+            }
+
+            ${names.map(nm => s"type $nm { bar: String }").mkString("\n")}
+          """
+        ).toOption.get
+
+      override val typeMappings =
+        TypeMappings.unchecked(
+          ObjectMapping(schema.ref("Query"))(
+            names.map(nm => CursorField[String](nm.toLowerCase, _ => ???, Nil)): _*
+          ) ::
+          names.toList.map(nm =>
+            ObjectMapping(schema.ref(nm))(
+              CursorField[String]("bar", _ => ???, Nil)
+            )
+          )
+        )
+    }
+
+    onSmallStack(M.validate()).assertEquals(Nil)
+  }
+
+  private def onSmallStack(validate: => List[ValidationFailure]): IO[List[ValidationFailure]] =
+    IO.async_ { cb =>
+      // A StackOverflowError is fatal, so catch Throwable or the callback never fires.
+      val run: Runnable = () => cb(try Right(validate) catch { case t: Throwable => Left(t) })
+      val t = new Thread(null, run, "validator", 256L * 1024)
+      t.setDaemon(true)
+      t.start()
+    }
+}

--- a/modules/core/.jvm/src/test/scala/validator/ValidatorStackSafetySuite.scala
+++ b/modules/core/.jvm/src/test/scala/validator/ValidatorStackSafetySuite.scala
@@ -22,8 +22,8 @@ import munit.CatsEffectSuite
 import grackle.{Schema, ValidationFailure}
 
 /**
- * JVM only: needs a thread with a fixed, small stack so the result does not depend on the
- * stack size the test runner happens to give us.
+ * JVM only: needs a thread with a fixed, small stack so the result does not depend on the stack
+ * size the test runner happens to give us.
  */
 final class ValidatorStackSafetySuite extends CatsEffectSuite {
   test("validation is stack safe for large mappings") {
@@ -47,11 +47,12 @@ final class ValidatorStackSafetySuite extends CatsEffectSuite {
           ObjectMapping(schema.ref("Query"))(
             names.map(nm => CursorField[String](nm.toLowerCase, _ => ???, Nil)): _*
           ) ::
-          names.toList.map(nm =>
-            ObjectMapping(schema.ref(nm))(
-              CursorField[String]("bar", _ => ???, Nil)
-            )
-          )
+            names
+              .toList
+              .map(nm =>
+                ObjectMapping(schema.ref(nm))(
+                  CursorField[String]("bar", _ => ???, Nil)
+                ))
         )
     }
 
@@ -61,7 +62,10 @@ final class ValidatorStackSafetySuite extends CatsEffectSuite {
   private def onSmallStack(validate: => List[ValidationFailure]): IO[List[ValidationFailure]] =
     IO.async_ { cb =>
       // A StackOverflowError is fatal, so catch Throwable or the callback never fires.
-      val run: Runnable = () => cb(try Right(validate) catch { case t: Throwable => Left(t) })
+      val run: Runnable = () =>
+        cb(
+          try Right(validate)
+          catch { case t: Throwable => Left(t) })
       val t = new Thread(null, run, "validator", 256L * 1024)
       t.setDaemon(true)
       t.start()

--- a/modules/core/src/main/scala/mapping.scala
+++ b/modules/core/src/main/scala/mapping.scala
@@ -19,7 +19,7 @@ import scala.collection.Factory
 import scala.collection.mutable.{Map => MMap}
 import scala.reflect.ClassTag
 
-import cats.{ApplicativeError, Id, MonadThrow}
+import cats.{ApplicativeError, Eval, MonadThrow}
 import cats.data.{Chain, NonEmptyList, StateT}
 import cats.implicits._
 import fs2.{Compiler, Stream}
@@ -566,7 +566,7 @@ abstract class Mapping[F[_]] {
           _ <- mappings.traverse_(refChecks)
         } yield ()
 
-      res.runS(initialState).problems.reverse
+      res.runS(initialState).value.problems.reverse
     }
   }
 
@@ -800,7 +800,8 @@ abstract class Mapping[F[_]] {
 
     val empty: TypeMappings = unchecked(Nil)
 
-    private type MappingValidator[T] = StateT[Id, MappingValidator.State, T]
+    // Eval for stack safety: the validator's recursion depth grows with the number of type mappings.
+    private type MappingValidator[T] = StateT[Eval, MappingValidator.State, T]
     private object MappingValidator {
       type MV[T] = MappingValidator[T]
       def unit: MV[Unit] = StateT.pure(())


### PR DESCRIPTION
Use `Eval` instead of `Id` to keep `MappingValidator` stack safe.

In a schema with 30+k lines this got to be an issue.